### PR TITLE
Fix HTML comment boundary check

### DIFF
--- a/src/syntax_html.c
+++ b/src/syntax_html.c
@@ -13,7 +13,8 @@ void print_char_with_attr(WINDOW *win, int y, int *x, char c, int attr) {
 void handle_html_comment(WINDOW *win, const char *line, int *i, int y, int *x) {
     int len = strlen(line);
     print_char_with_attr(win, y, x, line[(*i)++], COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-    while (*i < len && !(line[*i] == '-' && line[*i + 1] == '-' && line[*i + 2] == '>')) {
+    while (*i < len && !(*i + 1 < len && *i + 2 < len &&
+                         line[*i] == '-' && line[*i + 1] == '-' && line[*i + 2] == '>')) {
         print_char_with_attr(win, y, x, line[(*i)++], COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
     }
     if (*i < len) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -34,3 +34,8 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_common.c -o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_long_identifier.c \
     obj_test/syntax_c.o obj_test/syntax_csharp.o obj_test/syntax_common.o -lncurses -o test_long_identifier
 ./test_long_identifier
+
+# build and run HTML comment boundary test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_html.c -o obj_test/syntax_html.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c obj_test/syntax_html.o -lncurses -o test_html_comment
+./test_html_comment

--- a/tests/test_html_comment.c
+++ b/tests/test_html_comment.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#include "syntax.h"
+
+/* minimal WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW *w){free(w);return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
+int wattron(WINDOW*w,int a){(void)w;(void)a;return 0;}
+int wattroff(WINDOW*w,int a){(void)w;(void)a;return 0;}
+int wattrset(WINDOW*w,int a){(void)w;(void)a;return 0;}
+
+int main(void){
+    WINDOW *w = newwin(1,1,0,0);
+    const char *line = "<!--";
+    highlight_html_syntax(w, line, 0);
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prevent out-of-bounds access in `handle_html_comment`
- test HTML comment parsing with AddressSanitizer

## Testing
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a105b1118832498c15f2d69dc7c4e