### PR TITLE
Add strdup failure checks

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -370,8 +370,12 @@ void delete_current_line(FileState *fs) {
     int line_to_delete = fs->cursor_y - 1 + fs->start_line;
 
     // Push the current state to the undo stack
-    push(&fs->undo_stack,
-         (Change){line_to_delete, strdup(fs->text_buffer[line_to_delete]), NULL});
+    char *old_text = strdup(fs->text_buffer[line_to_delete]);
+    if (!old_text) {
+        allocation_failed("strdup failed");
+        return;
+    }
+    push(&fs->undo_stack, (Change){line_to_delete, old_text, NULL});
 
     // Shift lines up to delete the current line
     for (int i = line_to_delete; i < fs->line_count - 1; ++i) {
@@ -424,6 +428,10 @@ void insert_new_line(FileState *fs) {
     change.line = fs->cursor_y + fs->start_line - 1;
     change.old_text = NULL;
     change.new_text = strdup("");
+    if (!change.new_text) {
+        allocation_failed("strdup failed");
+        return;
+    }
 
     push(&fs->undo_stack, change);
     mark_comment_state_dirty(fs);

--- a/src/input.c
+++ b/src/input.c
@@ -328,6 +328,10 @@ void handle_tab_key(FileState *fs) {
         return;
 
     char *old_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
+    if (!old_text) {
+        allocation_failed("strdup failed");
+        return;
+    }
 
     while (inserted < TAB_SIZE && fs->cursor_x < fs->line_capacity - 1) {
         int len = strlen(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
@@ -346,6 +350,11 @@ void handle_tab_key(FileState *fs) {
 
     if (inserted > 0) {
         char *new_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
+        if (!new_text) {
+            free(old_text);
+            allocation_failed("strdup failed");
+            return;
+        }
         Change change = { fs->cursor_y - 1 + fs->start_line, old_text, new_text };
         push(&fs->undo_stack, change);
         mark_comment_state_dirty(fs);
@@ -380,6 +389,10 @@ void handle_default_key(FileState *fs, int ch) {
     if (fs->cursor_x < fs->line_capacity - 1) {
         int len = strlen(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
         char *old_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
+        if (!old_text) {
+            allocation_failed("strdup failed");
+            return;
+        }
 
         // Shift the characters to the right of the cursor to make space for the new character
         if (fs->cursor_x <= len) {
@@ -394,6 +407,11 @@ void handle_default_key(FileState *fs, int ch) {
         fs->cursor_x++;
 
         char *new_text = strdup(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]);
+        if (!new_text) {
+            free(old_text);
+            allocation_failed("strdup failed");
+            return;
+        }
         Change change = { fs->cursor_y - 1 + fs->start_line, old_text, new_text };
         push(&fs->undo_stack, change);
         mark_comment_state_dirty(fs);


### PR DESCRIPTION
## Summary
- guard `strdup` calls in `handle_tab_key` and `handle_default_key`
- guard `strdup` calls before pushing to the undo stack in `editor.c`

## Testing
- `sh -x tests/run_tests.sh`