### PR TITLE
Ensure syntax comment state resets on edits

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -359,6 +359,7 @@ void delete_current_line(FileState *fs) {
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(fs, text_win);
+    mark_comment_state_dirty(fs);
 }
 
 /**
@@ -384,6 +385,7 @@ void insert_new_line(FileState *fs) {
         change.new_text = strdup("");
 
         push(&fs->undo_stack, change);
+        mark_comment_state_dirty(fs);
 
         // Move cursor to the new line
         fs->cursor_x = 1;

--- a/src/input.c
+++ b/src/input.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include "input.h"
+#include "syntax.h"
 
 char *strdup(const char *s);  // Explicitly declare strdup
 
@@ -111,6 +112,7 @@ void handle_key_backspace(FileState *fs) {
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
+    mark_comment_state_dirty(fs);
 }
 
 /**
@@ -137,6 +139,7 @@ void handle_key_delete(FileState *fs) {
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
+    mark_comment_state_dirty(fs);
 }
 
 /**
@@ -174,6 +177,7 @@ void handle_key_enter(FileState *fs) {
         werase(text_win);
         box(text_win, 0, 0);
         draw_text_buffer(active_file, text_win);
+        mark_comment_state_dirty(fs);
     }
 }
 
@@ -346,6 +350,7 @@ void handle_default_key(FileState *fs, int ch) {
         char *new_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
         Change change = { fs->cursor_y - 1 + fs->start_line, old_text, new_text };
         push(&fs->undo_stack, change);
+        mark_comment_state_dirty(fs);
     }
 
     // Redraw the text buffer

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -93,6 +93,11 @@ void sync_multiline_comment(FileState *fs, int line) {
     fs->last_comment_state = in_comment;
 }
 
+void mark_comment_state_dirty(FileState *fs) {
+    fs->last_scanned_line = 0;
+    fs->last_comment_state = false;
+}
+
 
 /**
  * Applies syntax highlighting to a line of text based on the current syntax mode.

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -28,5 +28,6 @@ void highlight_no_syntax(WINDOW *win, const char *line, int y);
 void highlight_python_syntax(WINDOW *win, const char *line, int y);
 void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void sync_multiline_comment(struct FileState *fs, int line);
+void mark_comment_state_dirty(struct FileState *fs);
 
 #endif // SYNTAX_H


### PR DESCRIPTION
## Summary
- add `mark_comment_state_dirty` helper to reset comment scanning state
- trigger this helper in all editing functions so syntax highlighting stays accurate

## Testing
- `make`