### PR TITLE
Implement settings dialog

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -212,7 +212,12 @@ void menuPrevFile() {
 }
 
 void menuSettings() {
-    show_settings_dialog(&app_config);
+    if (show_settings_dialog(&app_config)) {
+        config_save(&app_config);
+        config_load(&app_config);
+        redraw();
+        drawBar();
+    }
 }
 
 void menuQuitEditor() {

--- a/src/ui.h
+++ b/src/ui.h
@@ -12,6 +12,6 @@ void free_dir_contents(char **choices, int n_choices);
 void show_find_dialog(char *output, int max_input_len);
 int show_open_file_dialog(char *path, int max_len);
 int show_save_file_dialog(char *path, int max_len);
-void show_settings_dialog(AppConfig *cfg);
+int show_settings_dialog(AppConfig *cfg);
 
 #endif // UI_H


### PR DESCRIPTION
## Summary
- implement configurable settings dialog
- return bool to signal config change
- save and reload config when menu item called

## Testing
- `make`