### PR TITLE
Add theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Vento currently supports the following features:
 - **Interactive Settings Dialog**: Open **File → Settings** and use the arrow
   keys or mouse clicks to choose options. Mouse support can be enabled or
   disabled in this dialog, and all dialogs accept mouse input.
+- **Theme Selection**: Choose from predefined color themes located in the
+  `themes/` directory.
 - **Basic Syntax Highlighting**: Simple syntax highlighting for C, HTML, and Python files.
 - **Status Bar**: Displays the current line and column number.
 - **Scroll Bar**: Indicates your position within the document.
@@ -57,10 +59,14 @@ This file is created automatically with default values if it does not exist. Unk
 - `string_color`
 - `type_color`
 - `symbol_color`
+- `theme`
 - `enable_color`
 - `enable_mouse`
 
-Set `enable_mouse` to `false` if you want to disable mouse input entirely.
+Set `theme` to the base name of a file in the `themes/` directory (without the
+`.theme` extension). Colors defined in that theme are loaded before any
+individual color overrides. Set `enable_mouse` to `false` if you want to disable
+mouse input entirely.
 
 ### Multi-File Support
 

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -73,11 +73,13 @@ type_color
 .IP \[bu] 2
 symbol_color
 .IP \[bu] 2
+theme
+.IP \[bu] 2
 enable_color
 .IP \[bu] 2
 enable_mouse - enable or disable mouse support
 .PP
-These options can also be modified using the Settings dialog found under \fBFile\fP -> \fBSettings\fP. Exiting the dialog automatically writes the configuration back to \fB~/.ventorc\fP.
+Set \fBtheme\fP to the basename of a file in the \fBthemes\fP directory (without the \fB.theme\fP extension). Colors from that theme are loaded before applying any individual color overrides. These options can also be modified using the Settings dialog found under \fBFile\fP -> \fBSettings\fP. Exiting the dialog automatically writes the configuration back to \fB~/.ventorc\fP.
 .SH KEYBOARD SHORTCUTS
 .TP 
 .B CTRL-H

--- a/src/config.h
+++ b/src/config.h
@@ -13,6 +13,7 @@ typedef struct {
     char string_color[16];
     char type_color[16];
     char symbol_color[16];
+    char theme[32];
     int enable_color;
     int enable_mouse;
 } AppConfig;
@@ -20,6 +21,7 @@ typedef struct {
 extern AppConfig app_config;
 
 short get_color_code(const char *color_name);
+void load_theme(const char *name, AppConfig *cfg);
 void config_load(AppConfig *cfg);
 void config_save(const AppConfig *cfg);
 void read_config_file(void);

--- a/themes/default.theme
+++ b/themes/default.theme
@@ -1,0 +1,6 @@
+background_color=BLACK
+keyword_color=CYAN
+comment_color=GREEN
+string_color=YELLOW
+type_color=MAGENTA
+symbol_color=RED


### PR DESCRIPTION
## Summary
- extend `AppConfig` with `theme`
- implement theme loading in config
- add theme option in settings dialog
- ship a default theme
- document themes in README and man page

## Testing
- `sh -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a37fc0ba88324ab005c6ce940918f