### PR TITLE
Refactor syntax helpers

### DIFF
--- a/src/syntax.h
+++ b/src/syntax.h
@@ -32,4 +32,10 @@ void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line
 void sync_multiline_comment(struct FileState *fs, int line);
 void mark_comment_state_dirty(struct FileState *fs);
 
+/* Token scanning helpers shared by highlight implementations */
+int scan_identifier(const char *line, int start);
+int scan_number(const char *line, int start);
+int scan_string(const char *line, int start, char quote, bool *closed);
+int scan_multiline_string(const char *line, int start, char quote, bool *closed);
+
 #endif // SYNTAX_H

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -42,5 +42,6 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c
 
 # build and run python syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_python.c -o obj_test/syntax_python.o
-gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_python_syntax.c obj_test/syntax_python.o obj_test/files.o -lncurses -o test_python_syntax
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_python_syntax.c \
+    obj_test/syntax_python.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_python_syntax
 ./test_python_syntax


### PR DESCRIPTION
## Summary
- add common token scanning helpers
- refactor Python syntax highlighter to use new helpers
- use helpers inside generic keyword highlighter
- link syntax_common into python tests

## Testing
- `bash -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a22325eb88324a8a30853057293b4