### PR TITLE
Add Home/End key support

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -100,6 +100,18 @@ static void handle_key_enter_wrapper(struct FileState *fs, int *cx, int *cy) {
     handle_key_enter(fs);
 }
 
+static void handle_key_home_wrapper(struct FileState *fs, int *cx, int *cy) {
+    (void)cx;
+    (void)cy;
+    handle_key_home(fs);
+}
+
+static void handle_key_end_wrapper(struct FileState *fs, int *cx, int *cy) {
+    (void)cx;
+    (void)cy;
+    handle_key_end(fs);
+}
+
 static void handle_key_page_up_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
@@ -271,6 +283,8 @@ void initialize_key_mappings(void) {
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_DOWN, handle_key_down_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_LEFT, handle_key_left_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_RIGHT, handle_key_right_wrapper};
+    key_mappings[key_mapping_count++] = (KeyMapping){KEY_HOME, handle_key_home_wrapper};
+    key_mappings[key_mapping_count++] = (KeyMapping){KEY_END, handle_key_end_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_BACKSPACE, handle_key_backspace_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){127, handle_key_backspace_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_DC, handle_key_delete_wrapper};

--- a/src/input.h
+++ b/src/input.h
@@ -9,6 +9,8 @@ void handle_key_up(struct FileState *fs);
 void handle_key_down(struct FileState *fs);
 void handle_key_left(struct FileState *fs);
 void handle_key_right(struct FileState *fs);
+void handle_key_home(struct FileState *fs);
+void handle_key_end(struct FileState *fs);
 void handle_key_backspace(struct FileState *fs);
 void handle_key_delete(struct FileState *fs);
 void handle_key_enter(struct FileState *fs);

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -189,6 +189,14 @@ void handle_ctrl_key_right(FileState *fs) {
     fs->cursor_x = strlen(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]) + 1;
 }
 
+void handle_key_home(FileState *fs) {
+    fs->cursor_x = 1;
+}
+
+void handle_key_end(FileState *fs) {
+    fs->cursor_x = strlen(fs->text_buffer[fs->cursor_y - 1 + fs->start_line]) + 1;
+}
+
 void handle_tab_key(FileState *fs) {
     const int TAB_SIZE = 4;
     int inserted = 0;

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -38,8 +38,8 @@ void show_help() {
     mvwprintw(help_win, 6, win_width / 2, "CTRL-D: Delete current line");
     mvwprintw(help_win, 7, win_width / 2, "Arrow Keys: Navigate text");
     mvwprintw(help_win, 8, win_width / 2, "Page Up/Down: Scroll document");
-    mvwprintw(help_win, 9, win_width / 2, "CTRL-Left: Move to line start");
-    mvwprintw(help_win, 10, win_width / 2, "CTRL-Right: Move to line end");
+    mvwprintw(help_win, 9, win_width / 2, "Home/CTRL-Left: Move to line start");
+    mvwprintw(help_win, 10, win_width / 2, "End/CTRL-Right: Move to line end");
     mvwprintw(help_win, 11, win_width / 2, "CTRL-PgUp: Move to top of doc");
     mvwprintw(help_win, 12, win_width / 2, "CTRL-PgDn: Move to end of doc");
     mvwprintw(help_win, 14, win_width / 2, "F5: Insert blank line");

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -64,6 +64,8 @@ void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
 void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
 void handle_ctrl_key_up(FileState*fs){(void)fs;}
 void handle_ctrl_key_down(FileState*fs){(void)fs;}
+void handle_key_home(FileState*fs){(void)fs;}
+void handle_key_end(FileState*fs){(void)fs;}
 void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
 void handle_mouse_event(FileState*fs, MEVENT *ev){(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -60,6 +60,8 @@ void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
 void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
 void handle_ctrl_key_up(FileState*fs){(void)fs;}
 void handle_ctrl_key_down(FileState*fs){(void)fs;}
+void handle_key_home(FileState*fs){(void)fs;}
+void handle_key_end(FileState*fs){(void)fs;}
 void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
 void handle_mouse_event(FileState*fs, MEVENT *ev){(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}


### PR DESCRIPTION
## Summary
- implement handlers for `KEY_HOME` and `KEY_END`
- add wrappers and mappings for the new keys
- show Home/End bindings in the help screen
- update resize tests with stubs for new handlers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a2351022c8324a7e77eb5a602bc94