### PR TITLE
Fix multiline comment state when scrolling

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -676,6 +676,8 @@ void draw_text_buffer(FileState *fs, WINDOW *win) {
     if (fs->start_line < 0)
         fs->start_line = 0;
 
+    sync_multiline_comment(fs, fs->start_line);
+
     werase(win);
     box(win, 0, 0);
     int max_lines = LINES - 4;  // Adjust for the status bar

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -77,6 +77,8 @@ void load_file(FileState *fs_unused, const char *filename) {
         fclose(fp);
         mvprintw(LINES - 2, 2, "File loaded: %s", filename);
 
+        fs->in_multiline_comment = false;
+
         strcpy(current_filename, filename);
     } else {
         mvprintw(LINES - 2, 2, "Error loading file!");

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -39,6 +39,48 @@ const char *CSHARP_KEYWORDS[] = {
 };
 const int CSHARP_KEYWORDS_COUNT = sizeof(CSHARP_KEYWORDS) / sizeof(CSHARP_KEYWORDS[0]);
 
+// Synchronize the in_multiline_comment flag up to the specified line
+void sync_multiline_comment(FileState *fs, int line) {
+    bool in_comment = false;
+    bool in_string = false;
+    char quote = '\0';
+
+    int max = line < fs->line_count ? line : fs->line_count;
+    for (int l = 0; l < max; l++) {
+        char *p = fs->text_buffer[l];
+        for (int i = 0; p[i] != '\0'; i++) {
+            char c = p[i];
+
+            if (in_string) {
+                if (c == '\\' && p[i + 1] != '\0') {
+                    i++; // Skip escaped char
+                    continue;
+                } else if (c == quote) {
+                    in_string = false;
+                }
+                continue;
+            }
+
+            if (!in_comment) {
+                if (c == '"' || c == '\'' ) {
+                    in_string = true;
+                    quote = c;
+                } else if (c == '/' && p[i + 1] == '*') {
+                    in_comment = true;
+                    i++; // skip '*'
+                }
+            } else {
+                if (c == '*' && p[i + 1] == '/') {
+                    in_comment = false;
+                    i++; // skip '/'
+                }
+            }
+        }
+    }
+
+    fs->in_multiline_comment = in_comment;
+}
+
 
 /**
  * Applies syntax highlighting to a line of text based on the current syntax mode.

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -27,5 +27,6 @@ void print_char_with_attr(WINDOW *win, int y, int *x, char c, int attr);
 void highlight_no_syntax(WINDOW *win, const char *line, int y);
 void highlight_python_syntax(WINDOW *win, const char *line, int y);
 void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
+void sync_multiline_comment(struct FileState *fs, int line);
 
 #endif // SYNTAX_H


### PR DESCRIPTION
## Summary
- add `sync_multiline_comment` helper to recompute comment state
- call the helper from `draw_text_buffer`
- clear `in_multiline_comment` when loading a file
- expose the helper in `syntax.h`

## Testing
- `make clean`
- `make`