### PR TITLE
Fix compile warning in file dialog

### DIFF
--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <ncurses.h>
 #include <stdio.h>
 


### PR DESCRIPTION
## Summary
- include `<ctype.h>` in `ui_file_dialog.c` so `isprint` prototype is available

## Testing
- `make` *(fails: conflicting types for `select_color`)*