### PR TITLE
Add dynamic buffer capacity tracking

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -381,7 +381,7 @@ void delete_current_line(FileState *fs) {
  * @param fs Pointer to the current file state.
  */
 void insert_new_line(FileState *fs) {
-    if (fs->line_count < MAX_LINES - 1) {
+    if (fs->line_count < DEFAULT_BUFFER_LINES - 1) {
         // Move lines below the cursor down by one
         for (int i = fs->line_count; i > fs->cursor_y + fs->start_line - 1; --i) {
             strcpy(fs->text_buffer[i], fs->text_buffer[i - 1]);
@@ -611,7 +611,7 @@ void cleanup_on_exit(FileManager *fm) {
         free_stack(fs->redo_stack);
         fs->redo_stack = NULL;
 
-        free_file_state(fs, MAX_LINES);
+        free_file_state(fs, DEFAULT_BUFFER_LINES);
     }
 
     freeMenus();
@@ -634,7 +634,7 @@ void close_editor() {
  */
 void initialize_buffer() {
     // Allocate memory for each line in the text buffer
-    for (int i = 0; i < MAX_LINES; ++i) {
+    for (int i = 0; i < DEFAULT_BUFFER_LINES; ++i) {
         if (active_file->text_buffer[i] != NULL) {
             free(active_file->text_buffer[i]);
             active_file->text_buffer[i] = NULL;
@@ -808,7 +808,7 @@ void handle_resize(int sig) {
  */
 void clear_text_buffer() {
     // Set all elements of the text buffer to 0
-    for (int i = 0; i < MAX_LINES; ++i) {
+    for (int i = 0; i < DEFAULT_BUFFER_LINES; ++i) {
         memset(active_file->text_buffer[i], 0, COLS - 3);
     }
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -15,7 +15,7 @@ typedef struct Node {
     struct Node *next;
 } Node;
 
-#define MAX_LINES 5000
+#define DEFAULT_BUFFER_LINES 5000
 
 // Define custom key constants for CTRL-Left, CTRL-Right, CTRL-Page Up, CTRL-Page Down
 #define KEY_CTRL_LEFT       1000

--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -29,7 +29,7 @@ int fm_add(FileManager *fm, FileState *fs) {
 
 void fm_close(FileManager *fm, int index) {
     if (!fm || index < 0 || index >= fm->count) return;
-    free_file_state(fm->files[index], MAX_LINES);
+    free_file_state(fm->files[index], DEFAULT_BUFFER_LINES);
     for (int i = index; i < fm->count - 1; i++) {
         fm->files[i] = fm->files[i + 1];
     }

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -59,7 +59,7 @@ void load_file(FileState *fs_unused, const char *filename) {
     }
 
     /* Allocate a new file state */
-    FileState *fs = initialize_file_state(filename, MAX_LINES, COLS - 3);
+    FileState *fs = initialize_file_state(filename, DEFAULT_BUFFER_LINES, COLS - 3);
     if (!fs) {
         mvprintw(LINES - 2, 2, "Memory allocation failed!");
         refresh();
@@ -79,7 +79,7 @@ void load_file(FileState *fs_unused, const char *filename) {
     FILE *fp = fopen(filename, "r");
     if (fp) {
         fs->line_count = 0;
-        while (fgets(fs->text_buffer[fs->line_count], COLS - 3, fp) && fs->line_count < MAX_LINES) {
+        while (fgets(fs->text_buffer[fs->line_count], COLS - 3, fp) && fs->line_count < DEFAULT_BUFFER_LINES) {
             fs->text_buffer[fs->line_count][strcspn(fs->text_buffer[fs->line_count], "\n")] = '\0';
             fs->line_count++;
         }
@@ -123,7 +123,7 @@ void load_file(FileState *fs_unused, const char *filename) {
 
 void new_file(FileState *fs_unused) {
     (void)fs_unused;
-    FileState *fs = initialize_file_state("", MAX_LINES, COLS - 3);
+    FileState *fs = initialize_file_state("", DEFAULT_BUFFER_LINES, COLS - 3);
     if (!fs) {
         mvprintw(LINES - 2, 2, "Memory allocation failed!");
         refresh();

--- a/src/files.c
+++ b/src/files.c
@@ -32,6 +32,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     }
 
     file_state->line_count = 0;
+    file_state->max_lines = max_lines;
     file_state->start_line = 0;
     file_state->cursor_x = 1;
     file_state->cursor_y = 1;
@@ -52,7 +53,8 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
 
 // Function to free allocated resources in FileState
 void free_file_state(FileState *file_state, int max_lines) {
-    for (int i = 0; i < max_lines; i++) {
+    (void)max_lines;
+    for (int i = 0; i < file_state->max_lines; i++) {
         free(file_state->text_buffer[i]);
     }
     free(file_state->text_buffer);

--- a/src/files.h
+++ b/src/files.h
@@ -8,6 +8,7 @@ typedef struct FileState {
     char filename[256];
     char **text_buffer;
     int line_count;
+    int max_lines;
     int start_line;
     int cursor_x, cursor_y;
     Node *undo_stack;

--- a/src/input.c
+++ b/src/input.c
@@ -152,7 +152,7 @@ void handle_key_delete(FileState *fs) {
  * @param fs->start_line Pointer to the starting line of the visible text area.
  */
 void handle_key_enter(FileState *fs) {
-    if (fs->line_count < MAX_LINES - 1) {
+    if (fs->line_count < DEFAULT_BUFFER_LINES - 1) {
         for (int i = fs->line_count; i > fs->cursor_y + fs->start_line; --i) {
             strcpy(fs->text_buffer[i], fs->text_buffer[i - 1]);
         }


### PR DESCRIPTION
## Summary
- track per-file buffer capacity via `FileState.max_lines`
- initialise this new field in `initialize_file_state`
- free buffers using `file_state->max_lines`
- rename `MAX_LINES` to `DEFAULT_BUFFER_LINES` and update usages

## Testing
- `make`