### PR TITLE
Fix window resize updates and add test

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -536,6 +536,7 @@ void handle_resize(int sig) {
     (void)sig; // Cast to void to suppress unused parameter warning
 
     endwin(); // End the curses mode
+    resizeterm(0, 0); // update ncurses internal size
     refresh(); // Refresh the screen
     clear(); // Clear the screen
 
@@ -562,11 +563,23 @@ void handle_resize(int sig) {
         }
     }
 
+    drawBar();
+
     /* Use the resized window of the active file */
     text_win = active_file->text_win;
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
+    if (active_file->cursor_x >= COLS - 1)
+        active_file->cursor_x = COLS - 2;
+    if (active_file->cursor_x < 1)
+        active_file->cursor_x = 1;
+    if (active_file->cursor_y >= LINES - BOTTOM_MARGIN)
+        active_file->cursor_y = LINES - BOTTOM_MARGIN - 1;
+    if (active_file->cursor_y < 1)
+        active_file->cursor_y = 1;
+
+    wmove(text_win, active_file->cursor_y, active_file->cursor_x);
     wrefresh(text_win);
 
     update_status_bar(active_file);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,3 +18,7 @@ gcc -Wall -Wextra -std=c99 -g -Isrc -c src/file_manager.c -o obj_test/file_manag
 # build and run file state initialization/switching test
 gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_file_state
 ./test_file_state
+
+# build and run resize handling test (provides many stubs)
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_resize
+./test_resize

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -1,0 +1,128 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ncurses.h>
+#undef refresh
+#undef clear
+#undef box
+#include "files.h"
+#include "file_manager.h"
+#include "editor.h"
+#include "menu.h"
+
+/* stub ncurses global vars */
+int COLS = 80;
+int LINES = 24;
+
+/* simple WINDOW implementation */
+typedef struct {
+    int h, w, y, x;
+} SIMPLE_WIN;
+
+WINDOW *newwin(int nlines, int ncols, int y, int x) {
+    SIMPLE_WIN *w = calloc(1, sizeof(SIMPLE_WIN));
+    w->h = nlines; w->w = ncols; w->y = y; w->x = x;
+    return (WINDOW*)w;
+}
+int delwin(WINDOW *w){free(w);return 0;}
+int wresize(WINDOW *w, int h, int c){((SIMPLE_WIN*)w)->h=h; ((SIMPLE_WIN*)w)->w=c; return 0;}
+int mvwin(WINDOW *w, int y, int x){((SIMPLE_WIN*)w)->y=y; ((SIMPLE_WIN*)w)->x=x; return 0;}
+int werase(WINDOW *w){(void)w; return 0;}
+int box(WINDOW *w, chtype a, chtype b){(void)w;(void)a;(void)b;return 0;}
+int wrefresh(WINDOW *w){(void)w; return 0;}
+int wmove(WINDOW *w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int endwin(void){return 0;}
+int refresh(void){return 0;}
+int clear(void){return 0;}
+int resizeterm(int r,int c){(void)r;(void)c;return 0;}
+
+/* stubs for editor dependencies */
+void update_status_bar(FileState *fs){(void)fs;}
+static int drawBar_called = 0;
+void drawBar(void){drawBar_called=1;}
+
+/* stubs for unused functions referenced in editor.o */
+void handle_key_up(FileState*fs){(void)fs;}
+void handle_key_down(FileState*fs){(void)fs;}
+void handle_key_left(FileState*fs){(void)fs;}
+void handle_key_right(FileState*fs){(void)fs;}
+void handle_key_backspace(FileState*fs){(void)fs;}
+void handle_key_delete(FileState*fs){(void)fs;}
+void handle_key_enter(FileState*fs){(void)fs;}
+void handle_key_page_up(FileState*fs){(void)fs;}
+void handle_key_page_down(FileState*fs){(void)fs;}
+void handle_ctrl_key_left(FileState*fs){(void)fs;}
+void handle_ctrl_key_right(FileState*fs){(void)fs;}
+void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
+void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
+void handle_ctrl_key_up(FileState*fs){(void)fs;}
+void handle_ctrl_key_down(FileState*fs){(void)fs;}
+void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
+void handle_mouse_event(FileState*fs, MEVENT *ev){(void)fs;(void)ev;}
+void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void end_selection_mode(FileState*fs){(void)fs;}
+void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void delete_current_line(FileState*fs){(void)fs;}
+void insert_new_line(FileState*fs){(void)fs;}
+void next_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void prev_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void move_forward_to_next_word(FileState*fs){(void)fs;}
+void move_backward_to_previous_word(FileState*fs){(void)fs;}
+void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
+void apply_syntax_highlighting(FileState*fs, WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
+void show_about(void){}
+void show_help(void){}
+void find(FileState*fs,int new_search){(void)fs;(void)new_search;}
+void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
+void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
+void replace(FileState*fs){(void)fs;}
+void save_file(FileState*fs){(void)fs;}
+void save_file_as(FileState*fs){(void)fs;}
+void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
+void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
+void menuNewFile(void){}
+void menuLoadFile(void){}
+void menuSaveFile(void){}
+void menuSaveAs(void){}
+void menuCloseFile(void){}
+void menuNextFile(void){}
+void menuPrevFile(void){}
+void menuSettings(void){}
+void menuQuitEditor(void){}
+void menuUndo(void){}
+void menuRedo(void){}
+void menuFind(void){}
+void menuReplace(void){}
+void menuAbout(void){}
+void menuHelp(void){}
+void menuTestwindow(void){}
+
+/* minimal global vars */
+int enable_mouse = 0;
+Menu *menus = NULL; int menuCount = 0;
+WINDOW *stdscr = NULL;
+
+/* Include editor.c for handle_resize implementation */
+#include "../src/editor.c"
+
+int main(void){
+    fm_init(&file_manager);
+    FileState *fs = initialize_file_state("x", 2, 10);
+    assert(fs);
+    fm_add(&file_manager, fs);
+    active_file = fs;
+    int new_LINES = 30, new_COLS = 100;
+    LINES = new_LINES; COLS = new_COLS; /* starting values */
+    handle_resize(0);
+    assert(fs->line_capacity == new_COLS - 3);
+    assert(((SIMPLE_WIN*)fs->text_win)->h == new_LINES - 2);
+    assert(((SIMPLE_WIN*)fs->text_win)->w == new_COLS);
+    assert(drawBar_called);
+    free_file_state(fs, fs->max_lines);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- call `resizeterm` inside `handle_resize` so ncurses updates size
- redraw menus after resizing file windows
- clamp cursor coordinates when the terminal shrinks
- move the cursor in the resized window and refresh
- add unit test for resizing logic and hook it into `run_tests.sh`

## Testing
- `./tests/run_tests.sh`
