### PR TITLE
Refactor global editor state into FileState

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -4,84 +4,80 @@
 #include "clipboard.h"
 #include "files.h"
 
-char *clipboard;
-bool selection_mode = false;
-int sel_start_x = 0, sel_start_y = 0;
-int sel_end_x = 0, sel_end_y = 0;
+/* Clipboard and selection state are now stored in FileState */
 
 void start_selection_mode(FileState *fs, int cursor_x, int cursor_y) {
-    (void)fs;
-    selection_mode = true;
-    sel_start_x = cursor_x;
-    sel_start_y = cursor_y;
-    sel_end_x = cursor_x;
-    sel_end_y = cursor_y;
+    fs->selection_mode = true;
+    fs->sel_start_x = cursor_x;
+    fs->sel_start_y = cursor_y;
+    fs->sel_end_x = cursor_x;
+    fs->sel_end_y = cursor_y;
 }
 
 void end_selection_mode(FileState *fs) {
-    selection_mode = false;
+    fs->selection_mode = false;
     copy_selection(fs);
 }
 
 void copy_selection(FileState *fs) {
-    int start_x = sel_start_x;
-    int end_x = sel_end_x;
+    int start_x = fs->sel_start_x;
+    int end_x = fs->sel_end_x;
     int start_y, end_y;
 
-    if (sel_start_y < sel_end_y) {
-        start_y = sel_start_y;
-        end_y = sel_end_y;
+    if (fs->sel_start_y < fs->sel_end_y) {
+        start_y = fs->sel_start_y;
+        end_y = fs->sel_end_y;
     } else {
-        start_y = sel_end_y;
-        end_y = sel_start_y;
+        start_y = fs->sel_end_y;
+        end_y = fs->sel_start_y;
     }
 
-    if (clipboard == NULL) {
+    if (fs->clipboard == NULL) {
         return;
     }
 
-    clipboard[0] = '\0';  // Clear clipboard
+    fs->clipboard[0] = '\0';  // Clear clipboard
     size_t clip_len = 0;
     for (int y = start_y; y <= end_y && clip_len < CLIPBOARD_SIZE - 1; y++) {
         if (y == start_y) {
-            const char *src = &text_buffer[y - 1 + fs->start_line][start_x - 1];
+            const char *src = &fs->text_buffer[y - 1 + fs->start_line][start_x - 1];
             size_t to_copy = end_x - start_x + 1;
             if (to_copy > CLIPBOARD_SIZE - 1 - clip_len) {
                 to_copy = CLIPBOARD_SIZE - 1 - clip_len;
             }
-            strncpy(clipboard + clip_len, src, to_copy);
+            strncpy(fs->clipboard + clip_len, src, to_copy);
             clip_len += to_copy;
-            clipboard[clip_len] = '\0';
+            fs->clipboard[clip_len] = '\0';
         } else {
             if (clip_len < CLIPBOARD_SIZE - 1) {
-                clipboard[clip_len++] = '\n';
-                clipboard[clip_len] = '\0';
+                fs->clipboard[clip_len++] = '\n';
+                fs->clipboard[clip_len] = '\0';
             }
-            const char *src = text_buffer[y - 1 + fs->start_line];
+            const char *src = fs->text_buffer[y - 1 + fs->start_line];
             size_t to_copy = strlen(src);
             if (to_copy > CLIPBOARD_SIZE - 1 - clip_len) {
                 to_copy = CLIPBOARD_SIZE - 1 - clip_len;
             }
-            strncpy(clipboard + clip_len, src, to_copy);
+            strncpy(fs->clipboard + clip_len, src, to_copy);
             clip_len += to_copy;
-            clipboard[clip_len] = '\0';
+            fs->clipboard[clip_len] = '\0';
         }
     }
 }
 
 void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
-    if (clipboard == NULL) {
+    if (fs->clipboard == NULL) {
         return;
     }
 
     char tmp[CLIPBOARD_SIZE];
-    strncpy(tmp, clipboard, sizeof(tmp) - 1);
+    strncpy(tmp, fs->clipboard, sizeof(tmp) - 1);
     tmp[sizeof(tmp) - 1] = '\0';
 
     char *line = strtok(tmp, "\n");
     while (line) {
         size_t len = strlen(line);
-        char *dest = text_buffer[*cursor_y - 1 + fs->start_line];
+        char *dest = fs->text_buffer[*cursor_y - 1 + fs->start_line];
         size_t dest_len = strlen(dest);
 
         if (dest_len + len >= (size_t)(COLS - 3)) {
@@ -104,19 +100,19 @@ void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
 void handle_selection_mode(FileState *fs, int ch, int *cursor_x, int *cursor_y) {
     if (ch == KEY_UP) {
         if (*cursor_y > 1) (*cursor_y)--;
-        sel_end_y = *cursor_y;
+        fs->sel_end_y = *cursor_y;
     }
     if (ch == KEY_DOWN) {
         if (*cursor_y < LINES - 4) (*cursor_y)++;
-        sel_end_y = *cursor_y;
+        fs->sel_end_y = *cursor_y;
     }
     if (ch == KEY_LEFT) {
         if (*cursor_x > 1) (*cursor_x)--;
-        sel_end_x = *cursor_x;
+        fs->sel_end_x = *cursor_x;
     }
     if (ch == KEY_RIGHT) {
         if (*cursor_x < COLS - 6) (*cursor_x)++;
-        sel_end_x = *cursor_x;
+        fs->sel_end_x = *cursor_x;
     }
     if (ch == 10) {
         end_selection_mode(fs);

--- a/src/clipboard.h
+++ b/src/clipboard.h
@@ -7,10 +7,6 @@
 #define CLIPBOARD_SIZE 4096
 
 #include "files.h"
-extern char *clipboard;
-extern bool selection_mode;
-extern int sel_start_x, sel_start_y;
-extern int sel_end_x, sel_end_y;
 
 void start_selection_mode(FileState *fs, int cursor_x, int cursor_y);
 void end_selection_mode(FileState *fs);

--- a/src/editor.h
+++ b/src/editor.h
@@ -39,10 +39,6 @@ typedef struct {
 extern WINDOW *text_win;
 extern char current_filename[256];
 extern struct FileState *active_file;
-extern char *text_buffer[MAX_LINES];
-extern int line_count;
-extern Node *undo_stack;
-extern Node *redo_stack;
 void handle_regular_mode(struct FileState *fs, int ch);
 void initialize(void);
 void draw_text_buffer(struct FileState *fs, WINDOW *win);

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -14,7 +14,7 @@ void save_file(FileState *fs) {
         FILE *fp = fopen(current_filename, "w");
         if (fp) {
             for (int i = 0; i < fs->line_count; ++i) {
-                fprintf(fp, "%s\n", text_buffer[i]);
+                fprintf(fp, "%s\n", fs->text_buffer[i]);
             }
             fclose(fp);
             mvprintw(LINES - 2, 2, "File saved as %s", current_filename);
@@ -34,7 +34,7 @@ void save_file_as(FileState *fs) {
     FILE *fp = fopen(current_filename, "w");
     if (fp) {
         for (int i = 0; i < fs->line_count; ++i) {
-            fprintf(fp, "%s\n", text_buffer[i]);
+            fprintf(fp, "%s\n", fs->text_buffer[i]);
         }
         fclose(fp);
         mvprintw(LINES - 2, 2, "File saved as %s", current_filename);
@@ -62,10 +62,9 @@ void load_file(FileState *fs, const char *filename) {
     FILE *fp = fopen(filename, "r");
     if (fp) {
         fs->line_count = 0;
-        while (fgets(text_buffer[fs->line_count], COLS - 3, fp) && fs->line_count < MAX_LINES) {
-            text_buffer[fs->line_count][strcspn(text_buffer[fs->line_count], "\n")] = '\0';
+        while (fgets(fs->text_buffer[fs->line_count], COLS - 3, fp) && fs->line_count < MAX_LINES) {
+            fs->text_buffer[fs->line_count][strcspn(fs->text_buffer[fs->line_count], "\n")] = '\0';
             fs->line_count++;
-            line_count = fs->line_count;
         }
         fclose(fp);
         mvprintw(LINES - 2, 2, "File loaded: %s", filename);

--- a/src/search.c
+++ b/src/search.c
@@ -17,7 +17,7 @@ void find_next_occurrence(FileState *fs, const char *word) {
 
     // Search from the current cursor position to the end of the document
     for (int line = start_search; line < fs->line_count; ++line) {
-        const char *line_text = text_buffer[line];
+        const char *line_text = fs->text_buffer[line];
         const char *found_position = strstr(line == start_search ? line_text + *cursor_x : line_text, word);
 
         if (found_position != NULL) {
@@ -49,7 +49,7 @@ void find_next_occurrence(FileState *fs, const char *word) {
     // If not found, wrap around and search from the start to the initial cursor position
     if (!found) {
         for (int line = 0; line < start_search; ++line) {
-            const char *line_text = text_buffer[line];
+            const char *line_text = fs->text_buffer[line];
             const char *found_position = strstr(line_text, word);
 
             if (found_position != NULL) {

--- a/src/vento.c
+++ b/src/vento.c
@@ -38,12 +38,12 @@ int main(int argc, char *argv[]) {
     endwin();
 
     // Free the undo stack
-    free_stack(undo_stack);
-    undo_stack = NULL; // Prevent double free
+    free_stack(active_file->undo_stack);
+    active_file->undo_stack = NULL; // Prevent double free
 
     // Free the redo stack
-    free_stack(redo_stack);
-    redo_stack = NULL; // Prevent double free
+    free_stack(active_file->redo_stack);
+    active_file->redo_stack = NULL; // Prevent double free
 
     cleanup_on_exit();
 


### PR DESCRIPTION
## Summary
- keep undo/redo history, clipboard, and buffer data inside `FileState`
- remove global variables from editor and clipboard modules
- allocate clipboard in `initialize_buffer`
- update all modules to reference `fs->` fields

## Testing
- `make`