### PR TITLE
Add AppConfig struct and config helpers

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,125 +1,146 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <pwd.h>
 #include <unistd.h>
 #include "editor.h"
 #include "config.h"
 #include "syntax.h"
 
-int enable_color = 1; // Default to enabled
+int enable_color = 1; // global flag used throughout the editor
 
-// Function to map color names to ncurses color constants
-// Returns the corresponding color code for the given color name
+// default application configuration
+AppConfig app_config = {
+    .background_color = "BLACK",
+    .keyword_color = "CYAN",
+    .comment_color = "GREEN",
+    .string_color = "YELLOW",
+    .type_color = "MAGENTA",
+    .symbol_color = "RED",
+    .enable_color = 1
+};
+
+// Helper to map color name to ncurses constant
 short get_color_code(const char *color_name) {
-    if (strcmp(color_name, "BLACK") == 0) return COLOR_BLACK; // Black color
-    if (strcmp(color_name, "RED") == 0) return COLOR_RED; // Red color
-    if (strcmp(color_name, "GREEN") == 0) return COLOR_GREEN; // Green color
-    if (strcmp(color_name, "YELLOW") == 0) return COLOR_YELLOW; // Yellow color
-    if (strcmp(color_name, "BLUE") == 0) return COLOR_BLUE; // Blue color
-    if (strcmp(color_name, "MAGENTA") == 0) return COLOR_MAGENTA; // Magenta color
-    if (strcmp(color_name, "CYAN") == 0) return COLOR_CYAN; // Cyan color
-    if (strcmp(color_name, "WHITE") == 0) return COLOR_WHITE; // White color
-    return -1; // Invalid color
+    if (strcmp(color_name, "BLACK") == 0) return COLOR_BLACK;
+    if (strcmp(color_name, "RED") == 0) return COLOR_RED;
+    if (strcmp(color_name, "GREEN") == 0) return COLOR_GREEN;
+    if (strcmp(color_name, "YELLOW") == 0) return COLOR_YELLOW;
+    if (strcmp(color_name, "BLUE") == 0) return COLOR_BLUE;
+    if (strcmp(color_name, "MAGENTA") == 0) return COLOR_MAGENTA;
+    if (strcmp(color_name, "CYAN") == 0) return COLOR_CYAN;
+    if (strcmp(color_name, "WHITE") == 0) return COLOR_WHITE;
+    return -1;
 }
 
