### PR TITLE
Fix warning dialog cleanup

### DIFF
--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -106,6 +106,11 @@ void show_warning_dialog() {
     wrefresh(warning_win);
     wgetch(warning_win);
 
+    werase(warning_win);
+    wrefresh(warning_win);
+    delwin(warning_win);
+    wrefresh(stdscr);
+
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);


### PR DESCRIPTION
## Summary
- properly erase and delete the warning dialog window
- refresh the standard screen after closing the dialog

## Testing
- `tests/run_tests.sh`