### PR TITLE
Add file switching controls

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -39,6 +39,7 @@ typedef struct {
 extern WINDOW *text_win;
 extern char current_filename[256];
 extern struct FileState *active_file;
+extern int cursor_x, cursor_y;
 struct FileManager;
 extern struct FileManager file_manager;
 void fm_init(struct FileManager *fm);
@@ -60,6 +61,8 @@ void update_status_bar(int cursor_y, int cursor_x, struct FileState *fs);
 void handle_resize(int sig);
 void cleanup_on_exit(void);
 void disable_ctrl_c_z(void);
+void next_file(struct FileState *fs, int *cx, int *cy);
+void prev_file(struct FileState *fs, int *cx, int *cy);
 
 
 #endif // EDITOR_H

--- a/src/menu.c
+++ b/src/menu.c
@@ -42,7 +42,7 @@ void initializeMenus() {
     }
 
     // Create the file menu
-    MenuItem *fileMenuItems = malloc(4 * sizeof(MenuItem));
+    MenuItem *fileMenuItems = malloc(6 * sizeof(MenuItem));
     if (fileMenuItems == NULL) {
         fprintf(stderr, "Failed to allocate memory for file menu items\n");
         freeMenus();
@@ -51,10 +51,12 @@ void initializeMenus() {
     fileMenuItems[0] = (MenuItem){"New File", menuNewFile};
     fileMenuItems[1] = (MenuItem){"Load File", menuLoadFile};
     fileMenuItems[2] = (MenuItem){"Save File", menuSaveFile};
-    fileMenuItems[3] = (MenuItem){"Quit", menuQuitEditor};
+    fileMenuItems[3] = (MenuItem){"Next File", menuNextFile};
+    fileMenuItems[4] = (MenuItem){"Previous File", menuPrevFile};
+    fileMenuItems[5] = (MenuItem){"Quit", menuQuitEditor};
 
     // Initialize and assign the file menu
-    Menu fileMenu = {"File", fileMenuItems, 4};
+    Menu fileMenu = {"File", fileMenuItems, 6};
     menus[0] = fileMenu;
 
     // Create the edit menu
@@ -187,6 +189,14 @@ void menuLoadFile() {
 
 void menuSaveFile() {
     save_file(active_file);
+}
+
+void menuNextFile() {
+    next_file(active_file, &cursor_x, &cursor_y);
+}
+
+void menuPrevFile() {
+    prev_file(active_file, &cursor_x, &cursor_y);
 }
 
 void menuQuitEditor() {

--- a/src/menu.h
+++ b/src/menu.h
@@ -17,6 +17,8 @@ void drawMenu(Menu *menu, int currentItem, int startX, int startY);
 void menuNewFile(void);
 void menuLoadFile(void);
 void menuSaveFile(void);
+void menuNextFile(void);
+void menuPrevFile(void);
 void menuQuitEditor(void);
 void menuUndo(void);
 void menuRedo(void);


### PR DESCRIPTION
## Summary
- add `key_next_file` and `key_prev_file` key codes
- implement `next_file` and `prev_file` handlers that switch active file
- map new handlers to keys and expose them in the menu
- extend the File menu with "Next File" and "Previous File"

## Testing
- `make clean && make`