### PR TITLE
Use fs->max_lines across cleanup and buffer ops

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -610,7 +610,7 @@ void cleanup_on_exit(FileManager *fm) {
         free_stack(fs->redo_stack);
         fs->redo_stack = NULL;
 
-        free_file_state(fs, DEFAULT_BUFFER_LINES);
+        free_file_state(fs, fs->max_lines);
     }
 
     freeMenus();
@@ -633,7 +633,7 @@ void close_editor() {
  */
 void initialize_buffer() {
     // Allocate memory for each line in the text buffer
-    for (int i = 0; i < DEFAULT_BUFFER_LINES; ++i) {
+    for (int i = 0; i < active_file->max_lines; ++i) {
         if (active_file->text_buffer[i] != NULL) {
             free(active_file->text_buffer[i]);
             active_file->text_buffer[i] = NULL;
@@ -807,7 +807,7 @@ void handle_resize(int sig) {
  */
 void clear_text_buffer() {
     // Set all elements of the text buffer to 0
-    for (int i = 0; i < DEFAULT_BUFFER_LINES; ++i) {
+    for (int i = 0; i < active_file->max_lines; ++i) {
         memset(active_file->text_buffer[i], 0, COLS - 3);
     }
 

--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -29,7 +29,7 @@ int fm_add(FileManager *fm, FileState *fs) {
 
 void fm_close(FileManager *fm, int index) {
     if (!fm || index < 0 || index >= fm->count) return;
-    free_file_state(fm->files[index], DEFAULT_BUFFER_LINES);
+    free_file_state(fm->files[index], fm->files[index]->max_lines);
     for (int i = index; i < fm->count - 1; i++) {
         fm->files[i] = fm->files[i + 1];
     }


### PR DESCRIPTION
## Summary
- use each file's `max_lines` when closing via fm_close or cleaning up
- rely on `FileState.max_lines` in initialize_buffer and clear_text_buffer loops

## Testing
- `make`