### PR TITLE
Add go to line feature

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -66,6 +66,7 @@ int key_find_next = KEY_F(3);  // Key code for find next occurrence
 int key_next_file = KEY_F(6);  // Key code for switching to the next file
 int key_prev_file = KEY_F(7);  // Key code for switching to the previous file
 int key_replace = 18;  // Key code for replacing text (CTRL-R)
+int key_goto_line = 7;  // Key code for go to line (CTRL-G)
 
 static void handle_key_up_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
@@ -207,6 +208,15 @@ static void handle_replace_wrapper(struct FileState *fs, int *cx, int *cy) {
     redraw();
 }
 
+static void handle_goto_line_wrapper(struct FileState *fs, int *cx, int *cy) {
+    int line;
+    if (show_goto_dialog(&line)) {
+        go_to_line(fs, line);
+        *cx = fs->cursor_x;
+        *cy = fs->cursor_y;
+    }
+}
+
 static void handle_delete_line_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     delete_current_line(fs);
@@ -315,6 +325,7 @@ void initialize_key_mappings(void) {
     key_mappings[key_mapping_count++] = (KeyMapping){key_find, handle_find_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_find_next, handle_find_next_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_replace, handle_replace_wrapper};
+    key_mappings[key_mapping_count++] = (KeyMapping){key_goto_line, handle_goto_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_delete_line, handle_delete_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_insert_line, handle_insert_line_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_move_forward, handle_move_forward_wrapper};

--- a/src/editor.h
+++ b/src/editor.h
@@ -54,6 +54,7 @@ void redraw(void);
 void delete_current_line(struct FileState *fs);
 void insert_new_line(struct FileState *fs);
 void update_status_bar(struct FileState *fs);
+void go_to_line(struct FileState *fs, int line);
 void handle_resize(int sig);
 void cleanup_on_exit(struct FileManager *fm);
 void disable_ctrl_c_z(void);

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -133,3 +133,36 @@ void update_status_bar(FileState *fs) {
     mvprintw(LINES - 1, COLS - 15, "CTRL-H - Help");
     wnoutrefresh(stdscr);
 }
+
+void go_to_line(FileState *fs, int line) {
+    if (fs->line_count == 0)
+        return;
+
+    if (line < 1)
+        line = 1;
+    if (line > fs->line_count)
+        line = fs->line_count;
+
+    int lines_per_screen = LINES - 3;
+    int middle_line = lines_per_screen / 2;
+    int idx = line - 1;
+
+    if (fs->line_count <= lines_per_screen) {
+        fs->start_line = 0;
+    } else if (idx < middle_line) {
+        fs->start_line = 0;
+    } else if (idx > fs->line_count - middle_line) {
+        fs->start_line = fs->line_count - lines_per_screen;
+    } else {
+        fs->start_line = idx - middle_line;
+    }
+
+    fs->cursor_y = idx - fs->start_line + 1;
+    fs->cursor_x = 1;
+
+    werase(text_win);
+    box(text_win, 0, 0);
+    draw_text_buffer(fs, text_win);
+    wmove(text_win, fs->cursor_y, fs->cursor_x);
+    wnoutrefresh(text_win);
+}

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,6 +1,7 @@
 #include <ncurses.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdlib.h>
 #include "config.h"
 #include "ui.h"
 #include "syntax.h"
@@ -167,5 +168,18 @@ int show_replace_dialog(char *search, int max_search_len,
 
     create_dialog("Replace:", replace, max_replace_len);
     curs_set(1);
+    return 1;
+}
+
+int show_goto_dialog(int *line_number) {
+    char buf[32];
+
+    create_dialog("Go To Line:", buf, sizeof(buf));
+
+    if (buf[0] == '\0') {
+        return 0;
+    }
+
+    *line_number = atoi(buf);
     return 1;
 }

--- a/src/ui.h
+++ b/src/ui.h
@@ -11,6 +11,7 @@ void show_warning_dialog(void);
 int show_find_dialog(char *output, int max_input_len, const char *preset);
 int show_replace_dialog(char *search, int max_search_len,
                         char *replace, int max_replace_len);
+int show_goto_dialog(int *line_number);
 int show_open_file_dialog(char *path, int max_len);
 int show_save_file_dialog(char *path, int max_len);
 int show_settings_dialog(AppConfig *cfg);

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -31,6 +31,7 @@ void show_help() {
     mvwprintw(help_win, 13, 2, "CTRL-F: Search for text string");
     mvwprintw(help_win, 14, 2, "F3: Find next occurrence");
     mvwprintw(help_win, 15, 2, "CTRL-R: Replace");
+    mvwprintw(help_win, 16, 2, "CTRL-G: Go to line");
 
     mvwprintw(help_win, 3, win_width / 2, "CTRL-C: Copy selection");
     mvwprintw(help_win, 4, win_width / 2, "CTRL-X: Cut selection");

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -109,6 +109,8 @@ void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
 void menuTestwindow(void){}
+int show_goto_dialog(int *line){(void)line;return 0;}
+void go_to_line(FileState *fs,int line){(void)fs;(void)line;}
 
 /* minimal global vars */
 int enable_mouse = 0;

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -105,6 +105,8 @@ void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
 void menuTestwindow(void){}
+int show_goto_dialog(int *line){(void)line;return 0;}
+void go_to_line(FileState *fs,int line){(void)fs;(void)line;}
 
 /* minimal global vars */
 int enable_mouse = 0;


### PR DESCRIPTION
## Summary
- implement a `show_goto_dialog` for prompting a line number
- implement `go_to_line` action and wire it to CTRL-G
- expose the action in help
- update tests with new stubs

## Testing
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a28f66194832495f0ae41f0cfd4ee