### PR TITLE
Fix start_line reset on buffer clear

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -754,7 +754,7 @@ void clear_text_buffer() {
     
     // Reset line count and start line variables
     line_count = 1;
-    start_line = 1;
+    start_line = 0;
     
     // Clear the text window
     werase(text_win);


### PR DESCRIPTION
## Summary
- ensure `clear_text_buffer` resets `start_line` to zero
- keep start line initialization consistent across editor startup

## Testing
- `make clean`
- `make`
