### PR TITLE
Remove fixed color setup

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -493,16 +493,6 @@ void initialize() {
     timeout(10); 
 
 
-    // Set up color pairs for syntax highlighting
-    if (has_colors() && can_change_color()) {
-        start_color();
-        init_pair(1, COLOR_WHITE, COLOR_BLUE);     // Background color
-        init_pair(2, COLOR_CYAN, COLOR_BLACK);     // Keywords
-        init_pair(3, COLOR_GREEN, COLOR_BLACK);    // Comments
-        init_pair(4, COLOR_YELLOW, COLOR_BLACK);   // Strings
-        init_pair(5, COLOR_MAGENTA, COLOR_BLACK);  // Types
-        init_pair(6, COLOR_BLUE, COLOR_BLACK);     // Symbols (braces, parentheses)
-    }
 
     // Set the background color of the screen
     bkgd(COLOR_PAIR(1));


### PR DESCRIPTION
## Summary
- drop hard-coded color pair initialization in `initialize`
- rely on `config_load(&app_config)` for color setup

## Testing
- `bash -x tests/run_tests.sh`
- `make`
