### PR TITLE
Fix menu bar redraw on window resize

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -566,8 +566,6 @@ void handle_resize(int sig) {
         }
     }
 
-    drawBar();
-
     /* Use the resized window of the active file */
     text_win = active_file->text_win;
     werase(text_win);
@@ -586,6 +584,9 @@ void handle_resize(int sig) {
     wrefresh(text_win);
 
     update_status_bar(active_file);
+
+    /* Redraw the menu bar after all windows have been updated */
+    drawBar();
 }
 
 /**


### PR DESCRIPTION
## Summary
- refresh menu bar at end of `handle_resize`

## Testing
- `bash -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6839fdaad3e883248d67e406bc3da6e5