### PR TITLE
Add menu cleanup routine

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -804,6 +804,8 @@ void cleanup_on_exit() {
         free(clipboard);
         clipboard = NULL;
     }
+
+    freeMenus();
 }
 
 void close_editor() {

--- a/src/menu.c
+++ b/src/menu.c
@@ -197,3 +197,23 @@ void menuTestwindow() {
     drawBar();
 }
 
+/**
+ * Frees the memory allocated for all menus and their menu items.
+ */
+void freeMenus() {
+    if (menus == NULL) {
+        return;
+    }
+
+    for (int i = 0; i < menuCount; ++i) {
+        if (menus[i].items != NULL) {
+            free(menus[i].items);
+            menus[i].items = NULL;  // Avoid dangling pointer
+        }
+    }
+
+    free(menus);
+    menus = NULL;
+    menuCount = 0;
+}
+

--- a/src/menu.h
+++ b/src/menu.h
@@ -25,6 +25,10 @@ void menuAbout();
 void menuHelp();
 void menuTestwindow();
 void drawBar();
+/**
+ * Frees the memory allocated for the menus and menu items.
+ */
+void freeMenus();
 
 extern Menu *menus;
 extern int menuCount;


### PR DESCRIPTION
## Summary
- add `freeMenus` to deallocate menu structures
- release menus from `cleanup_on_exit`
- document cleanup routine in `menu.h`

## Testing
- `make`