### PR TITLE
Fix file window allocation and error handling

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -132,6 +132,9 @@ void load_file(FileState *fs_unused, const char *filename) {
 
 void new_file(FileState *fs_unused) {
     (void)fs_unused;
+    FileState *previous_active = active_file;
+    int previous_index = file_manager.active_index;
+
     FileState *fs = initialize_file_state("", DEFAULT_BUFFER_LINES, COLS - 3);
     if (!fs) {
         mvprintw(LINES - 2, 2, "Memory allocation failed!");
@@ -153,6 +156,9 @@ void new_file(FileState *fs_unused) {
         mvprintw(LINES - 2, 2, "                            ");
         refresh();
         free_file_state(fs, fs->max_lines);
+        file_manager.active_index = previous_index;
+        active_file = previous_active;
+        text_win = previous_active ? previous_active->text_win : NULL;
         return;
     }
 
@@ -163,6 +169,9 @@ void new_file(FileState *fs_unused) {
         mvprintw(LINES - 2, 2, "                            ");
         refresh();
         fm_close(&file_manager, idx);
+        file_manager.active_index = previous_index;
+        active_file = previous_active;
+        text_win = previous_active ? previous_active->text_win : NULL;
         return;
     }
 

--- a/src/files.c
+++ b/src/files.c
@@ -50,7 +50,11 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->last_comment_state = false;
     file_state->text_win = newwin(LINES - 2, COLS, 1, 0); // Create a new window for the file
     if (!file_state->text_win) {
-        free_file_state(file_state, max_lines);
+        for (int j = 0; j < max_lines; j++) {
+            free(file_state->text_buffer[j]);
+        }
+        free(file_state->text_buffer);
+        free(file_state);
         return NULL;
     }
 


### PR DESCRIPTION
## Summary
- avoid invalid `delwin` call if `newwin` fails during file state initialization
- preserve active file if new file creation fails

## Testing
- `make`