### PR TITLE
Refactor cursor tracking

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -37,9 +37,7 @@ typedef struct {
 } KeyMapping;
 
 extern WINDOW *text_win;
-extern char current_filename[256];
 extern struct FileState *active_file;
-extern int cursor_x, cursor_y;
 struct FileManager;
 extern struct FileManager file_manager;
 void fm_init(struct FileManager *fm);
@@ -54,10 +52,10 @@ void close_editor(void);
 void clear_text_buffer(void);
 void run_editor(void);
 void initialize_buffer(void);
-void redraw(int *cursor_x, int *cursor_y);
+void redraw(void);
 void delete_current_line(struct FileState *fs);
 void insert_new_line(struct FileState *fs);
-void update_status_bar(int cursor_y, int cursor_x, struct FileState *fs);
+void update_status_bar(struct FileState *fs);
 void handle_resize(int sig);
 void cleanup_on_exit(void);
 void disable_ctrl_c_z(void);

--- a/src/menu.c
+++ b/src/menu.c
@@ -110,7 +110,7 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
         werase(text_win);
         box(text_win, 0, 0);
         draw_text_buffer(active_file, text_win);
-        update_status_bar(1, 1, active_file);
+        update_status_bar(active_file);
         wrefresh(text_win);
 
         // Draw menu bar
@@ -193,15 +193,15 @@ void menuSaveFile() {
 }
 
 void menuCloseFile() {
-    close_current_file(active_file, &cursor_x, &cursor_y);
+    close_current_file(active_file, &active_file->cursor_x, &active_file->cursor_y);
 }
 
 void menuNextFile() {
-    next_file(active_file, &cursor_x, &cursor_y);
+    next_file(active_file, &active_file->cursor_x, &active_file->cursor_y);
 }
 
 void menuPrevFile() {
-    prev_file(active_file, &cursor_x, &cursor_y);
+    prev_file(active_file, &active_file->cursor_x, &active_file->cursor_y);
 }
 
 void menuQuitEditor() {

--- a/src/ui.c
+++ b/src/ui.c
@@ -234,7 +234,7 @@ void show_warning_dialog() {
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
     wrefresh(text_win);
-    update_status_bar(1, 1, active_file);
+    update_status_bar(active_file);
     wrefresh(stdscr);  // Refresh the main screen after closing the dialog
 }
 
@@ -336,7 +336,7 @@ int show_select_file(char *selected_path, int max_path_len) {
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
     wrefresh(text_win);
-    update_status_bar(1, 1, active_file);
+    update_status_bar(active_file);
     wrefresh(stdscr);  // Refresh the main screen after closing the dialog
 }
 


### PR DESCRIPTION
## Summary
- manage cursor position and file name through `FileState`
- drop global `cursor_x`, `cursor_y` and `current_filename`
- update helpers to operate on `FileState`
- adjust menu and UI helpers for new signatures

## Testing
- `make`