### PR TITLE
Add persistent find dialog and F3 find-next

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -46,6 +46,7 @@ int key_redo = 18;  // Key code for the redo command
 int key_undo = 21;  // Key code for the undo command
 int key_quit = 24;  // Key code for quitting the editor
 int key_find = 6;  // Key code for finding next word
+int key_find_next = KEY_F(3);  // Key code for find next occurrence
 int key_next_file = KEY_F(6);  // Key code for switching to the next file
 int key_prev_file = KEY_F(7);  // Key code for switching to the previous file
 
@@ -160,6 +161,13 @@ static void handle_find_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
     find(fs, 1);
+    redraw();
+}
+
+static void handle_find_next_wrapper(struct FileState *fs, int *cx, int *cy) {
+    (void)cx;
+    (void)cy;
+    find(fs, 0);
     redraw();
 }
 
@@ -308,6 +316,7 @@ static void initialize_key_mappings(void) {
     key_mappings[key_mapping_count++] = (KeyMapping){key_help, handle_help_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_about, handle_about_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_find, handle_find_wrapper};
+    key_mappings[key_mapping_count++] = (KeyMapping){key_find_next, handle_find_next_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_delete_line, handle_delete_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_insert_line, handle_insert_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_move_forward, handle_move_forward_wrapper};

--- a/src/editor.h
+++ b/src/editor.h
@@ -39,6 +39,7 @@ typedef struct {
 extern WINDOW *text_win;
 extern struct FileState *active_file;
 extern struct FileManager file_manager;
+extern char search_text[256];
 void handle_regular_mode(struct FileState *fs, int ch);
 void initialize(void);
 void draw_text_buffer(struct FileState *fs, WINDOW *win);

--- a/src/search.c
+++ b/src/search.c
@@ -7,6 +7,8 @@
 #include "search.h"
 #include "files.h"
 
+extern char search_text[256];
+
 void find_next_occurrence(FileState *fs, const char *word) {
     int *cursor_x = &fs->cursor_x;
     int *cursor_y = &fs->cursor_y;
@@ -91,18 +93,21 @@ void find_next_occurrence(FileState *fs, const char *word) {
 
 void find(FileState *fs, int new_search)
 {
-    (void)new_search;
-    char *output = malloc(256 * sizeof(char));
-    if (!output) {
-        mvprintw(LINES - 2, 0, "Memory allocation failed.");
-        refresh();
-        return;
+    char output[256];
+
+    if (new_search) {
+        while (1) {
+            show_find_dialog(search_text, output, sizeof(output));
+            if (output[0] == '\0')
+                break;
+
+            strncpy(search_text, output, sizeof(search_text) - 1);
+            search_text[sizeof(search_text) - 1] = '\0';
+            find_next_occurrence(fs, search_text);
+        }
+    } else {
+        if (search_text[0] != '\0')
+            find_next_occurrence(fs, search_text);
     }
-
-    *output = '\0';
-    show_find_dialog(output, 20);
-
-    find_next_occurrence(fs, output);
-    free(output);
 }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -9,7 +9,7 @@ void create_dialog(const char *message, char *output, int max_input_len);
 void show_warning_dialog(void);
 void get_dir_contents(const char *dir_path, char ***choices, int *n_choices);
 void free_dir_contents(char **choices, int n_choices);
-void show_find_dialog(char *output, int max_input_len);
+void show_find_dialog(const char *initial, char *output, int max_input_len);
 int show_open_file_dialog(char *path, int max_len);
 int show_save_file_dialog(char *path, int max_len);
 int show_settings_dialog(AppConfig *cfg);


### PR DESCRIPTION
## Summary
- keep last search text globally
- allow `show_find_dialog` to prefill previous term
- implement looping search with ESC exit
- add F3 binding for find-next without dialog

## Testing
- `make clean`
- `make`