### PR TITLE
Hide cursor for menus and dialogs

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -94,6 +94,8 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
     int ch;
     bool inMenu = true;
 
+    curs_set(0);
+
     while (inMenu) {
         if (*currentMenu < 0 || *currentMenu >= menuCount) {
             inMenu = false;
@@ -203,6 +205,7 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
                 break;
         }
     }
+    curs_set(1);
 }
 
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -7,6 +7,7 @@
 #include "ui_common.h"
 
 void create_dialog(const char *message, char *output, int max_input_len) {
+    curs_set(0);
     /* Use existing color pairs configured by the application */
 
     int win_y = LINES / 3;
@@ -68,9 +69,11 @@ void create_dialog(const char *message, char *output, int max_input_len) {
     wrefresh(dialog_win);
     delwin(dialog_win);
     wrefresh(stdscr);
+    curs_set(1);
 }
 
 int show_find_dialog(char *output, int max_input_len, const char *preset) {
+    curs_set(0);
     /* Use configured color pairs for dialog display */
 
     int win_y = LINES / 3;
@@ -83,6 +86,7 @@ int show_find_dialog(char *output, int max_input_len, const char *preset) {
         if (output)
             output[0] = '\0';
         show_message("Unable to create window");
+        curs_set(1);
         return 0;
     }
     keypad(dialog_win, TRUE);
@@ -148,15 +152,20 @@ int show_find_dialog(char *output, int max_input_len, const char *preset) {
     wrefresh(dialog_win);
     delwin(dialog_win);
     wrefresh(stdscr);
+    curs_set(1);
 
     return cancelled ? 0 : 1;
 }
 
 int show_replace_dialog(char *search, int max_search_len,
                         char *replace, int max_replace_len) {
-    if (!show_find_dialog(search, max_search_len, NULL) || search[0] == '\0')
+    curs_set(0);
+    if (!show_find_dialog(search, max_search_len, NULL) || search[0] == '\0') {
+        curs_set(1);
         return 0;
+    }
 
     create_dialog("Replace:", replace, max_replace_len);
+    curs_set(1);
     return 1;
 }

--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -36,6 +36,7 @@ WINDOW *create_popup_window(int height, int width, WINDOW *parent) {
 }
 
 void show_message(const char *msg) {
+    curs_set(0);
     int win_height = 3;
     int win_width = (int)strlen(msg) + 4;
     int win_y = (LINES - win_height) / 2;
@@ -50,9 +51,11 @@ void show_message(const char *msg) {
     wrefresh(win);
     delwin(win);
     wrefresh(stdscr);
+    curs_set(1);
 }
 
 int show_scrollable_window(const char **options, int count, WINDOW *parent) {
+    curs_set(0);
     int highlight = 0;
     int ch;
     int start = 0;
@@ -69,15 +72,19 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         win_height = ph - 4;
         win_width = pw - 4;
         win = create_popup_window(win_height, win_width, parent);
-        if (!win)
+        if (!win) {
+            curs_set(1);
             return -1;
+        }
         own = 1;
     } else {
         win_height = LINES - 4;
         win_width = COLS - 4;
         win = create_popup_window(win_height, win_width, NULL);
-        if (!win)
+        if (!win) {
+            curs_set(1);
             return -1;
+        }
         own = 1;
     }
     keypad(win, TRUE);
@@ -126,6 +133,7 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
                     wrefresh(stdscr);
                 }
             }
+            curs_set(1);
             return highlight;
         } else if (ch == 27) {
             if (own) {
@@ -139,6 +147,7 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
                     wrefresh(stdscr);
                 }
             }
+            curs_set(1);
             return -1;
         } else if (ch == KEY_MOUSE && enable_mouse) {
             MEVENT ev;
@@ -174,6 +183,7 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         }
     }
 
