### PR TITLE
Refactor UI file dialog

### DIFF
--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -61,7 +61,8 @@ void free_dir_contents(char **choices, int n_choices) {
     free(choices);
 }
 
-int show_open_file_dialog(char *path, int max_len) {
+static int file_dialog_loop(char *path, int max_len,
+                            int cursor_on_enter, int cursor_on_mouse) {
     curs_set(0);
     int highlight = 0;
     int ch;
@@ -73,10 +74,10 @@ int show_open_file_dialog(char *path, int max_len) {
     int win_height = LINES - 4;
     int win_width = COLS - 4;
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
-        if (!win) {
-            curs_set(1);
-            return 0;
-        }
+    if (!win) {
+        curs_set(1);
+        return 0;
+    }
     keypad(win, TRUE);
 
     getcwd(cwd, sizeof(cwd));
@@ -108,7 +109,8 @@ int show_open_file_dialog(char *path, int max_len) {
             mvwprintw(win, i + 2, 2, "%*s", win_width - 4, "");
         }
 
-        mvwprintw(win, win_height - 3, 2, "Arrows: move  Enter: select  ESC: cancel");
+        mvwprintw(win, win_height - 3, 2,
+                  "Arrows: move  Enter: select  ESC: cancel");
         mvwprintw(win, win_height - 2, 2, "Path: %s", input);
         wmove(win, win_height - 2, 8 + input_len);
         wrefresh(win);
@@ -136,14 +138,16 @@ int show_open_file_dialog(char *path, int max_len) {
                 wrefresh(win);
                 delwin(win);
                 wrefresh(stdscr);
-                curs_set(1);
+                if (cursor_on_enter)
+                    curs_set(1);
                 return 1;
             }
 
             if (n_choices > 0) {
                 struct stat sb;
                 char next_path[2048];
-                snprintf(next_path, sizeof(next_path), "%s/%s", cwd, choices[highlight]);
+                snprintf(next_path, sizeof(next_path), "%s/%s", cwd,
+                         choices[highlight]);
                 if (stat(next_path, &sb) == 0 && S_ISDIR(sb.st_mode)) {
                     strncpy(cwd, next_path, sizeof(cwd));
                     cwd[sizeof(cwd) - 1] = '\0';
@@ -200,6 +204,8 @@ int show_open_file_dialog(char *path, int max_len) {
                                 wrefresh(win);
                                 delwin(win);
                                 wrefresh(stdscr);
+                                if (cursor_on_mouse)
+                                    curs_set(1);
                                 return 1;
                             }
                         }
@@ -237,178 +243,11 @@ int show_open_file_dialog(char *path, int max_len) {
     return 0;
 }
 
-int show_save_file_dialog(char *path, int max_len) {
-    curs_set(0);
-    int highlight = 0;
-    int ch;
-    char cwd[1024];
-    char input[1024] = "";
-    int input_len = 0;
-    int start = 0;
-
-    int win_height = LINES - 4;
-    int win_width = COLS - 4;
-    WINDOW *win = create_popup_window(win_height, win_width, NULL);
-    if (!win) {
-        curs_set(1);
-        return 0;
-    }
-    keypad(win, TRUE);
-
-    getcwd(cwd, sizeof(cwd));
-
-    while (1) {
-        werase(win);
-        box(win, 0, 0);
-        mvwprintw(win, 1, 2, "Current Directory: %s", cwd);
-
-        char **choices = NULL;
-        int n_choices = 0;
-        get_dir_contents(cwd, &choices, &n_choices);
-
-        int max_display = win_height - 5;
-        if (highlight < start)
-            start = highlight;
-        if (highlight >= start + max_display)
-            start = highlight - max_display + 1;
-
-        for (int i = 0; i < max_display && i + start < n_choices; ++i) {
-            int idx = i + start;
-            if (idx == highlight)
-                wattron(win, A_REVERSE);
-            mvwprintw(win, i + 2, 2, "%s", choices[idx]);
-            wattroff(win, A_REVERSE);
-        }
-
-        for (int i = n_choices - start; i < max_display; ++i) {
-            mvwprintw(win, i + 2, 2, "%*s", win_width - 4, "");
-        }
-
-        mvwprintw(win, win_height - 3, 2, "Arrows: move  Enter: select  ESC: cancel");
-        mvwprintw(win, win_height - 2, 2, "Path: %s", input);
-        wmove(win, win_height - 2, 8 + input_len);
-        wrefresh(win);
-
-        ch = wgetch(win);
-        if (ch == KEY_UP) {
-            if (highlight > 0)
-                --highlight;
-        } else if (ch == KEY_DOWN) {
-            if (highlight < n_choices - 1)
-                ++highlight;
-        } else if (ch == '\n') {
-            if (input_len > 0) {
-                char tmp[2048];
-                if (input[0] == '/') {
-                    strncpy(tmp, input, sizeof(tmp) - 1);
-                    tmp[sizeof(tmp) - 1] = '\0';
-                } else {
-                    snprintf(tmp, sizeof(tmp), "%s/%s", cwd, input);
-                }
-                strncpy(path, tmp, max_len);
-                path[max_len - 1] = '\0';
-                free_dir_contents(choices, n_choices);
-                wclear(win);
-                wrefresh(win);
-                delwin(win);
-                wrefresh(stdscr);
-                return 1;
-            }
-
-            if (n_choices > 0) {
-                struct stat sb;
-                char next_path[2048];
-                snprintf(next_path, sizeof(next_path), "%s/%s", cwd, choices[highlight]);
-                if (stat(next_path, &sb) == 0 && S_ISDIR(sb.st_mode)) {
-                    strncpy(cwd, next_path, sizeof(cwd));
-                    cwd[sizeof(cwd) - 1] = '\0';
-                    highlight = 0;
-                    start = 0;
-                    input_len = 0;
-                    input[0] = '\0';
-                } else {
-                    strncpy(path, next_path, max_len);
-                    path[max_len - 1] = '\0';
-                    free_dir_contents(choices, n_choices);
-                    wclear(win);
-                    wrefresh(win);
-                    delwin(win);
-                    wrefresh(stdscr);
-                    curs_set(1);
-                    return 1;
-                }
-            }
-        } else if (ch == KEY_MOUSE && enable_mouse) {
-            MEVENT ev;
-            if (getmouse(&ev) == OK &&
-                (ev.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED |
-                               BUTTON1_RELEASED))) {
-                int wy, wx;
-                getbegyx(win, wy, wx);
-                int row = ev.y - wy - 2;
-                int col = ev.x - wx - 2;
-                int max_display = win_height - 5;
-                if (row >= 0 && row < max_display &&
-                    col >= 0 && col < win_width - 4) {
-                    int idx = start + row;
-                    if (idx >= 0 && idx < n_choices)
-                        highlight = idx;
-
-                    if (ev.bstate & (BUTTON1_RELEASED | BUTTON1_CLICKED)) {
-                        if (n_choices > 0) {
-                            struct stat sb;
-                            char next_path[2048];
-                            snprintf(next_path, sizeof(next_path), "%s/%s", cwd,
-                                     choices[highlight]);
-                            if (stat(next_path, &sb) == 0 && S_ISDIR(sb.st_mode)) {
-                                strncpy(cwd, next_path, sizeof(cwd));
-                                cwd[sizeof(cwd) - 1] = '\0';
-                                highlight = 0;
-                                start = 0;
-                                input_len = 0;
-                                input[0] = '\0';
-                            } else {
-                                strncpy(path, next_path, max_len);
-                                path[max_len - 1] = '\0';
-                                free_dir_contents(choices, n_choices);
-                                wclear(win);
-                                wrefresh(win);
-                    delwin(win);
-                    wrefresh(stdscr);
-                    curs_set(1);
-                    return 1;
-                            }
-                        }
-                    }
-                }
-            }
-        } else if (ch == KEY_BACKSPACE || ch == 127) {
-            if (input_len > 0) {
-                input_len--;
-                input[input_len] = '\0';
-            }
-        } else if (ch == 27) {
-            free_dir_contents(choices, n_choices);
-            wclear(win);
-            wrefresh(win);
-            delwin(win);
-            wrefresh(stdscr);
-            curs_set(1);
-            return 0;
-        } else if (isprint(ch)) {
-            if (input_len < (int)sizeof(input) - 1) {
-                input[input_len++] = ch;
-                input[input_len] = '\0';
-            }
-        }
-
-        free_dir_contents(choices, n_choices);
-    }
-
-    wclear(win);
-    wrefresh(win);
-    delwin(win);
-    wrefresh(stdscr);
-    curs_set(1);
-    return 0;
+int show_open_file_dialog(char *path, int max_len) {
+    return file_dialog_loop(path, max_len, 1, 0);
 }
+
+int show_save_file_dialog(char *path, int max_len) {
+    return file_dialog_loop(path, max_len, 0, 1);
+}
+


### PR DESCRIPTION
## Summary
- reduce duplicated logic between open/save file dialogs
- introduce `file_dialog_loop` helper with optional cursor restore behavior
- simplify `show_open_file_dialog` and `show_save_file_dialog` to call the helper

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a1ad9d6b8832492a606b585c57d77