### PR TITLE
Remove keypad/meta setup from initialize

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -464,8 +464,6 @@ void initialize() {
     noecho();  // Disable echoing of input characters
     keypad(stdscr, TRUE);  // Enable special keys
     meta(stdscr, TRUE);  // Enable 8-bit control characters
-    keypad(text_win, TRUE);  // Enable special keys for text_win
-    meta(text_win, TRUE);  // Enable 8-bit control characters for text_win
 
     // Initialize mouse support
     mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);


### PR DESCRIPTION
## Summary
- avoid referencing the not-yet-created `text_win` window in `initialize()`
- keep keypad and meta configuration in `load_file()` and `new_file()` where `text_win` is created

## Testing
- `make`