### PR TITLE
Improve allocation failure handling

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -101,7 +101,8 @@ void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
             (*cursor_y)++;
             fs->cursor_x = *cursor_x = 1;
             fs->cursor_y = *cursor_y;
-            ensure_line_capacity(fs, fs->line_count + 1);
+            if (ensure_line_capacity(fs, fs->line_count + 1) < 0)
+                allocation_failed("ensure_line_capacity failed");
             insert_new_line(fs);
         }
     }

--- a/src/editor.h
+++ b/src/editor.h
@@ -56,6 +56,7 @@ void cleanup_on_exit(struct FileManager *fm);
 void disable_ctrl_c_z(void);
 void next_file(struct FileState *fs, int *cx, int *cy);
 void prev_file(struct FileState *fs, int *cx, int *cy);
+void allocation_failed(const char *msg);
 
 
 #endif // EDITOR_H

--- a/src/files.h
+++ b/src/files.h
@@ -30,6 +30,6 @@ typedef struct FileState {
 FileState *initialize_file_state(const char *filename, int max_lines, int max_cols);
 void free_file_state(FileState *file_state, int max_lines);
 int load_file_into_buffer(FileState *file_state);
-void ensure_line_capacity(FileState *fs, int min_needed);
+int ensure_line_capacity(FileState *fs, int min_needed);
 
 #endif

--- a/src/input.c
+++ b/src/input.c
@@ -157,7 +157,8 @@ void handle_key_delete(FileState *fs) {
  * @param fs->start_line Pointer to the starting line of the visible text area.
  */
 void handle_key_enter(FileState *fs) {
-    ensure_line_capacity(fs, fs->line_count + 1);
+    if (ensure_line_capacity(fs, fs->line_count + 1) < 0)
+        allocation_failed("ensure_line_capacity failed");
     for (int i = fs->line_count; i > fs->cursor_y + fs->start_line; --i) {
         strcpy(fs->text_buffer[i], fs->text_buffer[i - 1]);
     }

--- a/src/undo.c
+++ b/src/undo.c
@@ -36,7 +36,8 @@ void undo(FileState *fs) {
     Change change = pop(&fs->undo_stack);
 
     if (change.old_text && !change.new_text) { /* Deletion */
-        ensure_line_capacity(fs, fs->line_count + 1);
+        if (ensure_line_capacity(fs, fs->line_count + 1) < 0)
+            allocation_failed("ensure_line_capacity failed");
         for (int i = fs->line_count; i > change.line; --i) {
             strncpy(fs->text_buffer[i], fs->text_buffer[i - 1], fs->line_capacity - 1);
             fs->text_buffer[i][fs->line_capacity - 1] = '\0';
@@ -90,7 +91,8 @@ void redo(FileState *fs) {
         fs->line_count--;
         free(change.old_text);
     } else if (!change.old_text && change.new_text) { /* Insertion */
-        ensure_line_capacity(fs, fs->line_count + 1);
+        if (ensure_line_capacity(fs, fs->line_count + 1) < 0)
+            allocation_failed("ensure_line_capacity failed");
         for (int i = fs->line_count; i > change.line; --i) {
             strncpy(fs->text_buffer[i], fs->text_buffer[i - 1], fs->line_capacity - 1);
             fs->text_buffer[i][fs->line_capacity - 1] = '\0';

--- a/tests/test_paste.c
+++ b/tests/test_paste.c
@@ -9,10 +9,12 @@
 WINDOW *text_win = NULL;
 FileState *active_file = NULL;
 void draw_text_buffer(FileState *fs, WINDOW *win) { (void)fs; (void)win; }
+void allocation_failed(const char *msg) { (void)msg; abort(); }
 
 /* Stub of insert_new_line without ncurses dependencies */
 void insert_new_line(FileState *fs) {
-    ensure_line_capacity(fs, fs->line_count + 1);
+    if (ensure_line_capacity(fs, fs->line_count + 1) < 0)
+        abort();
     for (int i = fs->line_count; i > fs->cursor_y + fs->start_line - 1; --i) {
         strcpy(fs->text_buffer[i], fs->text_buffer[i - 1]);
     }


### PR DESCRIPTION
## Summary
- add `allocation_failed` helper to exit on memory failures
- make `ensure_line_capacity` return error code and free partial allocations
- propagate allocation errors throughout editor code and tests
- update `test_paste` for new API

## Testing
- `make`
- `./tests/run_tests.sh`