+    curs_set(1);
     return -1;
 }
 

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -62,6 +62,7 @@ void free_dir_contents(char **choices, int n_choices) {
 }
 
 int show_open_file_dialog(char *path, int max_len) {
+    curs_set(0);
     int highlight = 0;
     int ch;
     char cwd[1024];
@@ -72,8 +73,10 @@ int show_open_file_dialog(char *path, int max_len) {
     int win_height = LINES - 4;
     int win_width = COLS - 4;
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
-    if (!win)
-        return 0;
+        if (!win) {
+            curs_set(1);
+            return 0;
+        }
     keypad(win, TRUE);
 
     getcwd(cwd, sizeof(cwd));
@@ -133,6 +136,7 @@ int show_open_file_dialog(char *path, int max_len) {
                 wrefresh(win);
                 delwin(win);
                 wrefresh(stdscr);
+                curs_set(1);
                 return 1;
             }
 
@@ -155,6 +159,7 @@ int show_open_file_dialog(char *path, int max_len) {
                     wrefresh(win);
                     delwin(win);
                     wrefresh(stdscr);
+                    curs_set(1);
                     return 1;
                 }
             }
@@ -212,6 +217,7 @@ int show_open_file_dialog(char *path, int max_len) {
             wrefresh(win);
             delwin(win);
             wrefresh(stdscr);
+            curs_set(1);
             return 0;
         } else if (isprint(ch)) {
             if (input_len < (int)sizeof(input) - 1) {
@@ -227,10 +233,12 @@ int show_open_file_dialog(char *path, int max_len) {
     wrefresh(win);
     delwin(win);
     wrefresh(stdscr);
+    curs_set(1);
     return 0;
 }
 
 int show_save_file_dialog(char *path, int max_len) {
+    curs_set(0);
     int highlight = 0;
     int ch;
     char cwd[1024];
@@ -241,8 +249,10 @@ int show_save_file_dialog(char *path, int max_len) {
     int win_height = LINES - 4;
     int win_width = COLS - 4;
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
-    if (!win)
+    if (!win) {
+        curs_set(1);
         return 0;
+    }
     keypad(win, TRUE);
 
     getcwd(cwd, sizeof(cwd));
@@ -324,6 +334,7 @@ int show_save_file_dialog(char *path, int max_len) {
                     wrefresh(win);
                     delwin(win);
                     wrefresh(stdscr);
+                    curs_set(1);
                     return 1;
                 }
             }
@@ -362,9 +373,10 @@ int show_save_file_dialog(char *path, int max_len) {
                                 free_dir_contents(choices, n_choices);
                                 wclear(win);
                                 wrefresh(win);
-                                delwin(win);
-                                wrefresh(stdscr);
-                                return 1;
+                    delwin(win);
+                    wrefresh(stdscr);
+                    curs_set(1);
+                    return 1;
                             }
                         }
                     }
@@ -381,6 +393,7 @@ int show_save_file_dialog(char *path, int max_len) {
             wrefresh(win);
             delwin(win);
             wrefresh(stdscr);
+            curs_set(1);
             return 0;
         } else if (isprint(ch)) {
             if (input_len < (int)sizeof(input) - 1) {
@@ -396,5 +409,6 @@ int show_save_file_dialog(char *path, int max_len) {
     wrefresh(win);
     delwin(win);
     wrefresh(stdscr);
+    curs_set(1);
     return 0;
 }

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 void show_help() {
+    curs_set(0);
     int win_height = 18;
     int win_width = COLS - 40;
     int win_y = (LINES - win_height) / 2;
@@ -55,9 +56,11 @@ void show_help() {
     wrefresh(help_win);
     delwin(help_win);
     wrefresh(stdscr);
+    curs_set(1);
 }
 
 void show_about() {
+    curs_set(0);
     int win_height = 10;
     int win_width = COLS - 20;
     int win_y = (LINES - win_height) / 2;
@@ -81,9 +84,11 @@ void show_about() {
     wrefresh(about_win);
     delwin(about_win);
     wrefresh(stdscr);
+    curs_set(1);
 }
 
 void show_warning_dialog() {
+    curs_set(0);
     int win_height = 7;
     int win_width = COLS - 20;
     int win_y = (LINES - win_height) / 2;
@@ -117,4 +122,5 @@ void show_warning_dialog() {
     wrefresh(text_win);
     update_status_bar(active_file);
     wrefresh(stdscr);
+    curs_set(1);
 }

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -9,6 +9,7 @@ const char *select_color(const char *current, WINDOW *parent);
 int select_bool(const char *prompt, int current, WINDOW *parent);
 
 int show_settings_dialog(AppConfig *cfg) {
+    curs_set(0);
     AppConfig original = *cfg;
 
     mmask_t oldmask = mousemask(0, NULL);
@@ -80,8 +81,10 @@ int show_settings_dialog(AppConfig *cfg) {
         win_width = 50;
 
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
-    if (!win)
+    if (!win) {
+        curs_set(1);
         return 0;
+    }
     keypad(win, TRUE);
 
     while (!done) {
@@ -314,11 +317,13 @@ int show_settings_dialog(AppConfig *cfg) {
     wrefresh(win);
     delwin(win);
     wrefresh(stdscr);
+    curs_set(1);
 
     return memcmp(&original, cfg, sizeof(AppConfig)) != 0;
 }
 
 const char *select_color(const char *current, WINDOW *parent) {
+    curs_set(0);
     static const char *colors[] = {
         "BLACK", "RED", "GREEN", "YELLOW",
         "BLUE", "MAGENTA", "CYAN", "WHITE"
@@ -345,15 +350,19 @@ const char *select_color(const char *current, WINDOW *parent) {
         win_height = ph - 4;
         win_width = pw - 4;
         win = create_popup_window(win_height, win_width, parent);
-        if (!win)
+        if (!win) {
+            curs_set(1);
             return NULL;
+        }
         own = 1;
     } else {
         win_height = LINES - 4;
         win_width = COLS - 4;
         win = create_popup_window(win_height, win_width, NULL);
-        if (!win)
+        if (!win) {
+            curs_set(1);
             return NULL;
+        }
         own = 1;
     }
     keypad(win, TRUE);
@@ -402,6 +411,7 @@ const char *select_color(const char *current, WINDOW *parent) {
                     wrefresh(stdscr);
                 }
             }
+            curs_set(1);
             return colors[highlight];
         } else if (ch == KEY_MOUSE) {
             MEVENT ev;
@@ -431,6 +441,7 @@ const char *select_color(const char *current, WINDOW *parent) {
                                 wrefresh(stdscr);
                             }
                         }
+                        curs_set(1);
                         return colors[highlight];
                     }
                 }
@@ -447,14 +458,17 @@ const char *select_color(const char *current, WINDOW *parent) {
                     wrefresh(stdscr);
                 }
             }
+            curs_set(1);
             return NULL;
         }
     }
 
+    curs_set(1);
     return NULL;
 }
 
 int select_bool(const char *prompt, int current, WINDOW *parent) {
+    curs_set(0);
     static const char *options[] = {"Disabled", "Enabled"};
     int highlight = current ? 1 : 0;
 
@@ -464,13 +478,17 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
     WINDOW *win;
     if (parent) {
         win = create_popup_window(win_height, win_width, parent);
-        if (!win)
+        if (!win) {
+            curs_set(1);
             return current;
+        }
         own = 1;
     } else {
         win = create_popup_window(win_height, win_width, NULL);
-        if (!win)
+        if (!win) {
+            curs_set(1);
             return current;
+        }
         own = 1;
     }
     keypad(win, TRUE);
@@ -513,6 +531,7 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
                     wrefresh(stdscr);
                 }
             }
+            curs_set(1);
             return highlight == 1 ? 1 : 0;
         } else if (ch == KEY_MOUSE) {
             MEVENT ev;
@@ -540,6 +559,7 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
                                 wrefresh(stdscr);
                             }
                         }
+                        curs_set(1);
                         return highlight == 1 ? 1 : 0;
                     }
                 }
@@ -556,9 +576,11 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
                     wrefresh(stdscr);
                 }
             }
+            curs_set(1);
             return current;
         }
     }
 
+    curs_set(1);
     return current;
 }


### PR DESCRIPTION
## Summary
- hide the cursor when showing menus or dialogs
- restore the cursor when leaving those windows

## Testing
- `make test`
- `./test_paste && echo "paste=$?"; ./test_file_state && echo "state=$?"; ./test_resize && echo "resize=$?"; ./test_resize_trunc && echo "trunc=$?"`

------
https://chatgpt.com/codex/tasks/task_e_683a079cfa308324812466af2b43acbd