### PR TITLE
Fix SIGWINCH portability

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -42,7 +42,10 @@ void initialize() {
     sa.sa_handler = handle_resize;
     sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART;
+#ifdef SIGWINCH
+    /* Some platforms may not support SIGWINCH */
     sigaction(SIGWINCH, &sa, NULL);
+#endif
     disable_ctrl_c_z();
     define_key("\033[1;5D", KEY_CTRL_LEFT);
     define_key("\033[1;5C", KEY_CTRL_RIGHT);


### PR DESCRIPTION
## Summary
- handle platforms that don't define SIGWINCH when setting resize handler

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a1d69206c8324901215b44cec2766