### PR TITLE
Optimize curses refresh

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -356,12 +356,12 @@ void run_editor() {
         //mvprintw(LINES - 1, 0, "Pressed key: %d", ch); // Add this line for debugging
         drawBar();
         update_status_bar(active_file);
-        refresh();
+        doupdate();
         
         if (active_file->selection_mode) {
             handle_selection_mode(active_file, ch, &active_file->cursor_x, &active_file->cursor_y);
         } else if (ch == KEY_CTRL_T) { // CTRL-T
-            refresh();
+            doupdate();
             handleMenuNavigation(menus, menuCount, &currentMenu, &currentItem);
             // Redraw the editor screen after closing the menu
             redraw();
@@ -383,7 +383,8 @@ void run_editor() {
 
         update_status_bar(active_file);
         wmove(text_win, active_file->cursor_y, active_file->cursor_x);  // Restore cursor position
-        wrefresh(text_win);
+        wnoutrefresh(text_win);
+        doupdate();
     }
 
 }
@@ -525,7 +526,7 @@ void redraw() {
     box(text_win, 0, 0); // Redraw the border of the text window
     draw_text_buffer(active_file, text_win); // Redraw the text buffer
     wmove(text_win, active_file->cursor_y, active_file->cursor_x); // Move the cursor to its previous position
-    wrefresh(text_win); // Refresh the text window
+    wnoutrefresh(text_win); // Queue refresh for the text window
 }
 
 /**
@@ -542,7 +543,6 @@ void handle_resize(int sig) {
 
     endwin(); // End the curses mode
     resizeterm(0, 0); // update ncurses internal size
-    refresh(); // Refresh the screen
     clear(); // Clear the screen
 
     int new_capacity = COLS - 3;
@@ -589,10 +589,11 @@ void handle_resize(int sig) {
 
     update_status_bar(active_file);
     wmove(text_win, active_file->cursor_y, active_file->cursor_x);
-    wrefresh(text_win);
+    wnoutrefresh(text_win);
 
     /* Redraw the menu bar after all windows have been updated */
     drawBar();
+    doupdate();
 }
 
 /**

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -131,5 +131,5 @@ void update_status_bar(FileState *fs) {
     int actual_line_number = fs ? (fs->cursor_y + fs->start_line) : 0;
     mvprintw(LINES - 1, 0, "Lines: %d  Current Line: %d  Column: %d", fs ? fs->line_count : 0, actual_line_number, fs ? fs->cursor_x : 0);
     mvprintw(LINES - 1, COLS - 15, "CTRL-H - Help");
-    refresh();
+    wnoutrefresh(stdscr);
 }

--- a/src/menu_draw.c
+++ b/src/menu_draw.c
@@ -9,7 +9,7 @@ void drawMenuBar(Menu *menus, int menuCount) {
     for (int i = 0; i < menuCount; ++i) {
         mvprintw(0, i * 10, "%s", menus[i].label);
     }
-    refresh();
+    wnoutrefresh(stdscr);
 }
 
 /* Convenience wrapper used by various modules */

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -40,6 +40,8 @@ int endwin(void){return 0;}
 int refresh(void){return 0;}
 int clear(void){return 0;}
 int resizeterm(int r,int c){(void)r;(void)c;return 0;}
+int wnoutrefresh(WINDOW *w){(void)w; return 0;}
+int doupdate(void){return 0;}
 
 /* stubs for editor dependencies */
 void update_status_bar(FileState *fs){(void)fs;}

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -36,6 +36,8 @@ int endwin(void){return 0;}
 int refresh(void){return 0;}
 int clear(void){return 0;}
 int resizeterm(int r,int c){(void)r;(void)c;return 0;}
+int wnoutrefresh(WINDOW *w){(void)w; return 0;}
+int doupdate(void){return 0;}
 
 /* stubs for editor dependencies */
 void update_status_bar(FileState *fs){(void)fs;}


### PR DESCRIPTION
## Summary
- queue redraws in drawMenuBar, update_status_bar and redraw using `wnoutrefresh`
- batch updates in run_editor and handle_resize with `doupdate`
- add stubs for `wnoutrefresh` and `doupdate` in tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a05bbc75083249f9b9791bda085b9