### PR TITLE
Fix ncurses format security warnings

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -14,7 +14,7 @@ void drawMenuBar(Menu *menus, int menuCount) {
 
     // Draw the menu bar
     for (int i = 0; i < menuCount; ++i) {
-        mvprintw(0, i * 10, menus[i].label);
+        mvprintw(0, i * 10, "%s", menus[i].label);
     }
     refresh();
 }
@@ -91,7 +91,7 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
 
         // Draw menu bar
         for (int i = 0; i < menuCount; ++i) {
-            mvprintw(0, i * 10, menus[i].label);
+            mvprintw(0, i * 10, "%s", menus[i].label);
         }
         drawMenu(&menus[*currentMenu], *currentItem, *currentMenu * 10, 1);
         refresh();
@@ -146,7 +146,7 @@ void drawMenu(Menu *menu, int currentItem, int startX, int startY) {
         if (i == currentItem) {
             wattron(menuWin, A_REVERSE); // Highlight the currently selected item
         }
-        mvwprintw(menuWin, 1 + i, 1, menu->items[i].label); // Print the label of the menu item
+        mvwprintw(menuWin, 1 + i, 1, "%s", menu->items[i].label); // Print the label of the menu item
         if (i == currentItem) {
             wattroff(menuWin, A_REVERSE); // Turn off the highlight for the currently selected item
         }

--- a/src/ui.c
+++ b/src/ui.c
@@ -156,7 +156,7 @@ void create_dialog(const char *message, char *output, int max_input_len) {
 
     // Print the message at the center
     wattron(dialog_win, A_BOLD); // Bold the message
-    mvwprintw(dialog_win, 1, (win_width - strlen(message)) / 2, message);
+    mvwprintw(dialog_win, 1, (win_width - strlen(message)) / 2, "%s", message);
     wattroff(dialog_win, A_BOLD);
 
     // Input field and cursor position
@@ -372,7 +372,7 @@ void show_find_dialog(char *output, int max_input_len) {
     // Print the message at the center
     char *message = "Find: ";
     wattron(dialog_win, A_BOLD); // Bold the message
-    mvwprintw(dialog_win, 1, (win_width - strlen(message)) / 2, message);
+    mvwprintw(dialog_win, 1, (win_width - strlen(message)) / 2, "%s", message);
     wattroff(dialog_win, A_BOLD);
 
     // Input field and cursor position


### PR DESCRIPTION
## Summary
- adjust `mvprintw` and `mvwprintw` calls in menu and ui code
- rebuild to verify `-Wformat-security` warnings are gone

## Testing
- `make`