### PR TITLE
Prevent identifier buffer overflow

### DIFF
--- a/src/syntax_c.c
+++ b/src/syntax_c.c
@@ -86,7 +86,8 @@ void highlight_c_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
             wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
         } else if (isalpha((unsigned char)line[i]) || line[i] == '_') {
             word_len = 0;
-            while (i < len && (isalnum((unsigned char)line[i]) || line[i] == '_')) {
+            while (i < len && (isalnum((unsigned char)line[i]) || line[i] == '_') &&
+                   word_len < (int)sizeof(word) - 1) {
                 word[word_len++] = line[i++];
             }
             word[word_len] = '\0';

--- a/src/syntax_csharp.c
+++ b/src/syntax_csharp.c
@@ -93,7 +93,8 @@ void highlight_csharp_syntax(FileState *fs, WINDOW *win, const char *line, int y
             wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
         } else if (isalpha((unsigned char)line[i]) || line[i] == '_') {
             word_len = 0;
-            while (i < len && (isalnum((unsigned char)line[i]) || line[i] == '_')) {
+            while (i < len && (isalnum((unsigned char)line[i]) || line[i] == '_') &&
+                   word_len < (int)sizeof(word) - 1) {
                 word[word_len++] = line[i++];
             }
             word[word_len] = '\0';

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -26,3 +26,11 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize.
 # build and run line truncation resize test
 gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_resize_trunc
 ./test_resize_trunc
+
+# build and run identifier overflow test with AddressSanitizer
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_c.c -o obj_test/syntax_c.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_csharp.c -o obj_test/syntax_csharp.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_common.c -o obj_test/syntax_common.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_long_identifier.c \
+    obj_test/syntax_c.o obj_test/syntax_csharp.o obj_test/syntax_common.o -lncurses -o test_long_identifier
+./test_long_identifier

--- a/tests/test_long_identifier.c
+++ b/tests/test_long_identifier.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#include "syntax.h"
+#include "files.h"
+
+/* minimal WINDOW stub to satisfy functions */
+typedef struct { int dummy; } SIMPLE_WIN;
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW *w){free(w);return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
+int wattron(WINDOW*w,int a){(void)w;(void)a;return 0;}
+int wattroff(WINDOW*w,int a){(void)w;(void)a;return 0;}
+int wattrset(WINDOW*w,int a){(void)w;(void)a;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+
+    char line[600];
+    memset(line, 'a', sizeof(line)-2);
+    line[sizeof(line)-2] = ' ';
+    line[sizeof(line)-1] = '\0';
+
+    highlight_c_syntax(&fs, w, line, 0);
+    highlight_csharp_syntax(&fs, w, line, 0);
+
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard word extraction loops in C and C# syntax highlighters
- add ASan test for extremely long identifiers

## Testing
- `bash -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a0e6b82208324af03fbdb6fa82f4f