### PR TITLE
Remove refresh call from highlight_python_syntax

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -144,7 +144,6 @@ void highlight_python_syntax(WINDOW *win, const char *line, int y) {
             i++;
         }
     }
-    wrefresh(win);
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove redundant `wrefresh` call at the end of `highlight_python_syntax`

## Testing
- `make clean`
- `make`