### PR TITLE
Handle terminal resize input

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -348,6 +348,11 @@ void run_editor() {
             break;
         }
 
+        if (ch == KEY_RESIZE) {
+            handle_resize(0);
+            continue;
+        }
+
         //mvprintw(LINES - 1, 0, "Pressed key: %d", ch); // Add this line for debugging
         drawBar();
         update_status_bar(active_file);


### PR DESCRIPTION
## Summary
- handle `KEY_RESIZE` in the main editor loop

## Testing
- `sh tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a0457f7608324a17d9ac6f490a03d