### PR TITLE
Document file browsing shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We are currently in the initial development phase, focusing on building the core
 Vento currently supports the following features:
 
 - **Basic Editor**: Provides essential text editing capabilities.
-- **Load Files**: Open and edit existing files.
+- **Load Files**: Press `CTRL-L` to open a dialog for browsing directories or typing a filename, then edit the selected file.
 - **Create New File**: Start a new document easily.
 - **Save As**: Save your work with a new filename.
 - **Save Feature**: Save changes without being prompted for a filename each time.
@@ -39,9 +39,9 @@ Vento currently supports the following features:
 
 ### Multi-File Support
 
-Vento allows multiple files to be opened at once. Load additional files using
-`CTRL-L` and switch between them with `F6` for the next file or `F7` for the
-previous one.
+Vento allows multiple files to be opened at once. Press `CTRL-L` to open a
+dialog for browsing directories or typing a filename, and switch between loaded
+files with `F6` for the next file or `F7` for the previous one.
 
 ## Planned Features
 

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -20,15 +20,15 @@ Show the help screen.
 [optional-filename]
 
 .PP
-Vento allows multiple files to be opened at once. Load additional files using
-\fBCTRL-L\fP and switch between them with \fBF6\fP for the next file or
-\fBF7\fP for the previous one.
+Vento allows multiple files to be opened at once. Press \fBCTRL-L\fP to open a
+dialog for browsing directories or typing a filename, and switch between them
+with \fBF6\fP for the next file or \fBF7\fP for the previous one.
 
 .SH FEATURES
 .IP \[bu] 2
 Basic editor functionality: Navigate through text using arrow keys, edit text, and manage files.
 .IP \[bu] 2
-Load files: Open existing files for editing.
+Load files: Press \fBCTRL-L\fP to open a dialog for browsing directories or typing a filename before editing the file.
 .IP \[bu] 2
 Save as: Save the current document with a new filename.
 .IP \[bu] 2
@@ -65,7 +65,7 @@ Display the help screen.
 Show the about box with the name of the product, version, and GPL message.
 .TP 
 .B CTRL-L
-Load a new file.
+Open a dialog to browse directories or type a filename for loading a new file.
 .TP 
 .B CTRL-O
 Save the current file with a new filename (Save As).

--- a/src/ui.c
+++ b/src/ui.c
@@ -42,7 +42,7 @@ void show_help() {
     // Print the command and keybinding for each command
     mvwprintw(help_win, 3, 2, "CTRL-H: Show this help");
     mvwprintw(help_win, 4, 2, "CTRL-A: About");
-    mvwprintw(help_win, 5, 2, "CTRL-L: Load a new file");
+    mvwprintw(help_win, 5, 2, "CTRL-L: Load a new file (browse files)");
     mvwprintw(help_win, 6, 2, "CTRL-O: Save as");
     mvwprintw(help_win, 7, 2, "CTRL-P: Save");
     mvwprintw(help_win, 8, 2, "CTRL-J: Start/Stop selection mode");


### PR DESCRIPTION
## Summary
- explain that **CTRL-L** opens a file browser dialog
- document this in the man page
- show the hint in the help screen

## Testing
- `make`