### PR TITLE
Enable mouse support in settings selection dialogs

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -388,6 +388,38 @@ const char *select_color(const char *current, WINDOW *parent) {
                 }
             }
             return colors[highlight];
+        } else if (ch == KEY_MOUSE && enable_mouse) {
+            MEVENT ev;
+            if (getmouse(&ev) == OK &&
+                (ev.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED |
+                               BUTTON1_RELEASED))) {
+                int wy, wx;
+                getbegyx(win, wy, wx);
+                int row = ev.y - wy - 1;
+                int col = ev.x - wx - 1;
+                int max_display = win_height - 2;
+                if (row >= 0 && row < max_display &&
+                    col >= 0 && col < win_width - 2) {
+                    int idx = start + row;
+                    if (idx >= 0 && idx < count)
+                        highlight = idx;
+
+                    if (ev.bstate & (BUTTON1_RELEASED | BUTTON1_CLICKED)) {
+                        if (own) {
+                            werase(win);
+                            wrefresh(win);
+                            delwin(win);
+                            if (parent) {
+                                touchwin(parent);
+                                wrefresh(parent);
+                            } else {
+                                wrefresh(stdscr);
+                            }
+                        }
+                        return colors[highlight];
+                    }
+                }
+            }
         } else if (ch == 27) {
             if (own) {
                 werase(win);
@@ -467,6 +499,36 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
                 }
             }
             return highlight == 1 ? 1 : 0;
+        } else if (ch == KEY_MOUSE && enable_mouse) {
+            MEVENT ev;
+            if (getmouse(&ev) == OK &&
+                (ev.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED |
+                               BUTTON1_RELEASED))) {
+                int wy, wx;
+                getbegyx(win, wy, wx);
+                int option_start = prompt ? 2 : 1;
+                int row_click = ev.y - wy - option_start;
+                int col = ev.x - wx - 1;
+                if (row_click >= 0 && row_click < 2 &&
+                    col >= 0 && col < win_width - 2) {
+                    highlight = row_click;
+
+                    if (ev.bstate & (BUTTON1_RELEASED | BUTTON1_CLICKED)) {
+                        if (own) {
+                            werase(win);
+                            wrefresh(win);
+                            delwin(win);
+                            if (parent) {
+                                touchwin(parent);
+                                wrefresh(parent);
+                            } else {
+                                wrefresh(stdscr);
+                            }
+                        }
+                        return highlight == 1 ? 1 : 0;
+                    }
+                }
+            }
         } else if (ch == 27) {
             if (own) {
                 werase(win);


### PR DESCRIPTION
## Summary
- allow `select_color` and `select_bool` to respond to mouse events

## Testing
- `sh -x tests/run_tests.sh`