### PR TITLE
Fix buffer width handling on resize

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -112,7 +112,8 @@ void handle_selection_mode(FileState *fs, int ch, int *cursor_x, int *cursor_y) 
         fs->sel_end_x = *cursor_x;
     }
     if (ch == KEY_RIGHT) {
-        if (*cursor_x < COLS - 6) (*cursor_x)++;
+        /* Do not allow the cursor to move past the buffer width */
+        if (*cursor_x < fs->line_capacity - 1) (*cursor_x)++;
         fs->sel_end_x = *cursor_x;
     }
     if (ch == 10) {

--- a/src/editor.c
+++ b/src/editor.c
@@ -788,7 +788,9 @@ void handle_resize(int sig) {
     refresh(); // Refresh the screen
     clear(); // Clear the screen
 
-    /* Resize all open file windows */
+    int new_capacity = COLS - 3;
+
+    /* Resize all open file windows and buffers */
     for (int i = 0; i < file_manager.count; ++i) {
         FileState *fs = file_manager.files[i];
         if (!fs || !fs->text_win) {
@@ -796,6 +798,17 @@ void handle_resize(int sig) {
         }
         wresize(fs->text_win, LINES - 2, COLS);
         mvwin(fs->text_win, 1, 0);
+
+        if (fs->line_capacity != new_capacity) {
+            fs->line_capacity = new_capacity;
+            for (int j = 0; j < fs->max_lines; ++j) {
+                char *tmp = realloc(fs->text_buffer[j], fs->line_capacity);
+                if (!tmp)
+                    continue;
+                fs->text_buffer[j] = tmp;
+                fs->text_buffer[j][fs->line_capacity - 1] = '\0';
+            }
+        }
     }
 
     /* Use the resized window of the active file */

--- a/src/input.c
+++ b/src/input.c
@@ -322,12 +322,13 @@ void handle_tab_key(FileState *fs) {
     const int TAB_SIZE = 4;
     int inserted = 0;
 
-    if (fs->cursor_x >= COLS - 6)
+    /* Prevent inserting beyond the allocated line capacity */
+    if (fs->cursor_x >= fs->line_capacity - 1)
         return;
 
     char *old_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
 
-    while (inserted < TAB_SIZE && fs->cursor_x < COLS - 6) {
+    while (inserted < TAB_SIZE && fs->cursor_x < fs->line_capacity - 1) {
         int len = strlen(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
 
         if (fs->cursor_x <= len) {
@@ -374,7 +375,8 @@ void handle_default_key(FileState *fs, int ch) {
         handle_tab_key(fs);
         return;
     }
-    if (fs->cursor_x < COLS - 6) {
+    /* Limit insertion to available line capacity */
+    if (fs->cursor_x < fs->line_capacity - 1) {
         int len = strlen(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
         char *old_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
 


### PR DESCRIPTION
## Summary
- prevent tab and char insertion past the buffer width
- keep selection cursor inside the line buffer
- update all open files' line capacity when the terminal is resized

## Testing
- `make`