### PR TITLE
Update mouse handling in settings dialog

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -239,6 +239,10 @@ void menuSettings() {
     if (show_settings_dialog(&app_config)) {
         config_save(&app_config);
         config_load(&app_config);
+        if (enable_mouse)
+            mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
+        else
+            mousemask(0, NULL);
         apply_colors();
         redraw();
         drawBar();

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -147,6 +147,11 @@ int show_settings_dialog(AppConfig *cfg) {
             case FIELD_MOUSE:
                 cfg->enable_mouse =
                     select_bool("Enable mouse", cfg->enable_mouse, win);
+                enable_mouse = cfg->enable_mouse;
+                if (enable_mouse)
+                    mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
+                else
+                    mousemask(0, NULL);
                 break;
             case FIELD_BACKGROUND: {
                 const char *sel = select_color(cfg->background_color, win);
@@ -225,6 +230,11 @@ int show_settings_dialog(AppConfig *cfg) {
                         case FIELD_MOUSE:
                             cfg->enable_mouse = select_bool(
                                 "Enable mouse", cfg->enable_mouse, win);
+                            enable_mouse = cfg->enable_mouse;
+                            if (enable_mouse)
+                                mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
+                            else
+                                mousemask(0, NULL);
                             break;
                         case FIELD_BACKGROUND: {
                             const char *sel =


### PR DESCRIPTION
## Summary
- update `menuSettings()` to reconfigure mouse events after reloading config
- toggle `enable_mouse` immediately when changed in settings

## Testing
- `tests/run_tests.sh && echo tests_ran`
- `./test_paste && ./test_file_state && echo ok`
