### PR TITLE
Refactor undo stack into new module

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -64,8 +64,6 @@ void save_file();
 void save_file_as();
 void load_file(const char *filename);
 void new_file();
-void undo();
-void redo();
 void find(int new_search);
 void redraw(int *cursor_x, int *cursor_y);
 void delete_current_line(int *cursor_y, int *start_line);
@@ -74,10 +72,5 @@ void update_status_bar(int cursor_y, int cursor_x);
 void handle_resize(int sig);
 void cleanup_on_exit();
 
-// Stack functions for undo and redo
-void push(Node **stack, Change change);
-Change pop(Node **stack);
-int is_empty(Node *stack);
-void free_stack(Node *stack);
 
 #endif

--- a/src/input.c
+++ b/src/input.c
@@ -1,5 +1,6 @@
 #include "editor.h"
 #include <ncurses.h>
+#include "undo.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/undo.c
+++ b/src/undo.c
@@ -1,0 +1,93 @@
+#include <stdlib.h>
+#include <string.h>
+#include <ncurses.h>
+#include "editor.h"
+#include "undo.h"
+char *strdup(const char *s);  // Explicitly declare strdup
+
+void push(Node **stack, Change change) {
+    Node *new_node = (Node *)malloc(sizeof(Node));
+    new_node->change = change;
+    new_node->next = *stack;
+    *stack = new_node;
+}
+
+Change pop(Node **stack) {
+    if (*stack == NULL) {
+        Change empty_change = {0, NULL, NULL};
+        return empty_change;
+    }
+    Node *top = *stack;
+    Change change = top->change;
+    *stack = top->next;
+    free(top);
+    return change;
+}
+
+int is_empty(Node *stack) {
+    return stack == NULL;
+}
+
+void undo() {
+    if (undo_stack == NULL) return;
+
+    Change change = pop(&undo_stack);
+
+    if (change.old_text) {
+        for (int i = line_count; i > change.line; --i) {
+            strcpy(text_buffer[i], text_buffer[i - 1]);
+        }
+        line_count++;
+
+        strcpy(text_buffer[change.line], change.old_text);
+
+        push(&redo_stack, (Change){change.line, strdup(change.old_text), NULL});
+        free(change.old_text);
+    } else {
+        for (int i = change.line; i < line_count - 1; ++i) {
+            strcpy(text_buffer[i], text_buffer[i + 1]);
+        }
+        text_buffer[line_count - 1][0] = '\0';
+        line_count--;
+
+        push(&redo_stack, change);
+    }
+
+    werase(text_win);
+    box(text_win, 0, 0);
+    draw_text_buffer(text_win);
+    wrefresh(text_win);
+}
+
+void redo() {
+    if (redo_stack == NULL) return;
+
+    Change change = pop(&redo_stack);
+
+    if (change.new_text) {
+        push(&undo_stack, (Change){change.line, strdup(text_buffer[change.line]), strdup(change.new_text)});
+        strcpy(text_buffer[change.line], change.new_text);
+        free(change.new_text);
+    }
+
+    werase(text_win);
+    box(text_win, 0, 0);
+    draw_text_buffer(text_win);
+}
+
+void free_stack(Node *stack) {
+    while (stack) {
+        Node *next = stack->next;
+        if (stack->change.old_text) {
+            free(stack->change.old_text);
+            stack->change.old_text = NULL;
+        }
+        if (stack->change.new_text) {
+            free(stack->change.new_text);
+            stack->change.new_text = NULL;
+        }
+        free(stack);
+        stack = next;
+    }
+}
+

--- a/src/undo.h
+++ b/src/undo.h
@@ -1,0 +1,13 @@
+#ifndef UNDO_H
+#define UNDO_H
+
+#include "editor.h"
+
+void push(Node **stack, Change change);
+Change pop(Node **stack);
+int is_empty(Node *stack);
+void free_stack(Node *stack);
+void undo();
+void redo();
+
+#endif

--- a/src/vento.c
+++ b/src/vento.c
@@ -2,35 +2,10 @@
 #include <stdlib.h>
 #include <signal.h>
 #include "editor.h"
+#include "undo.h"
 #include "input.h"
 #include "ui.h"
 
-/**
- * Frees the memory allocated for the undo stack.
- * 
- * @param stack The undo stack to be freed.
- */
-void free_stack(Node *stack) {
-    while (stack) {
-        Node *next = stack->next;
-        
-        // Free the old_text if it exists
-        if (stack->change.old_text) {
-            free(stack->change.old_text);
-            stack->change.old_text = NULL; // Prevent double free
-        }
-        
-        // Free the new_text if it exists
-        if (stack->change.new_text) {
-            free(stack->change.new_text);
-            stack->change.new_text = NULL; // Prevent double free
-        }
-        
-        // Free the stack node
-        free(stack);
-        stack = next;
-    }
-}
 
 /**
  * The main function of the program.


### PR DESCRIPTION
## Summary
- add new `undo.c` and `undo.h`
- include `undo.h` in editor, input and vento
- move stack management and undo/redo into the new module
- remove old declarations from `editor.h`

## Testing
- `make clean`
- `make`