### PR TITLE
Fix prototypes and forward declarations

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,6 @@
 extern int enable_color;
 
 short get_color_code(const char *color_name);
-void read_config_file();
+void read_config_file(void);
 
 #endif // CONFIG_H

--- a/src/editor.c
+++ b/src/editor.c
@@ -238,7 +238,7 @@ static void handle_quit_wrapper(struct FileState *fs, int *cx, int *cy) {
 static KeyMapping key_mappings[MAX_KEY_MAPPINGS];
 static int key_mapping_count = 0;
 
-static void initialize_key_mappings() {
+static void initialize_key_mappings(void) {
     key_mapping_count = 0;
 
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_UP, handle_key_up_wrapper};

--- a/src/editor.h
+++ b/src/editor.h
@@ -45,18 +45,19 @@ extern int start_line;
 extern Node *undo_stack;
 extern Node *redo_stack;
 void handle_regular_mode(struct FileState *fs, int ch);
-void initialize();
+void initialize(void);
 void draw_text_buffer(WINDOW *win);
-void close_editor();
-void clear_text_buffer();
-void run_editor();
-void initialize_buffer();
+void close_editor(void);
+void clear_text_buffer(void);
+void run_editor(void);
+void initialize_buffer(void);
 void redraw(int *cursor_x, int *cursor_y);
 void delete_current_line(int *cursor_y, int *start_line);
 void insert_new_line(int *cursor_x, int *cursor_y, int *start_line);
 void update_status_bar(int cursor_y, int cursor_x);
 void handle_resize(int sig);
-void cleanup_on_exit();
+void cleanup_on_exit(void);
+void disable_ctrl_c_z(void);
 
 
-#endif
+#endif // EDITOR_H

--- a/src/file_ops.h
+++ b/src/file_ops.h
@@ -1,7 +1,7 @@
 #ifndef FILE_OPS_H
 #define FILE_OPS_H
 
-typedef struct FileState FileState;
+struct FileState;
 void save_file(struct FileState *fs);
 void save_file_as(struct FileState *fs);
 void load_file(struct FileState *fs, const char *filename);

--- a/src/input.h
+++ b/src/input.h
@@ -4,7 +4,7 @@
 #define BOTTOM_MARGIN 4 // Define the bottom UI margin
 
 #include "files.h"
-void handle_ctrl_backtick();
+void handle_ctrl_backtick(void);
 void handle_key_up(struct FileState *fs);
 void handle_key_down(struct FileState *fs);
 void handle_key_left(struct FileState *fs);

--- a/src/menu.h
+++ b/src/menu.h
@@ -2,7 +2,7 @@
 #define MENU_H
 typedef struct MenuItem {
     const char *label;
-    void (*action)();
+    void (*action)(void);
 } MenuItem;
 
 typedef struct Menu {
@@ -11,24 +11,24 @@ typedef struct Menu {
     int itemCount;
 } Menu;
 
-void initializeMenus();
+void initializeMenus(void);
 void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *currentItem);
 void drawMenu(Menu *menu, int currentItem, int startX, int startY);
-void menuNewFile();
-void menuLoadFile();
-void menuSaveFile();
-void menuQuitEditor();
-void menuUndo();
-void menuRedo();
-void menuFind();
-void menuAbout();
-void menuHelp();
-void menuTestwindow();
-void drawBar();
+void menuNewFile(void);
+void menuLoadFile(void);
+void menuSaveFile(void);
+void menuQuitEditor(void);
+void menuUndo(void);
+void menuRedo(void);
+void menuFind(void);
+void menuAbout(void);
+void menuHelp(void);
+void menuTestwindow(void);
+void drawBar(void);
 /**
  * Frees the memory allocated for the menus and menu items.
  */
-void freeMenus();
+void freeMenus(void);
 
 extern Menu *menus;
 extern int menuCount;

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,10 +1,10 @@
 #ifndef UI_H
 #define UI_H
 
-void show_help();
-void show_about();
+void show_help(void);
+void show_about(void);
 void create_dialog(const char *message, char *output, int max_input_len);
-void show_warning_dialog();
+void show_warning_dialog(void);
 void get_dir_contents(const char *dir_path, char ***choices, int *n_choices);
 void free_dir_contents(char **choices, int n_choices);
 void show_find_dialog(char *output, int max_input_len);


### PR DESCRIPTION
## Summary
- fix forward declaration for `struct FileState`
- use `(void)` in zero-arg prototypes
- expose `disable_ctrl_c_z` in `editor.h`
- fix `initialize_key_mappings` definition

## Testing
- `make CFLAGS='-Wall -Wextra -Wpedantic -Wstrict-prototypes -std=c99'`
