### PR TITLE
Refactor buffer init path

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -75,7 +75,6 @@ void load_file(FileState *fs_unused, const char *filename) {
     strncpy(fs->filename, filename, sizeof(fs->filename) - 1);
     fs->filename[sizeof(fs->filename) - 1] = '\0';
 
-    initialize_buffer();
 
     FILE *fp = fopen(filename, "r");
     if (fp) {
@@ -161,8 +160,6 @@ void new_file(FileState *fs_unused) {
 
     active_file = fm_current(&file_manager);
     text_win = fs->text_win;
-
-    initialize_buffer();
 
     keypad(text_win, TRUE);
     meta(text_win, TRUE);

--- a/src/files.c
+++ b/src/files.c
@@ -3,6 +3,7 @@
 #include "files.h"
 #include "editor.h"
 #include "syntax.h"
+#include "clipboard.h"
 
 // Function to initialize a new FileState for a given filename
 FileState *initialize_file_state(const char *filename, int max_lines, int max_cols) {
@@ -32,7 +33,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
         }
     }
 
-    file_state->line_count = 0;
+    file_state->line_count = 1; // Start with a single empty line ready for editing
     file_state->max_lines = max_lines;
     file_state->line_capacity = max_cols;
     file_state->start_line = 0;
@@ -43,7 +44,16 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->selection_mode = false;
     file_state->sel_start_x = file_state->sel_start_y = 0;
     file_state->sel_end_x = file_state->sel_end_y = 0;
-    file_state->clipboard = NULL; // Initialize clipboard if needed
+    file_state->clipboard = malloc(CLIPBOARD_SIZE);
+    if (!file_state->clipboard) {
+        for (int j = 0; j < max_lines; j++) {
+            free(file_state->text_buffer[j]);
+        }
+        free(file_state->text_buffer);
+        free(file_state);
+        return NULL;
+    }
+    file_state->clipboard[0] = '\0';
     file_state->syntax_mode = NO_SYNTAX; // Set to NO_SYNTAX initially
     file_state->in_multiline_comment = false;
     file_state->last_scanned_line = 0;
@@ -54,6 +64,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
             free(file_state->text_buffer[j]);
         }
         free(file_state->text_buffer);
+        free(file_state->clipboard);
         free(file_state);
         return NULL;
     }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,10 +3,18 @@ set -e
 # Ensure a clean build directory
 rm -rf obj_test
 mkdir obj_test
-# compile minimal sources needed for the test
-for src in src/clipboard.c src/files.c; do
-    gcc -Wall -Wextra -std=c99 -g -Isrc -c "$src" -o obj_test/$(basename "$src" .c).o
-done
-# compile test file with stubbed insert_new_line
-gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_paste.c obj_test/*.o -lncurses -o test_paste
+
+# compile sources for paste test
+gcc -Wall -Wextra -std=c99 -g -Isrc -c src/clipboard.c -o obj_test/clipboard.o
+gcc -Wall -Wextra -std=c99 -g -Isrc -c src/files.c -o obj_test/files.o
+
+# build and run paste test (provides its own stubs)
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_paste.c obj_test/clipboard.o obj_test/files.o -lncurses -o test_paste
 ./test_paste
+
+# compile additional source for file state test
+gcc -Wall -Wextra -std=c99 -g -Isrc -c src/file_manager.c -o obj_test/file_manager.o
+
+# build and run file state initialization/switching test
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_file_state
+./test_file_state

--- a/tests/test_file_state.c
+++ b/tests/test_file_state.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <string.h>
+#include <ncurses.h>
+#include "files.h"
+#include "file_manager.h"
+
+/* stub minimal window functions to avoid full ncurses setup */
+WINDOW *newwin(int nlines, int ncols, int y, int x) {
+    (void)nlines; (void)ncols; (void)y; (void)x;
+    return (WINDOW *)1;
+}
+int delwin(WINDOW *w) { (void)w; return 0; }
+
+int main(void) {
+    FileManager fm;
+    fm_init(&fm);
+
+    FileState *fs1 = initialize_file_state("a.txt", 5, 20);
+    assert(fs1 && fs1->line_count == 1);
+    strcpy(fs1->text_buffer[0], "one");
+    int idx1 = fm_add(&fm, fs1);
+    assert(idx1 >= 0);
+
+    FileState *fs2 = initialize_file_state("b.txt", 5, 20);
+    assert(fs2 && fs2->line_count == 1);
+    strcpy(fs2->text_buffer[0], "two");
+    int idx2 = fm_add(&fm, fs2);
+    assert(idx2 >= 0);
+
+    char *p1 = fs1->text_buffer[0];
+    char *p2 = fs2->text_buffer[0];
+
+    fm_switch(&fm, idx2);
+    fm_switch(&fm, idx1);
+
+    assert(fs1->text_buffer[0] == p1);
+    assert(strcmp(fs1->text_buffer[0], "one") == 0);
+    fm_switch(&fm, idx2);
+    assert(fs2->text_buffer[0] == p2);
+    assert(strcmp(fs2->text_buffer[0], "two") == 0);
+
+    free_file_state(fs1, fs1->max_lines);
+    free_file_state(fs2, fs2->max_lines);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- eliminate extra buffer initialization when opening or creating files
- allocate clipboard during `initialize_file_state`
- keep `initialize_buffer` for resetting an existing file
- add regression test for file manager switching
- run both paste and file-state tests

## Testing
- `sh -x tests/run_tests.sh | tail -n 20`