### PR TITLE
Clarify Save As behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Vento currently supports the following features:
 - **Basic Editor**: Provides essential text editing capabilities.
 - **Load Files**: Press `CTRL-L` to open a dialog for browsing directories or typing a filename, then edit the selected file.
 - **Create New File**: Start a new document easily.
-- **Save As**: Save your work with a new filename.
+- **Save As**: Press `CTRL-O` or choose "Save As" from the File menu to open a dialog for browsing directories or typing a new filename.
 - **Save Feature**: Save changes without being prompted for a filename each time.
 - **Undo and Redo**: Undo and redo actions to correct mistakes.
 - **Find**: Search for the next occurrance of a word.

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -68,7 +68,7 @@ Show the about box with the name of the product, version, and GPL message.
 Open a dialog to browse directories or type a filename for loading a new file.
 .TP 
 .B CTRL-O
-Save the current file with a new filename (Save As).
+Open a dialog to choose a directory or type a new filename, then save the file (Save As).
 .TP 
 .B CTRL-P
 Save the current file without prompting for a new filename.

--- a/src/ui.c
+++ b/src/ui.c
@@ -43,7 +43,7 @@ void show_help() {
     mvwprintw(help_win, 3, 2, "CTRL-H: Show this help");
     mvwprintw(help_win, 4, 2, "CTRL-A: About");
     mvwprintw(help_win, 5, 2, "CTRL-L: Load a new file (browse files)");
-    mvwprintw(help_win, 6, 2, "CTRL-O: Save as");
+    mvwprintw(help_win, 6, 2, "CTRL-O: Save As (browse dir or name)");
     mvwprintw(help_win, 7, 2, "CTRL-P: Save");
     mvwprintw(help_win, 8, 2, "CTRL-J: Start/Stop selection mode");
     mvwprintw(help_win, 9, 2, "CTRL-K: Paste from clipboard");


### PR DESCRIPTION
## Summary
- document that **CTRL-O** and the File menu's *Save As* option bring up a dialog for browsing directories or entering a new filename
- adjust man page shortcut description
- update help screen text accordingly

## Testing
- `make`
