### PR TITLE
Refactor editor into modular files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ OBJ_DIR = ./obj
 BIN_DIR = ./bin
 DOC_DIR = ./docs
 
-SRCS = $(wildcard $(SRC_DIR)/*.c)
+# Include all source files and new editor modules
+SRCS = $(wildcard $(SRC_DIR)/*.c) \
+       $(SRC_DIR)/editor_init.c $(SRC_DIR)/editor_actions.c
+SRCS := $(sort $(SRCS))
 OBJS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
 DEPS = $(wildcard $(SRC_DIR)/*.h)
 MANPAGE = $(DOC_DIR)/vento.1

--- a/src/editor.h
+++ b/src/editor.h
@@ -36,10 +36,13 @@ typedef struct {
     KeyHandler handler;
 } KeyMapping;
 
+void initialize_key_mappings(void);
+
 extern WINDOW *text_win;
 extern struct FileState *active_file;
 extern struct FileManager file_manager;
 extern char search_text[256];
+extern int exiting;
 void handle_regular_mode(struct FileState *fs, int ch);
 void initialize(void);
 void draw_text_buffer(struct FileState *fs, WINDOW *win);
@@ -57,6 +60,8 @@ void disable_ctrl_c_z(void);
 void apply_colors(void);
 void next_file(struct FileState *fs, int *cx, int *cy);
 void prev_file(struct FileState *fs, int *cx, int *cy);
+void handle_redo_wrapper(struct FileState *fs, int *cx, int *cy);
+void handle_undo_wrapper(struct FileState *fs, int *cx, int *cy);
 void allocation_failed(const char *msg);
 
 

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -1,0 +1,77 @@
+#include <ncurses.h>
+#include <signal.h>
+#include "editor.h"
+#include "config.h"
+#include "ui.h"
+#include "menu.h"
+#include "file_manager.h"
+#include "undo.h"
+#include "files.h"
+#include "syntax.h"
+
+void disable_ctrl_c_z() {
+    signal(SIGINT, SIG_IGN);
+    signal(SIGTSTP, SIG_IGN);
+}
+
+void apply_colors() {
+    bkgd(enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
+    for (int i = 0; i < file_manager.count; ++i) {
+        FileState *fs = file_manager.files[i];
+        if (fs && fs->text_win) {
+            wbkgd(fs->text_win,
+                  enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
+        }
+    }
+}
+
+void initialize() {
+    initscr();
+    config_load(&app_config);
+    apply_colors();
+    if (enable_color) {
+        start_color();
+    }
+    cbreak();
+    noecho();
+    keypad(stdscr, TRUE);
+    meta(stdscr, TRUE);
+    if (enable_mouse)
+        mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
+    timeout(10);
+    bkgd(COLOR_PAIR(1));
+    refresh();
+    signal(SIGWINCH, handle_resize);
+    disable_ctrl_c_z();
+    define_key("\033[1;5D", KEY_CTRL_LEFT);
+    define_key("\033[1;5C", KEY_CTRL_RIGHT);
+    define_key("\033[5;5~", KEY_CTRL_PGUP);
+    define_key("\033[6;5~", KEY_CTRL_PGDN);
+    define_key("\033[1;5A", KEY_CTRL_UP);
+    define_key("\033[1;5B", KEY_CTRL_DOWN);
+    define_key("\024", KEY_CTRL_T);
+    initialize_key_mappings();
+    initializeMenus();
+    update_status_bar(active_file);
+}
+
+void cleanup_on_exit(FileManager *fm) {
+    if (!fm || !fm->files) {
+        freeMenus();
+        return;
+    }
+    for (int i = 0; i < fm->count; ++i) {
+        FileState *fs = fm->files[i];
+        if (!fs) continue;
+        free_stack(fs->undo_stack);
+        fs->undo_stack = NULL;
+        free_stack(fs->redo_stack);
+        fs->redo_stack = NULL;
+        free_file_state(fs, fs->max_lines);
+    }
+    freeMenus();
+}
+
+void close_editor() {
+    exiting = 1;
+}


### PR DESCRIPTION
## Summary
- split initialization and shutdown code into `editor_init.c`
- move editing actions and status bar helpers into `editor_actions.c`
- expose new helpers via `editor.h`
- update Makefile to explicitly list new source modules

## Testing
- `make test`
- `make` *(fails: conflicting types for `select_color` in `ui_settings.c`)*