### PR TITLE
Add multiline comment tracking

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -25,6 +25,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->sel_end_x = file_state->sel_end_y = 0;
     file_state->clipboard = NULL; // Initialize clipboard if needed
     file_state->syntax_mode = NO_SYNTAX; // Set to NO_SYNTAX initially
+    file_state->in_multiline_comment = false;
     file_state->text_win = newwin(LINES - 2, COLS, 1, 0); // Create a new window for the file
 
     return file_state;

--- a/src/files.h
+++ b/src/files.h
@@ -17,6 +17,7 @@ typedef struct FileState {
     int sel_end_x, sel_end_y;
     char *clipboard;
     int syntax_mode;
+    bool in_multiline_comment;
     WINDOW *text_win;
 } FileState;
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -51,7 +51,7 @@ void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *li
     switch (fs->syntax_mode) {
         case C_SYNTAX:
             // Apply C syntax highlighting
-            highlight_c_syntax(win, line, y);
+            highlight_c_syntax(fs, win, line, y);
             break;
         case HTML_SYNTAX:
             // Apply HTML syntax highlighting
@@ -63,7 +63,7 @@ void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *li
             break;
         case CSHARP_SYNTAX:
             // Apply C# syntax highlighting
-            highlight_csharp_syntax(win, line, y);
+            highlight_csharp_syntax(fs, win, line, y);
             break;
         default:
             // No syntax highlighting
@@ -153,7 +153,7 @@ void highlight_python_syntax(WINDOW *win, const char *line, int y) {
  * @param line The line of text to be highlighted.
  * @param y The y-coordinate of the line in the window.
  */
-void highlight_c_syntax(WINDOW *win, const char *line, int y) {
+void highlight_c_syntax(struct FileState *fs, WINDOW *win, const char *line, int y) {
     int x = 1;
     int i = 0;
     int len = strlen(line);
@@ -161,6 +161,22 @@ void highlight_c_syntax(WINDOW *win, const char *line, int y) {
     int word_len = 0;
 
     while (i < len) {
+        if (fs->in_multiline_comment) {
+            wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+            while (i < len) {
+                mvwprintw(win, y, x++, "%c", line[i]);
+                if (line[i] == '*' && i + 1 < len && line[i + 1] == '/') {
+                    mvwprintw(win, y, x++, "%c", line[i + 1]);
+                    i += 2;
+                    fs->in_multiline_comment = false;
+                    break;
+                }
+                i++;
+            }
+            wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+            continue;
+        }
+
         if (isspace(line[i])) {
             // Print spaces as is
             mvwprintw(win, y, x++, "%c", line[i]);
@@ -186,13 +202,16 @@ void highlight_c_syntax(WINDOW *win, const char *line, int y) {
                 // Multi-line comment
                 mvwprintw(win, y, x++, "%c", line[i++]);
                 mvwprintw(win, y, x++, "%c", line[i++]);
-                while (i < len && !(line[i] == '*' && line[i + 1] == '/')) {
+                fs->in_multiline_comment = true;
+                while (i < len) {
                     mvwprintw(win, y, x++, "%c", line[i]);
+                    if (line[i] == '*' && i + 1 < len && line[i + 1] == '/') {
+                        mvwprintw(win, y, x++, "%c", line[i + 1]);
+                        i += 2;
+                        fs->in_multiline_comment = false;
+                        break;
+                    }
                     i++;
-                }
-                if (i < len) {
-                    mvwprintw(win, y, x++, "%c", line[i++]);
-                    mvwprintw(win, y, x++, "%c", line[i++]);
                 }
             }
             wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
@@ -261,7 +280,7 @@ void highlight_c_syntax(WINDOW *win, const char *line, int y) {
  * @param line The line of text to be highlighted.
  * @param y The y-coordinate of the line in the window.
  */
-void highlight_csharp_syntax(WINDOW *win, const char *line, int y) {
+void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y) {
     int x = 1;
     int i = 0;
     int len = strlen(line);
@@ -269,6 +288,22 @@ void highlight_csharp_syntax(WINDOW *win, const char *line, int y) {
     int word_len = 0;
 
     while (i < len) {
+        if (fs->in_multiline_comment) {
+            wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+            while (i < len) {
+                mvwprintw(win, y, x++, "%c", line[i]);
+                if (line[i] == '*' && i + 1 < len && line[i + 1] == '/') {
+                    mvwprintw(win, y, x++, "%c", line[i + 1]);
+                    i += 2;
+                    fs->in_multiline_comment = false;
+                    break;
+                }
+                i++;
+            }
+            wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+            continue;
+        }
+
         if (isspace(line[i])) {
             // Print spaces as is
             mvwprintw(win, y, x++, "%c", line[i]);
@@ -294,13 +329,16 @@ void highlight_csharp_syntax(WINDOW *win, const char *line, int y) {
                 // Multi-line comment
                 mvwprintw(win, y, x++, "%c", line[i++]);
                 mvwprintw(win, y, x++, "%c", line[i++]);
-                while (i < len && !(line[i] == '*' && line[i + 1] == '/')) {
+                fs->in_multiline_comment = true;
+                while (i < len) {
                     mvwprintw(win, y, x++, "%c", line[i]);
+                    if (line[i] == '*' && i + 1 < len && line[i + 1] == '/') {
+                        mvwprintw(win, y, x++, "%c", line[i + 1]);
+                        i += 2;
+                        fs->in_multiline_comment = false;
+                        break;
+                    }
                     i++;
-                }
-                if (i < len) {
-                    mvwprintw(win, y, x++, "%c", line[i++]);
-                    mvwprintw(win, y, x++, "%c", line[i++]);
                 }
             }
             wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -19,13 +19,13 @@ typedef enum {
 } SyntaxColor;
 
 void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *line, int y);
-void highlight_c_syntax(WINDOW *win, const char *line, int y);
+void highlight_c_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_html_syntax(WINDOW *win, const char *line, int y);
 void handle_html_tag(WINDOW *win, const char *line, int *i, int y, int *x);
 void handle_html_comment(WINDOW *win, const char *line, int *i, int y, int *x);
 void print_char_with_attr(WINDOW *win, int y, int *x, char c, int attr);
 void highlight_no_syntax(WINDOW *win, const char *line, int y);
 void highlight_python_syntax(WINDOW *win, const char *line, int y);
-void highlight_csharp_syntax(WINDOW *win, const char *line, int y);
+void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 
 #endif // SYNTAX_H


### PR DESCRIPTION
## Summary
- track multi-line comment state inside `FileState`
- initialize `in_multiline_comment`
- pass file state to C/C# highlighters
- handle `/* */` sequences across lines

## Testing
- `make clean`
- `make`