### PR TITLE
Update resize behavior and add column capacity helper

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -556,19 +556,7 @@ void handle_resize(int sig) {
         wresize(fs->text_win, LINES - 2, COLS);
         mvwin(fs->text_win, 1, 0);
 
-        if (fs->line_capacity != new_capacity) {
-            fs->line_capacity = new_capacity;
-            for (int j = 0; j < fs->max_lines; ++j) {
-                size_t len = strlen(fs->text_buffer[j]);
-                char *tmp = realloc(fs->text_buffer[j], fs->line_capacity);
-                if (!tmp)
-                    continue;
-                fs->text_buffer[j] = tmp;
-                if (len > (size_t)(fs->line_capacity - 1))
-                    len = fs->line_capacity - 1;
-                fs->text_buffer[j][len] = '\0';
-            }
-        }
+        ensure_col_capacity(fs, new_capacity);
     }
 
     /* Use the resized window of the active file */

--- a/src/files.c
+++ b/src/files.c
@@ -118,6 +118,29 @@ int ensure_line_capacity(FileState *fs, int min_needed) {
     return 0;
 }
 
+int ensure_col_capacity(FileState *fs, int cols) {
+    if (cols <= fs->line_capacity)
+        return 0;
+
+    int old_capacity = fs->line_capacity;
+    for (int i = 0; i < fs->max_lines; ++i) {
+        char *tmp = realloc(fs->text_buffer[i], cols);
+        if (!tmp) {
+            for (int j = 0; j < i; ++j) {
+                char *restore = realloc(fs->text_buffer[j], old_capacity);
+                if (restore)
+                    fs->text_buffer[j] = restore;
+            }
+            return -1;
+        }
+        fs->text_buffer[i] = tmp;
+        memset(fs->text_buffer[i] + old_capacity, 0, cols - old_capacity);
+    }
+
+    fs->line_capacity = cols;
+    return 0;
+}
+
 // Function to load file content into the text buffer
 int load_file_into_buffer(FileState *file_state) {
     FILE *fp = fopen(file_state->filename, "r");

--- a/src/files.h
+++ b/src/files.h
@@ -34,5 +34,6 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
 void free_file_state(FileState *file_state, int max_lines);
 int load_file_into_buffer(FileState *file_state);
 int ensure_line_capacity(FileState *fs, int min_needed);
+int ensure_col_capacity(FileState *fs, int cols);
 
 #endif

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -121,6 +121,7 @@ int main(void){
 
     /* initial terminal size */
     LINES = 20; COLS = 50;
+    int initial_cols = COLS;
     FileState *fs = initialize_file_state("x", 2, COLS);
     assert(fs);
     fm_add(&file_manager, fs);
@@ -140,11 +141,11 @@ int main(void){
     assert(last_resize_win == fs->text_win);
     assert(last_resize_h == LINES - 2);
     assert(last_resize_w == COLS);
-    assert(fs->line_capacity == COLS - 3);
+    assert(fs->line_capacity == initial_cols);
     assert(fs->cursor_x == COLS - 1);
     assert(fs->cursor_y == LINES - BOTTOM_MARGIN);
-    assert(strlen(fs->text_buffer[0]) == (size_t)(fs->line_capacity - 1));
-    for(int i=0;i<fs->line_capacity-1;i++)
+    assert(strlen(fs->text_buffer[0]) == 40);
+    for(int i=0;i<40;i++)
         assert(fs->text_buffer[0][i] == 'A');
 
     assert(drawBar_called);

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -115,6 +115,7 @@ WINDOW *stdscr = NULL;
 int main(void){
     fm_init(&file_manager);
     LINES = 24; COLS = 50;
+    int initial_cols = COLS;
     FileState *fs = initialize_file_state("x", 2, 50);
     assert(fs);
     fm_add(&file_manager, fs);
@@ -127,11 +128,10 @@ int main(void){
     LINES = new_LINES; COLS = new_COLS;
     handle_resize(0);
 
-    assert(fs->line_capacity == new_COLS - 3);
-    assert(strlen(fs->text_buffer[0]) == (size_t)(fs->line_capacity - 1));
-    for(int i=0;i<fs->line_capacity-1;i++)
+    assert(fs->line_capacity == initial_cols);
+    assert(strlen(fs->text_buffer[0]) == 45);
+    for(int i=0;i<45;i++)
         assert(fs->text_buffer[0][i] == 'A');
-    assert(fs->text_buffer[0][fs->line_capacity-1] == '\0');
 
     free_file_state(fs, fs->max_lines);
     return 0;


### PR DESCRIPTION
## Summary
- add `ensure_col_capacity` to grow a file's column capacity
- use new helper in `handle_resize`
- adjust resize tests for non-shrinking behaviour

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a140f2c2083249e88c209e6e6ef0b