### PR TITLE
Fix resize signal handling

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -38,7 +38,11 @@ void initialize() {
     timeout(10);
     bkgd(COLOR_PAIR(1));
     refresh();
-    signal(SIGWINCH, handle_resize);
+    struct sigaction sa;
+    sa.sa_handler = handle_resize;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    sigaction(SIGWINCH, &sa, NULL);
     disable_ctrl_c_z();
     define_key("\033[1;5D", KEY_CTRL_LEFT);
     define_key("\033[1;5C", KEY_CTRL_RIGHT);


### PR DESCRIPTION
## Summary
- replace `signal` call with `sigaction` in `initialize`
- leave the `<signal.h>` include in place

## Testing
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a053c101c83249b256b3f1b678277