### PR TITLE
Fix warnings in settings dialog

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -39,7 +39,7 @@ static const Option options[] = {
     {"Symbol color", OPT_COLOR, offsetof(AppConfig, symbol_color), NULL},
 };
 
-#define FIELD_COUNT (sizeof(options) / sizeof(options[0]))
+#define FIELD_COUNT ((int)(sizeof(options) / sizeof(options[0])))
 
 static void edit_option(AppConfig *cfg, WINDOW *win, const Option *opt) {
     if (opt->type == OPT_BOOL) {


### PR DESCRIPTION
## Summary
- fix signed comparison warnings in `ui_settings.c`

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683a2cefddb0832496428b5413ad39e2