### PR TITLE
Refactor syntax highlighting to be file-specific

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -683,7 +683,7 @@ void draw_text_buffer(FileState *fs, WINDOW *win) {
     // Iterate over each line to be displayed on the window
     for (int i = 0; i < max_lines && i + fs->start_line < fs->line_count; ++i) {
         // Apply syntax highlighting to the current line of text
-        apply_syntax_highlighting(win, fs->text_buffer[i + fs->start_line], i + 1);
+        apply_syntax_highlighting(fs, win, fs->text_buffer[i + fs->start_line], i + 1);
     }
 
     // Calculate scrollbar position and size

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -61,8 +61,7 @@ void load_file(FileState *fs_unused, const char *filename) {
     FileState *fs = initialize_file_state(filename, MAX_LINES, COLS - 3);
     active_file = fs;
 
-    set_syntax_mode(filename);
-    fs->syntax_mode = current_syntax_mode;
+    fs->syntax_mode = set_syntax_mode(filename);
     strcpy(fs->filename, filename);
 
     initialize_buffer();
@@ -113,7 +112,7 @@ void new_file(FileState *fs_unused) {
     FileState *fs = initialize_file_state("", MAX_LINES, COLS - 3);
     active_file = fs;
     strcpy(current_filename, "");
-    fs->syntax_mode = NO_SYNTAX;
+    fs->syntax_mode = set_syntax_mode(fs->filename);
 
     initialize_buffer();
 
@@ -133,23 +132,20 @@ void new_file(FileState *fs_unused) {
     update_status_bar(active_file->cursor_y, active_file->cursor_x, active_file);
 }
 
-void set_syntax_mode(const char *filename) {
+int set_syntax_mode(const char *filename) {
     const char *ext = strrchr(filename, '.');
     if (ext) {
         if (strcmp(ext, ".c") == 0 || strcmp(ext, ".h") == 0) {
-            current_syntax_mode = C_SYNTAX;
+            return C_SYNTAX;
         } else if (strcmp(ext, ".html") == 0 || strcmp(ext, ".htm") == 0) {
-            current_syntax_mode = HTML_SYNTAX;
+            return HTML_SYNTAX;
         } else if (strcmp(ext, ".py") == 0) {
-            current_syntax_mode = PYTHON_SYNTAX;
+            return PYTHON_SYNTAX;
         } else if (strcmp(ext, ".cs") == 0) {
-            current_syntax_mode = CSHARP_SYNTAX;
-        } else {
-            current_syntax_mode = NO_SYNTAX;
+            return CSHARP_SYNTAX;
         }
-    } else {
-        current_syntax_mode = NO_SYNTAX;
     }
+    return NO_SYNTAX;
 }
 
 

--- a/src/file_ops.h
+++ b/src/file_ops.h
@@ -6,6 +6,6 @@ void save_file(struct FileState *fs);
 void save_file_as(struct FileState *fs);
 void load_file(struct FileState *fs, const char *filename);
 void new_file(struct FileState *fs);
-void set_syntax_mode(const char *filename);
+int set_syntax_mode(const char *filename);
 
 #endif // FILE_OPS_H

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include "syntax.h"
 #include "editor.h"
+#include "files.h"
 
 // Define color pairs as constants for readability
 #define COLOR_COMMENT 5
@@ -43,11 +44,6 @@ const char *CSHARP_KEYWORDS[] = {
 };
 const int CSHARP_KEYWORDS_COUNT = sizeof(CSHARP_KEYWORDS) / sizeof(CSHARP_KEYWORDS[0]);
 
-int current_syntax_mode = NO_SYNTAX;
-
-void set_syntax_highlighting(int mode) {
-    current_syntax_mode = mode;
-}
 
 /**
  * Applies syntax highlighting to a line of text based on the current syntax mode.
@@ -56,8 +52,8 @@ void set_syntax_highlighting(int mode) {
  * @param line The line of text to be highlighted.
  * @param y The y-coordinate of the line in the window.
  */
-void apply_syntax_highlighting(WINDOW *win, const char *line, int y) {
-    switch (current_syntax_mode) {
+void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *line, int y) {
+    switch (fs->syntax_mode) {
         case C_SYNTAX:
             // Apply C syntax highlighting
             highlight_c_syntax(win, line, y);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -9,10 +9,7 @@
 #define PYTHON_SYNTAX 3
 #define CSHARP_SYNTAX 4
 
-extern int current_syntax_mode;
-
-void set_syntax_highlighting(int mode);
-void apply_syntax_highlighting(WINDOW *win, const char *line, int y);
+void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_c_syntax(WINDOW *win, const char *line, int y);
 void highlight_html_syntax(WINDOW *win, const char *line, int y);
 void handle_html_tag(WINDOW *win, const char *line, int *i, int y, int *x);


### PR DESCRIPTION
## Summary
- remove global syntax state and setter
- use `FileState.syntax_mode` when applying syntax highlighting
- return syntax mode from `set_syntax_mode`
- update drawing and file loading to use the new API

## Testing
- `make clean && make`