### PR TITLE
Fix comment detection bounds

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -50,6 +50,7 @@ void save_file_as(FileState *fs) {
 }
 
 void load_file(FileState *fs_unused, const char *filename) {
+    (void)fs_unused;
     char file_to_load[256];
 
     if (filename == NULL) {
@@ -109,6 +110,7 @@ void load_file(FileState *fs_unused, const char *filename) {
 }
 
 void new_file(FileState *fs_unused) {
+    (void)fs_unused;
     FileState *fs = initialize_file_state("", MAX_LINES, COLS - 3);
     active_file = fs;
     strcpy(current_filename, "");

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -189,7 +189,7 @@ void highlight_c_syntax(struct FileState *fs, WINDOW *win, const char *line, int
                 i++;
             }
             wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-        } else if (line[i] == '/' && (line[i + 1] == '/' || line[i + 1] == '*')) {
+        } else if (line[i] == '/' && i + 1 < len && (line[i + 1] == '/' || line[i + 1] == '*')) {
             // Highlight comments
             wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
             if (line[i + 1] == '/') {
@@ -316,7 +316,7 @@ void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line
                 i++;
             }
             wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-        } else if (line[i] == '/' && (line[i + 1] == '/' || line[i + 1] == '*')) {
+        } else if (line[i] == '/' && i + 1 < len && (line[i + 1] == '/' || line[i + 1] == '*')) {
             // Highlight comments
             wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
             if (line[i + 1] == '/') {


### PR DESCRIPTION
## Summary
- handle comment pattern safely in C and C# syntax highlighter
- silence compiler warnings from unused parameters

## Testing
- `make`