-void create_default_config(const char *filepath) {
-    FILE *file = fopen(filepath, "w");
-    if (file) {
-        fprintf(file, "background_color=BLACK\n");
-        fprintf(file, "keyword_color=CYAN\n");
-        fprintf(file, "comment_color=GREEN\n");
-        fprintf(file, "string_color=YELLOW\n");
-        fprintf(file, "type_color=MAGENTA\n");
-        fprintf(file, "symbol_color=RED\n");
-        fprintf(file, "enable_color=true\n");
-        fclose(file);
-    }
-}
-
-/**
- * Reads the configuration file and applies the settings.
- * If the file doesn't exist, it creates a default configuration file.
- */
-void read_config_file() {
-    // Get the user's home directory
+static void get_config_path(char *buf, size_t size) {
     struct passwd *pw = getpwuid(getuid());
-    const char *homedir = pw->pw_dir;
+    const char *homedir = pw ? pw->pw_dir : getenv("HOME");
+    if (!homedir) homedir = "";
+    snprintf(buf, size, "%s/.ventorc", homedir);
+}
 
-    // Create the file path
-    char filepath[256];
-    snprintf(filepath, sizeof(filepath), "%s/ventorc", homedir);
+static void trim(char *str) {
+    char *start = str;
+    while (isspace((unsigned char)*start)) start++;
+    char *end = start + strlen(start);
+    while (end > start && isspace((unsigned char)*(end - 1))) end--;
+    size_t len = end - start;
+    memmove(str, start, len);
+    str[len] = '\0';
+}
 
-    // Open the configuration file for reading
-    FILE *file = fopen(filepath, "r");
+void config_save(const AppConfig *cfg) {
+    char path[256];
+    get_config_path(path, sizeof(path));
+    FILE *f = fopen(path, "w");
+    if (!f) return;
+    fprintf(f, "background_color=%s\n", cfg->background_color);
+    fprintf(f, "keyword_color=%s\n", cfg->keyword_color);
+    fprintf(f, "comment_color=%s\n", cfg->comment_color);
+    fprintf(f, "string_color=%s\n", cfg->string_color);
+    fprintf(f, "type_color=%s\n", cfg->type_color);
+    fprintf(f, "symbol_color=%s\n", cfg->symbol_color);
+    fprintf(f, "enable_color=%s\n", cfg->enable_color ? "true" : "false");
+    fclose(f);
+}
+
+void config_load(AppConfig *cfg) {
+    char path[256];
+    get_config_path(path, sizeof(path));
+    FILE *file = fopen(path, "r");
     if (!file) {
-        // Create default config if file doesn't exist
-        create_default_config(filepath);
-        file = fopen(filepath, "r");
+        config_save(cfg); // create default config
+        file = fopen(path, "r");
+        if (!file) return;
     }
 
-    if (!file) {
-        return; // Could not create or open the file
-    }
-
+    AppConfig tmp = *cfg;
     char line[256];
     while (fgets(line, sizeof(line), file)) {
-        char *key = strtok(line, "=");
-        char *value = strtok(NULL, "\n");
+        char *p = line;
+        while (isspace((unsigned char)*p)) p++;
+        if (*p == '#' || *p == '\0' || *p == '\n')
+            continue;
+        line[strcspn(line, "\n")] = '\0';
+        char *eq = strchr(p, '=');
+        if (!eq) continue;
+        *eq++ = '\0';
+        char *key = p;
+        char *value = eq;
+        trim(key);
+        trim(value);
 
-        if (key && value) {
-            short color_code = get_color_code(value);
-            if (strcmp(key, "enable_color") == 0) {
-                if (strcmp(value, "true") == 0) {
-                    enable_color = 1;
-                    start_color();
-                } else {
-                    enable_color = 0;
-                }
-#ifdef DEBUG
-                printf("Setting enable_color to %d\n", enable_color);
-#endif
-            } else if (enable_color) {
-                if (color_code == -1) {
-#ifdef DEBUG
-                    printf("Invalid color value: %s\n", value);
-#endif
-                    continue;
-                }
-
-                if (strcmp(key, "background_color") == 0) {
-                    init_pair(SYNTAX_BG, COLOR_WHITE, color_code);
-#ifdef DEBUG
-                    printf("Setting background_color to color code %d\n", color_code);
-#endif
-                } else if (strcmp(key, "keyword_color") == 0) {
-                    init_pair(SYNTAX_KEYWORD, color_code, COLOR_BLACK);
-#ifdef DEBUG
-                    printf("Setting keyword_color to color code %d\n", color_code);
-#endif
-                } else if (strcmp(key, "comment_color") == 0) {
-                    init_pair(SYNTAX_COMMENT, color_code, COLOR_BLACK);
-#ifdef DEBUG
-                    printf("Setting comment_color to color code %d\n", color_code);
-#endif
-                } else if (strcmp(key, "string_color") == 0) {
-                    init_pair(SYNTAX_STRING, color_code, COLOR_BLACK);
-#ifdef DEBUG
-                    printf("Setting string_color to color code %d\n", color_code);
-#endif
-                } else if (strcmp(key, "type_color") == 0) {
-                    init_pair(SYNTAX_TYPE, color_code, COLOR_BLACK);
-#ifdef DEBUG
-                    printf("Setting type_color to color code %d\n", color_code);
-#endif
-                } else if (strcmp(key, "symbol_color") == 0) {
-                    init_pair(SYNTAX_SYMBOL, color_code, COLOR_BLACK);
-#ifdef DEBUG
-                    printf("Setting symbol_color to color code %d\n", color_code);
-#endif
-                }
-            }
+        if (strcmp(key, "background_color") == 0) {
+            strncpy(tmp.background_color, value, sizeof(tmp.background_color)-1);
+            tmp.background_color[sizeof(tmp.background_color)-1] = '\0';
+        } else if (strcmp(key, "keyword_color") == 0) {
+            strncpy(tmp.keyword_color, value, sizeof(tmp.keyword_color)-1);
+            tmp.keyword_color[sizeof(tmp.keyword_color)-1] = '\0';
+        } else if (strcmp(key, "comment_color") == 0) {
+            strncpy(tmp.comment_color, value, sizeof(tmp.comment_color)-1);
+            tmp.comment_color[sizeof(tmp.comment_color)-1] = '\0';
+        } else if (strcmp(key, "string_color") == 0) {
+            strncpy(tmp.string_color, value, sizeof(tmp.string_color)-1);
+            tmp.string_color[sizeof(tmp.string_color)-1] = '\0';
+        } else if (strcmp(key, "type_color") == 0) {
+            strncpy(tmp.type_color, value, sizeof(tmp.type_color)-1);
+            tmp.type_color[sizeof(tmp.type_color)-1] = '\0';
+        } else if (strcmp(key, "symbol_color") == 0) {
+            strncpy(tmp.symbol_color, value, sizeof(tmp.symbol_color)-1);
+            tmp.symbol_color[sizeof(tmp.symbol_color)-1] = '\0';
+        } else if (strcmp(key, "enable_color") == 0) {
+            tmp.enable_color = (strcmp(value, "true") == 0 || strcmp(value, "1") == 0);
+        } else {
+            // Unknown key, ignore
+            continue;
         }
     }
     fclose(file);
+
+    *cfg = tmp;
+    enable_color = cfg->enable_color;
+
+    if (enable_color) {
+        start_color();
+        short code;
+        code = get_color_code(cfg->background_color);
+        if (code != -1) init_pair(SYNTAX_BG, COLOR_WHITE, code);
+        code = get_color_code(cfg->keyword_color);
+        if (code != -1) init_pair(SYNTAX_KEYWORD, code, COLOR_BLACK);
+        code = get_color_code(cfg->comment_color);
+        if (code != -1) init_pair(SYNTAX_COMMENT, code, COLOR_BLACK);
+        code = get_color_code(cfg->string_color);
+        if (code != -1) init_pair(SYNTAX_STRING, code, COLOR_BLACK);
+        code = get_color_code(cfg->type_color);
+        if (code != -1) init_pair(SYNTAX_TYPE, code, COLOR_BLACK);
+        code = get_color_code(cfg->symbol_color);
+        if (code != -1) init_pair(SYNTAX_SYMBOL, code, COLOR_BLACK);
+    }
+}
+
+// Compatibility wrapper
+void read_config_file() {
+    config_load(&app_config);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -5,7 +5,21 @@
 
 extern int enable_color;
 
+typedef struct {
+    char background_color[16];
+    char keyword_color[16];
+    char comment_color[16];
+    char string_color[16];
+    char type_color[16];
+    char symbol_color[16];
+    int enable_color;
+} AppConfig;
+
+extern AppConfig app_config;
+
 short get_color_code(const char *color_name);
+void config_load(AppConfig *cfg);
+void config_save(const AppConfig *cfg);
 void read_config_file(void);
 
 #endif // CONFIG_H

--- a/src/editor.c
+++ b/src/editor.c
@@ -443,8 +443,8 @@ void initialize() {
     // Initialize the screen
     initscr();
 
-    // Read the configuration file
-    read_config_file();
+    // Load the configuration file
+    config_load(&app_config);
 
     // Enable color if specified
     if (enable_color) {
@@ -463,8 +463,6 @@ void initialize() {
     // Set timeout to 100 milliseconds
     timeout(10); 
 
-    // Read the configuration file again (in case it was modified)
-    read_config_file();
 
     // Set up color pairs for syntax highlighting
     if (has_colors() && can_change_color()) {


### PR DESCRIPTION
## Summary
- add `AppConfig` struct to store configuration
- implement `config_load` and `config_save`
- move config parsing logic to new helpers and remove `strtok` usage
- load configuration from `initialize`

## Testing
- `make`