### PR TITLE
Remove redundant delwin call

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -382,7 +382,6 @@ void run_editor() {
         wrefresh(text_win);
     }
 
-    delwin(text_win);
 }
 
 


### PR DESCRIPTION
## Summary
- fix stack dump on exit by not deleting `text_win` before curses cleanup

## Testing
- `make`
- `make test`
