### PR TITLE
Add POSIX feature macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c99 -g
+CFLAGS = -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L
 
 SRC_DIR = ./src
 OBJ_DIR = ./obj

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,20 +5,20 @@ rm -rf obj_test
 mkdir obj_test
 
 # compile sources for paste test
-gcc -Wall -Wextra -std=c99 -g -Isrc -c src/clipboard.c -o obj_test/clipboard.o
-gcc -Wall -Wextra -std=c99 -g -Isrc -c src/files.c -o obj_test/files.o
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/clipboard.c -o obj_test/clipboard.o
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/files.c -o obj_test/files.o
 
 # build and run paste test (provides its own stubs)
-gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_paste.c obj_test/clipboard.o obj_test/files.o -lncurses -o test_paste
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_paste.c obj_test/clipboard.o obj_test/files.o -lncurses -o test_paste
 ./test_paste
 
 # compile additional source for file state test
-gcc -Wall -Wextra -std=c99 -g -Isrc -c src/file_manager.c -o obj_test/file_manager.o
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/file_manager.c -o obj_test/file_manager.o
 
 # build and run file state initialization/switching test
-gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_file_state
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_file_state
 ./test_file_state
 
 # build and run resize handling test (provides many stubs)
-gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_resize
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_resize
 ./test_resize


### PR DESCRIPTION
## Summary
- add POSIX feature macro to Makefile
- pass the macro to all gcc calls in run_tests.sh

## Testing
- `make clean >/tmp/make_clean_after2.txt && make 2>&1 | tee /tmp/make_after2.log >/tmp/make_output_dummy.txt`
- `grep -n "warning" -n /tmp/make_after2.log`
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6839e21bc7a8832484fe4fac37c7320e