### PR TITLE
Improve multiline comment tracking

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -78,6 +78,8 @@ void load_file(FileState *fs_unused, const char *filename) {
         mvprintw(LINES - 2, 2, "File loaded: %s", filename);
 
         fs->in_multiline_comment = false;
+        fs->last_scanned_line = 0;
+        fs->last_comment_state = false;
 
         strcpy(current_filename, filename);
     } else {

--- a/src/files.c
+++ b/src/files.c
@@ -26,6 +26,8 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->clipboard = NULL; // Initialize clipboard if needed
     file_state->syntax_mode = NO_SYNTAX; // Set to NO_SYNTAX initially
     file_state->in_multiline_comment = false;
+    file_state->last_scanned_line = 0;
+    file_state->last_comment_state = false;
     file_state->text_win = newwin(LINES - 2, COLS, 1, 0); // Create a new window for the file
 
     return file_state;
@@ -40,6 +42,8 @@ void free_file_state(FileState *file_state, int max_lines) {
     if (file_state->clipboard) {
         free(file_state->clipboard);
     }
+    file_state->last_scanned_line = 0;
+    file_state->last_comment_state = false;
     delwin(file_state->text_win);
     free(file_state);
 }
@@ -58,5 +62,8 @@ int load_file_into_buffer(FileState *file_state) {
         file_state->line_count++;
     }
     fclose(fp);
+    file_state->last_scanned_line = 0;
+    file_state->last_comment_state = false;
+    file_state->in_multiline_comment = false;
     return 0; // Success
 }

--- a/src/files.h
+++ b/src/files.h
@@ -18,6 +18,10 @@ typedef struct FileState {
     char *clipboard;
     int syntax_mode;
     bool in_multiline_comment;
+    /* The last line index scanned for multiline comment state */
+    int last_scanned_line;
+    /* Comment state after scanning last_scanned_line */
+    bool last_comment_state;
     WINDOW *text_win;
 } FileState;
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -41,12 +41,22 @@ const int CSHARP_KEYWORDS_COUNT = sizeof(CSHARP_KEYWORDS) / sizeof(CSHARP_KEYWOR
 
 // Synchronize the in_multiline_comment flag up to the specified line
 void sync_multiline_comment(FileState *fs, int line) {
-    bool in_comment = false;
+    bool in_comment;
     bool in_string = false;
     char quote = '\0';
 
+    int start;
+
+    if (line < fs->last_scanned_line) {
+        start = 0;
+        in_comment = false;
+    } else {
+        start = fs->last_scanned_line;
+        in_comment = fs->last_comment_state;
+    }
+
     int max = line < fs->line_count ? line : fs->line_count;
-    for (int l = 0; l < max; l++) {
+    for (int l = start; l < max; l++) {
         char *p = fs->text_buffer[l];
         for (int i = 0; p[i] != '\0'; i++) {
             char c = p[i];
@@ -79,6 +89,8 @@ void sync_multiline_comment(FileState *fs, int line) {
     }
 
     fs->in_multiline_comment = in_comment;
+    fs->last_scanned_line = max;
+    fs->last_comment_state = in_comment;
 }
 
 


### PR DESCRIPTION
## Summary
- track multiline comment scan progress in `FileState`
- reset comment tracking when loading files
- resume scans in `sync_multiline_comment`

## Testing
- `make clean`
- `make`