### PR TITLE
Add bool header to files.h

### DIFF
--- a/src/files.h
+++ b/src/files.h
@@ -2,6 +2,7 @@
 #define FILES_H
 
 #include <ncurses.h>
+#include <stdbool.h>
 #include "editor.h"
 
 typedef struct FileState {


### PR DESCRIPTION
## Summary
- include `stdbool.h` in `src/files.h` so the `bool` type is available without relying on indirect includes

## Testing
- `make`
