### PR TITLE
Remove redundant strdup prototypes

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -32,7 +32,6 @@ WINDOW *text_win;  // Pointer to the ncurses window for displaying the text
 
 // Undo and redo stacks are stored per file in FileState
 
-char *strdup(const char *s);  // Explicitly declare strdup
 int exiting = 0;
 
 char search_text[256] = "";

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -6,7 +6,6 @@
 #include "syntax.h"
 #include "files.h"
 #include "file_manager.h"
-char *strdup(const char *s);
 #include "undo.h"
 
 void delete_current_line(FileState *fs) {

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -9,8 +9,6 @@
 #include "clipboard.h"
 #include "syntax.h"
 
-char *strdup(const char *s);  // Explicitly declare strdup
-
 void handle_ctrl_backtick() {
     // Do nothing on CTRL+Backtick to avoid segmentation fault
 }

--- a/src/search.c
+++ b/src/search.c
@@ -9,8 +9,6 @@
 #include "undo.h"
 #include "syntax.h"
 
-char *strdup(const char *s);
-
 extern char search_text[256];
 
 void find_next_occurrence(FileState *fs, const char *word) {

--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -5,9 +5,6 @@
 #include <string.h>
 #include <stdio.h>
 
-// Ensure the correct prototype for strdup
-char *strdup(const char *s);
-
 WINDOW *create_centered_window(int height, int width, WINDOW *parent) {
     int win_y, win_x;
 

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -9,9 +9,6 @@
 #include <stdio.h>
 #include "config.h"
 
-// Ensure proper prototype for strdup
-char *strdup(const char *s);
-
 void get_dir_contents(const char *dir_path, char ***choices, int *n_choices) {
     DIR *dir;
     struct dirent *entry;

--- a/src/undo.c
+++ b/src/undo.c
@@ -4,7 +4,6 @@
 #include "editor.h"
 #include "undo.h"
 #include "files.h"
-char *strdup(const char *s);  // Explicitly declare strdup
 
 void push(Node **stack, Change change) {
     Node *new_node = (Node *)malloc(sizeof(Node));


### PR DESCRIPTION
## Summary
- clean up explicit `strdup` declarations from multiple source files
- ensure that each file still includes `<string.h>` so the standard prototype is available

## Testing
- `make test`
- `sh -x tests/run_tests.sh`