### PR TITLE
Handle initialization allocation failures

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -60,6 +60,14 @@ void load_file(FileState *fs_unused, const char *filename) {
 
     /* Allocate a new file state */
     FileState *fs = initialize_file_state(filename, MAX_LINES, COLS - 3);
+    if (!fs) {
+        mvprintw(LINES - 2, 2, "Memory allocation failed!");
+        refresh();
+        getch();
+        mvprintw(LINES - 2, 2, "                            ");
+        refresh();
+        return;
+    }
     active_file = fs;
 
     fs->syntax_mode = set_syntax_mode(filename);
@@ -116,6 +124,14 @@ void load_file(FileState *fs_unused, const char *filename) {
 void new_file(FileState *fs_unused) {
     (void)fs_unused;
     FileState *fs = initialize_file_state("", MAX_LINES, COLS - 3);
+    if (!fs) {
+        mvprintw(LINES - 2, 2, "Memory allocation failed!");
+        refresh();
+        getch();
+        mvprintw(LINES - 2, 2, "                            ");
+        refresh();
+        return;
+    }
     active_file = fs;
     fs->filename[0] = '\0';
     fs->syntax_mode = set_syntax_mode(fs->filename);

--- a/src/files.c
+++ b/src/files.c
@@ -6,13 +6,29 @@
 // Function to initialize a new FileState for a given filename
 FileState *initialize_file_state(const char *filename, int max_lines, int max_cols) {
     FileState *file_state = malloc(sizeof(FileState));
+    if (!file_state) {
+        return NULL;
+    }
+
     strncpy(file_state->filename, filename, sizeof(file_state->filename) - 1);
     file_state->filename[sizeof(file_state->filename) - 1] = '\0';
 
     // Initialize text buffer
     file_state->text_buffer = malloc(max_lines * sizeof(char *));
+    if (!file_state->text_buffer) {
+        free(file_state);
+        return NULL;
+    }
     for (int i = 0; i < max_lines; i++) {
         file_state->text_buffer[i] = calloc(max_cols, sizeof(char));
+        if (!file_state->text_buffer[i]) {
+            for (int j = 0; j < i; j++) {
+                free(file_state->text_buffer[j]);
+            }
+            free(file_state->text_buffer);
+            free(file_state);
+            return NULL;
+        }
     }
 
     file_state->line_count = 0;


### PR DESCRIPTION
## Summary
- check the results of `malloc` and `calloc` in `initialize_file_state`
- free resources and return `NULL` when allocations fail
- ensure callers handle a `NULL` `FileState` in `load_file` and `new_file`

## Testing
- `make`