### PR TITLE
Fix duplicate color init

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -29,9 +29,6 @@ void initialize() {
     initscr();
     config_load(&app_config);
     apply_colors();
-    if (enable_color) {
-        start_color();
-    }
     cbreak();
     noecho();
     keypad(stdscr, TRUE);


### PR DESCRIPTION
## Summary
- avoid calling `start_color()` twice during startup

## Testing
- `bash tests/run_tests.sh`