### PR TITLE
Enable replace function via menu and shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Vento currently supports the following features:
 - **Save Feature**: Save changes without being prompted for a filename each time.
 - **Undo and Redo**: Undo and redo actions to correct mistakes.
 - **Find**: Search for the next occurrance of a word.
+- **Replace**: Press `CTRL-S` to search and replace text.
 - **Delete Current Line**: Press `CTRL-D` to delete the current line.
 - **Word Navigation**: Use `CTRL-W` to move to the next word and `CTRL-B` to move to the previous word.
 - **Close Current File**: Press `CTRL-Q` to close the active file.
@@ -66,7 +67,6 @@ The following features are planned for future releases:
 - **Syntax Highlighting**: Support for more languages and improved highlighting.
 - **Large File Support**: Improved optimizations for handling large files.
 - **Mouse Support**: Navigate the user interface and files using a mouse.
-- **Replace**: Easily search for specific text and replace it with another.
 - **FTP Support**: Access files on FTP servers as if they were locally stored.
 - **Theme Support**: Multiple built in themes for easy visual customization.
 - **Spell Checker Support**: Automatically detect and correct typos.

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -117,6 +117,10 @@ Quit the editor and return to the shell.
 .TP
 .B CTRL-F
 Search the file for a string of text.
+.TP
+.B CTRL-S
+Replace occurrences of a search string.
+.TP
 .B CTRL-W
 Move the cursor forward to the beginning of the next word.
 .TP 

--- a/src/editor.c
+++ b/src/editor.c
@@ -49,6 +49,7 @@ int key_find = 6;  // Key code for finding next word
 int key_find_next = KEY_F(3);  // Key code for find next occurrence
 int key_next_file = KEY_F(6);  // Key code for switching to the next file
 int key_prev_file = KEY_F(7);  // Key code for switching to the previous file
+int key_replace = 19;  // Key code for replacing text (CTRL-S)
 
 static void handle_key_up_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
@@ -168,6 +169,13 @@ static void handle_find_next_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
     find(fs, 0);
+    redraw();
+}
+
+static void handle_replace_wrapper(struct FileState *fs, int *cx, int *cy) {
+    (void)cx;
+    (void)cy;
+    replace(fs);
     redraw();
 }
 
@@ -317,6 +325,7 @@ static void initialize_key_mappings(void) {
     key_mappings[key_mapping_count++] = (KeyMapping){key_about, handle_about_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_find, handle_find_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_find_next, handle_find_next_wrapper};
+    key_mappings[key_mapping_count++] = (KeyMapping){key_replace, handle_replace_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_delete_line, handle_delete_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_insert_line, handle_insert_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_move_forward, handle_move_forward_wrapper};

--- a/src/menu.c
+++ b/src/menu.c
@@ -64,7 +64,7 @@ void initializeMenus() {
     menus[0] = fileMenu;
 
     // Create the edit menu
-    MenuItem *editMenuItems = malloc(3 * sizeof(MenuItem));
+    MenuItem *editMenuItems = malloc(4 * sizeof(MenuItem));
     if (editMenuItems == NULL) {
         fprintf(stderr, "Failed to allocate memory for edit menu items\n");
         freeMenus();
@@ -73,9 +73,10 @@ void initializeMenus() {
     editMenuItems[0] = (MenuItem){"Undo", menuUndo};
     editMenuItems[1] = (MenuItem){"Redo", menuRedo};
     editMenuItems[2] = (MenuItem){"Find", menuFind};
+    editMenuItems[3] = (MenuItem){"Replace", menuReplace};
 
     // Initialize and assign the edit menu
-    Menu editMenu = {"Edit", editMenuItems, 3};
+    Menu editMenu = {"Edit", editMenuItems, 4};
     menus[1] = editMenu;
 
     // Create the help menu
@@ -234,6 +235,10 @@ void menuRedo() {
 
 void menuFind() {
     find(active_file, 1);
+}
+
+void menuReplace() {
+    replace(active_file);
 }
 
 void menuAbout() {

--- a/src/menu.h
+++ b/src/menu.h
@@ -26,6 +26,7 @@ void menuQuitEditor(void);
 void menuUndo(void);
 void menuRedo(void);
 void menuFind(void);
+void menuReplace(void);
 void menuAbout(void);
 void menuHelp(void);
 void menuTestwindow(void);

--- a/src/ui.c
+++ b/src/ui.c
@@ -52,6 +52,7 @@ void show_help() {
     mvwprintw(help_win, 11, 2, "CTRL-R: Redo");
     mvwprintw(help_win, 12, 2, "CTRL-U: Undo");
     mvwprintw(help_win, 13, 2, "CTRL-F: Search for text string");
+    mvwprintw(help_win, 14, 2, "CTRL-S: Replace text");
 
     // Print the second column of commands and keybindings
     mvwprintw(help_win, 3, win_width / 2, "CTRL-X: Quit");


### PR DESCRIPTION
## Summary
- expand Edit menu with Replace option
- implement `menuReplace()` to invoke the replace dialog
- add CTRL-S key constant and map it to a replace handler
- document the new shortcut in help text, the man page, and README

## Testing
- `make clean`
- `make`