### PR TITLE
Implement apply_colors and set window backgrounds

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -462,6 +462,17 @@ void disable_ctrl_c_z() {
     signal(SIGTSTP, SIG_IGN);
 }
 
+void apply_colors() {
+    bkgd(enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
+    for (int i = 0; i < file_manager.count; ++i) {
+        FileState *fs = file_manager.files[i];
+        if (fs && fs->text_win) {
+            wbkgd(fs->text_win,
+                  enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
+        }
+    }
+}
+
 /**
  * Initializes the editor by setting up the screen,
  * reading the configuration file, enabling color if specified, and setting up
@@ -473,6 +484,7 @@ void initialize() {
 
     // Load the configuration file
     config_load(&app_config);
+    apply_colors();
 
     // Enable color if specified
     if (enable_color) {

--- a/src/editor.h
+++ b/src/editor.h
@@ -54,6 +54,7 @@ void update_status_bar(struct FileState *fs);
 void handle_resize(int sig);
 void cleanup_on_exit(struct FileManager *fm);
 void disable_ctrl_c_z(void);
+void apply_colors(void);
 void next_file(struct FileState *fs, int *cx, int *cy);
 void prev_file(struct FileState *fs, int *cx, int *cy);
 void allocation_failed(const char *msg);

--- a/src/files.c
+++ b/src/files.c
@@ -68,6 +68,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
         free(file_state);
         return NULL;
     }
+    wbkgd(file_state->text_win, COLOR_PAIR(SYNTAX_BG));
 
     return file_state;
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -294,6 +294,7 @@ void menuSettings() {
     if (show_settings_dialog(&app_config)) {
         config_save(&app_config);
         config_load(&app_config);
+        apply_colors();
         redraw();
         drawBar();
     }


### PR DESCRIPTION
## Summary
- colorize window backgrounds after file state creation
- add apply_colors helper in editor
- refresh colors after config loading and in settings menu

## Testing
- `make test`