### PR TITLE
Add JS and CSS syntax highlighting

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -213,6 +213,10 @@ int set_syntax_mode(const char *filename) {
             return PYTHON_SYNTAX;
         } else if (strcmp(ext, ".cs") == 0) {
             return CSHARP_SYNTAX;
+        } else if (strcmp(ext, ".js") == 0) {
+            return JS_SYNTAX;
+        } else if (strcmp(ext, ".css") == 0) {
+            return CSS_SYNTAX;
         }
     }
     return NO_SYNTAX;

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -17,6 +17,12 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
         case CSHARP_SYNTAX:
             highlight_csharp_syntax(fs, win, line, y);
             break;
+        case JS_SYNTAX:
+            highlight_js_syntax(fs, win, line, y);
+            break;
+        case CSS_SYNTAX:
+            highlight_css_syntax(fs, win, line, y);
+            break;
         default:
             highlight_no_syntax(win, line, y);
             break;

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -8,6 +8,8 @@
 #define HTML_SYNTAX 2
 #define PYTHON_SYNTAX 3
 #define CSHARP_SYNTAX 4
+#define JS_SYNTAX 5
+#define CSS_SYNTAX 6
 
 typedef enum {
     SYNTAX_BG = 1,
@@ -29,6 +31,8 @@ void highlight_with_keywords(struct FileState *fs, WINDOW *win, const char *line
                              int y, const char **keywords, int keyword_count);
 void highlight_python_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
+void highlight_js_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
+void highlight_css_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void sync_multiline_comment(struct FileState *fs, int line);
 void mark_comment_state_dirty(struct FileState *fs);
 

--- a/src/syntax_css.c
+++ b/src/syntax_css.c
@@ -1,0 +1,16 @@
+#include <ncurses.h>
+#include <string.h>
+#include <ctype.h>
+#include "syntax.h"
+#include "files.h"
+
+static const char *CSS_KEYWORDS[] = {
+    "color", "background", "margin", "padding", "border", "font",
+    "display", "position", "top", "left", "right", "bottom",
+    "width", "height", "flex", "grid", "float", "clear"
+};
+static const int CSS_KEYWORDS_COUNT = sizeof(CSS_KEYWORDS) / sizeof(CSS_KEYWORDS[0]);
+
+void highlight_css_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
+    highlight_with_keywords(fs, win, line, y, CSS_KEYWORDS, CSS_KEYWORDS_COUNT);
+}

--- a/src/syntax_js.c
+++ b/src/syntax_js.c
@@ -1,0 +1,18 @@
+#include <ncurses.h>
+#include <string.h>
+#include <ctype.h>
+#include "syntax.h"
+#include "files.h"
+
+static const char *JS_KEYWORDS[] = {
+    "break", "case", "catch", "class", "const", "continue", "debugger", "default",
+    "delete", "do", "else", "export", "extends", "finally", "for", "function",
+    "if", "import", "in", "instanceof", "let", "new", "return", "super",
+    "switch", "this", "throw", "try", "typeof", "var", "void", "while",
+    "with", "yield", "static"
+};
+static const int JS_KEYWORDS_COUNT = sizeof(JS_KEYWORDS) / sizeof(JS_KEYWORDS[0]);
+
+void highlight_js_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
+    highlight_with_keywords(fs, win, line, y, JS_KEYWORDS, JS_KEYWORDS_COUNT);
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -45,3 +45,15 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_python.c -o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_python_syntax.c \
     obj_test/syntax_python.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_python_syntax
 ./test_python_syntax
+
+# build and run JavaScript syntax test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_js.c -o obj_test/syntax_js.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_js_syntax.c \
+    obj_test/syntax_js.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_js_syntax
+./test_js_syntax
+
+# build and run CSS syntax test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o obj_test/syntax_css.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_css_syntax.c \
+    obj_test/syntax_css.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_css_syntax
+./test_css_syntax

--- a/tests/test_css_syntax.c
+++ b/tests/test_css_syntax.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#undef mvwprintw
+#include "syntax.h"
+#include "files.h"
+
+/* simple WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+static int current_attr;
+static int call_index;
+static char printed[10][64];
+static int attrs[10];
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int wattron(WINDOW*w,int a){(void)w; current_attr |= a; return 0;}
+int wattroff(WINDOW*w,int a){(void)w; current_attr &= ~a; return 0;}
+int wattrset(WINDOW*w,int a){(void)w; current_attr = a; return 0;}
+int wattr_on(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr|=a; return 0;}
+int wattr_off(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr&=~a; return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;va_list ap;va_start(ap,fmt);vsnprintf(printed[call_index],sizeof(printed[call_index]),fmt,ap);va_end(ap);attrs[call_index]=current_attr;call_index++;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+
+    const char *line = "margin: 10px;";
+    highlight_css_syntax(&fs, w, line, 0);
+    int kw = 0, num = 0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i], "margin") == 0){
+            if(attrs[i] & COLOR_PAIR(SYNTAX_KEYWORD)) kw = 1;
+        }
+        if(strcmp(printed[i], "10px") == 0 || strcmp(printed[i], "10") == 0){
+            if(attrs[i] & COLOR_PAIR(SYNTAX_TYPE)) num = 1;
+        }
+    }
+    assert(kw);
+    assert(num);
+
+    delwin(w);
+    return 0;
+}

--- a/tests/test_js_syntax.c
+++ b/tests/test_js_syntax.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#undef mvwprintw
+#include "syntax.h"
+#include "files.h"
+
+/* simple WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+static int current_attr;
+static int call_index;
+static char printed[10][64];
+static int attrs[10];
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int wattron(WINDOW*w,int a){(void)w; current_attr |= a; return 0;}
+int wattroff(WINDOW*w,int a){(void)w; current_attr &= ~a; return 0;}
+int wattrset(WINDOW*w,int a){(void)w; current_attr = a; return 0;}
+int wattr_on(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr|=a; return 0;}
+int wattr_off(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr&=~a; return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;va_list ap;va_start(ap,fmt);vsnprintf(printed[call_index],sizeof(printed[call_index]),fmt,ap);va_end(ap);attrs[call_index]=current_attr;call_index++;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+
+    const char *line = "if (x) return 42;";
+    highlight_js_syntax(&fs, w, line, 0);
+    int kw = 0, num = 0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i], "if") == 0 || strcmp(printed[i], "return") == 0){
+            if(attrs[i] & COLOR_PAIR(SYNTAX_KEYWORD)) kw++;
+        }
+        if(strcmp(printed[i], "42") == 0){
+            if(attrs[i] & COLOR_PAIR(SYNTAX_TYPE)) num = 1;
+        }
+    }
+    assert(kw >= 2);
+    assert(num);
+
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expand syntax modes to include JavaScript and CSS
- implement `highlight_js_syntax` and `highlight_css_syntax`
- detect `.js` and `.css` extensions
- dispatch to new highlighters
- add unit tests for JS and CSS numbers and keywords

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a3999c42c83248460852fb3992512