### PR TITLE
Add Python numeric and multiline string highlighting

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -56,6 +56,8 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->clipboard[0] = '\0';
     file_state->syntax_mode = NO_SYNTAX; // Set to NO_SYNTAX initially
     file_state->in_multiline_comment = false;
+    file_state->in_multiline_string = false;
+    file_state->string_delim = '\0';
     file_state->last_scanned_line = 0;
     file_state->last_comment_state = false;
     file_state->text_win = newwin(LINES - 2, COLS, 1, 0); // Create a new window for the file
@@ -146,5 +148,7 @@ int load_file_into_buffer(FileState *file_state) {
     file_state->last_scanned_line = 0;
     file_state->last_comment_state = false;
     file_state->in_multiline_comment = false;
+    file_state->in_multiline_string = false;
+    file_state->string_delim = '\0';
     return 0; // Success
 }

--- a/src/files.h
+++ b/src/files.h
@@ -21,6 +21,8 @@ typedef struct FileState {
     char *clipboard;
     int syntax_mode;
     bool in_multiline_comment;
+    bool in_multiline_string;
+    char string_delim;
     /* The last line index scanned for multiline comment state */
     int last_scanned_line;
     /* Comment state after scanning last_scanned_line */

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -12,7 +12,7 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
             highlight_html_syntax(win, line, y);
             break;
         case PYTHON_SYNTAX:
-            highlight_python_syntax(win, line, y);
+            highlight_python_syntax(fs, win, line, y);
             break;
         case CSHARP_SYNTAX:
             highlight_csharp_syntax(fs, win, line, y);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -25,7 +25,7 @@ void handle_html_tag(WINDOW *win, const char *line, int *i, int y, int *x);
 void handle_html_comment(WINDOW *win, const char *line, int *i, int y, int *x);
 void print_char_with_attr(WINDOW *win, int y, int *x, char c, int attr);
 void highlight_no_syntax(WINDOW *win, const char *line, int y);
-void highlight_python_syntax(WINDOW *win, const char *line, int y);
+void highlight_python_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void sync_multiline_comment(struct FileState *fs, int line);
 void mark_comment_state_dirty(struct FileState *fs);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -39,3 +39,8 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_long_identifie
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_html.c -o obj_test/syntax_html.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c obj_test/syntax_html.o -lncurses -o test_html_comment
 ./test_html_comment
+
+# build and run python syntax test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_python.c -o obj_test/syntax_python.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_python_syntax.c obj_test/syntax_python.o obj_test/files.o -lncurses -o test_python_syntax
+./test_python_syntax

--- a/tests/test_python_syntax.c
+++ b/tests/test_python_syntax.c
@@ -1,0 +1,66 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#undef mvwprintw
+#include "syntax.h"
+#include "files.h"
+
+/* simple WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+static int current_attr;
+static int call_index;
+static char printed[10][64];
+static int attrs[10];
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int wattron(WINDOW*w,int a){(void)w; current_attr |= a; return 0;}
+int wattroff(WINDOW*w,int a){(void)w; current_attr &= ~a; return 0;}
+int wattrset(WINDOW*w,int a){(void)w; current_attr = a; return 0;}
+int wattr_on(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr|=a; return 0;}
+int wattr_off(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr&=~a; return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;va_list ap;va_start(ap,fmt);vsnprintf(printed[call_index],sizeof(printed[call_index]),fmt,ap);va_end(ap);attrs[call_index]=current_attr;call_index++;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+
+    const char *line = "x = 0x1F";
+    highlight_python_syntax(&fs, w, line, 0);
+    int found = 0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i], "0x1F")==0){
+            assert(attrs[i] & COLOR_PAIR(SYNTAX_TYPE));
+            found = 1;
+        }
+    }
+    assert(found);
+
+    call_index = 0; current_attr = 0; fs.in_multiline_string = false;
+    const char *l1 = "\"\"\"abc";
+    const char *l2 = "def\"\"\"";
+    highlight_python_syntax(&fs, w, l1, 0);
+    assert(fs.in_multiline_string);
+    highlight_python_syntax(&fs, w, l2, 0);
+    assert(!fs.in_multiline_string);
+    int found_open = 0, found_close = 0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i], "\"\"\"abc")==0){
+            assert(attrs[i] & COLOR_PAIR(SYNTAX_STRING));
+            found_open = 1;
+        }
+        if(strcmp(printed[i], "def\"\"\"")==0){
+            assert(attrs[i] & COLOR_PAIR(SYNTAX_STRING));
+            found_close = 1;
+        }
+    }
+    assert(found_open && found_close);
+
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- enhance `FileState` with multiline string tracking
- highlight numeric literals and triple-quoted strings in Python syntax
- adjust `highlight_python_syntax` signature and callers
- test that numeric literals and multiline strings receive proper attributes

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a119b3d8c8324a47e6a06b244622b