### PR TITLE
Fix HTML highlighting offset

### DIFF
--- a/src/syntax_html.c
+++ b/src/syntax_html.c
@@ -55,7 +55,7 @@ void handle_html_tag(WINDOW *win, const char *line, int *i, int y, int *x) {
 void highlight_html_syntax(WINDOW *win, const char *line, int y) {
     if (!win || !line) return;
     wattrset(win, COLOR_PAIR(SYNTAX_BG));
-    int x = 0;
+    int x = 1;
     int i = 0;
     int len = strlen(line);
     while (i < len) {

--- a/tests/test_html_comment.c
+++ b/tests/test_html_comment.c
@@ -9,10 +9,15 @@
 
 /* minimal WINDOW stub */
 typedef struct { int dummy; } SIMPLE_WIN;
+static int first_x = -1;
 
 WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
 int delwin(WINDOW *w){free(w);return 0;}
-int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){
+    (void)w; (void)y; (void)fmt;
+    if(first_x==-1) first_x = x;
+    return 0;
+}
 int wattron(WINDOW*w,int a){(void)w;(void)a;return 0;}
 int wattroff(WINDOW*w,int a){(void)w;(void)a;return 0;}
 int wattrset(WINDOW*w,int a){(void)w;(void)a;return 0;}
@@ -21,6 +26,7 @@ int main(void){
     WINDOW *w = newwin(1,1,0,0);
     const char *line = "<!--";
     highlight_html_syntax(w, line, 0);
+    assert(first_x == 1);
     delwin(w);
     return 0;
 }


### PR DESCRIPTION
## Summary
- prevent highlight_html_syntax from drawing in the border column
- confirm behavior via updated HTML comment test

## Testing
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a111f6a24832485c1c9cb64228527