### PR TITLE
Implement partial file loading

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -492,6 +492,9 @@ void draw_text_buffer(FileState *fs, WINDOW *win) {
     box(win, 0, 0);
     int max_lines = LINES - 4;  // Adjust for the status bar
 
+    // Ensure enough lines are loaded for display
+    ensure_line_loaded(fs, fs->start_line + max_lines);
+
     // Iterate over each line to be displayed on the window
     for (int i = 0; i < max_lines && i + fs->start_line < fs->line_count; ++i) {
         // Apply syntax highlighting to the current line of text

--- a/src/files.h
+++ b/src/files.h
@@ -3,6 +3,7 @@
 
 #include <ncurses.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include "editor.h"
 
 typedef struct FileState {
@@ -28,6 +29,8 @@ typedef struct FileState {
     /* Comment state after scanning last_scanned_line */
     bool last_comment_state;
     WINDOW *text_win;
+    FILE *fp;          /* Open file handle for lazy loading */
+    bool file_complete;/* True when the entire file is loaded */
 } FileState;
 
 FileState *initialize_file_state(const char *filename, int max_lines, int max_cols);
@@ -35,5 +38,8 @@ void free_file_state(FileState *file_state, int max_lines);
 int load_file_into_buffer(FileState *file_state);
 int ensure_line_capacity(FileState *fs, int min_needed);
 int ensure_col_capacity(FileState *fs, int cols);
+int load_next_lines(FileState *fs, int count);
+void ensure_line_loaded(FileState *fs, int idx);
+void load_all_remaining_lines(FileState *fs);
 
 #endif

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -8,6 +8,7 @@
 #include "input.h"
 #include "clipboard.h"
 #include "syntax.h"
+#include "files.h"
 
 void handle_ctrl_backtick() {
     // Do nothing on CTRL+Backtick to avoid segmentation fault
@@ -23,6 +24,7 @@ void handle_key_up(FileState *fs) {
 }
 
 void handle_key_down(FileState *fs) {
+    ensure_line_loaded(fs, fs->start_line + fs->cursor_y);
     if (fs->cursor_y < LINES - BOTTOM_MARGIN && fs->cursor_y < fs->line_count) {
         fs->cursor_y++;
     } else if (fs->start_line + fs->cursor_y < fs->line_count) {
@@ -168,6 +170,7 @@ void handle_key_page_up(FileState *fs) {
 }
 
 void handle_key_page_down(FileState *fs) {
+    ensure_line_loaded(fs, fs->start_line + (LINES - 4));
     int max_lines = LINES - 4;
     if (fs->start_line + max_lines < fs->line_count) {
         fs->start_line += max_lines;
@@ -196,6 +199,7 @@ void handle_ctrl_key_pgup(FileState *fs) {
 }
 
 void handle_ctrl_key_pgdn(FileState *fs) {
+    load_all_remaining_lines(fs);
     fs->cursor_y = LINES - 4;
     if (fs->line_count > LINES - 4) {
         fs->start_line = fs->line_count - (LINES - 4);


### PR DESCRIPTION
## Summary
- introduce lazy-loading fields in `FileState`
- add helpers to load additional lines on demand
- adjust save/load operations to use incremental loading
- ensure drawing and keyboard handlers fetch needed lines

## Testing
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a2b466a808324b8b09285cd4925c3