### PR TITLE
Fix malloc check in undo stack push

### DIFF
--- a/src/undo.c
+++ b/src/undo.c
@@ -8,6 +8,10 @@ char *strdup(const char *s);  // Explicitly declare strdup
 
 void push(Node **stack, Change change) {
     Node *new_node = (Node *)malloc(sizeof(Node));
+    if (new_node == NULL) {
+        allocation_failed("push malloc failed");
+        return;
+    }
     new_node->change = change;
     new_node->next = *stack;
     *stack = new_node;


### PR DESCRIPTION
## Summary
- check result of `malloc` in `push`
- call `allocation_failed` if allocation fails before accessing memory

## Testing
- `make test`