### PR TITLE
Add shell syntax support and shebang detection

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -204,7 +204,7 @@ void close_current_file(FileState *fs_unused, int *cx, int *cy) {
 
 int set_syntax_mode(const char *filename) {
     const char *ext = strrchr(filename, '.');
-    if (ext) {
+    if (ext && ext[1] != '\0') {
         if (strcmp(ext, ".c") == 0 || strcmp(ext, ".h") == 0) {
             return C_SYNTAX;
         } else if (strcmp(ext, ".html") == 0 || strcmp(ext, ".htm") == 0) {
@@ -218,6 +218,23 @@ int set_syntax_mode(const char *filename) {
         } else if (strcmp(ext, ".css") == 0) {
             return CSS_SYNTAX;
         }
+    }
+    FILE *fp = fopen(filename, "r");
+    if (fp) {
+        char first[256];
+        if (fgets(first, sizeof(first), fp)) {
+            if (strncmp(first, "#!", 2) == 0) {
+                if (strstr(first, "python")) {
+                    fclose(fp);
+                    return PYTHON_SYNTAX;
+                }
+                if (strstr(first, "bash") || strstr(first, "sh")) {
+                    fclose(fp);
+                    return SHELL_SYNTAX;
+                }
+            }
+        }
+        fclose(fp);
     }
     return NO_SYNTAX;
 }

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -23,6 +23,9 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
         case CSS_SYNTAX:
             highlight_css_syntax(fs, win, line, y);
             break;
+        case SHELL_SYNTAX:
+            highlight_shell_syntax(fs, win, line, y);
+            break;
         default:
             highlight_no_syntax(win, line, y);
             break;

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -10,6 +10,7 @@
 #define CSHARP_SYNTAX 4
 #define JS_SYNTAX 5
 #define CSS_SYNTAX 6
+#define SHELL_SYNTAX 7
 
 typedef enum {
     SYNTAX_BG = 1,
@@ -33,6 +34,7 @@ void highlight_python_syntax(struct FileState *fs, WINDOW *win, const char *line
 void highlight_csharp_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_js_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_css_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
+void highlight_shell_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void sync_multiline_comment(struct FileState *fs, int line);
 void mark_comment_state_dirty(struct FileState *fs);
 

--- a/src/syntax_shell.c
+++ b/src/syntax_shell.c
@@ -1,0 +1,68 @@
+#include <ncurses.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdbool.h>
+#include "syntax.h"
+#include "files.h"
+
+static const char *SHELL_KEYWORDS[] = {
+    "if", "then", "else", "fi", "for", "in", "do", "done",
+    "while", "case", "esac", "function"
+};
+static const int SHELL_KEYWORDS_COUNT = sizeof(SHELL_KEYWORDS) / sizeof(SHELL_KEYWORDS[0]);
+
+void highlight_shell_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
+    (void)fs;
+    wattrset(win, COLOR_PAIR(SYNTAX_BG));
+    int len = strlen(line);
+    int i = 0;
+    int x = 1;
+    char word[256];
+
+    while (i < len) {
+        if (line[i] == '#') {
+            wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+            mvwprintw(win, y, x, "%s", &line[i]);
+            wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+            break;
+        } else if (line[i] == '"' || line[i] == '\'') {
+            bool closed;
+            int l = scan_string(line, i, line[i], &closed);
+            wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+            mvwprintw(win, y, x, "%.*s", l, &line[i]);
+            wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+            x += l;
+            i += l;
+        } else if (isdigit((unsigned char)line[i])) {
+            int l = scan_number(line, i);
+            wattron(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
+            mvwprintw(win, y, x, "%.*s", l, &line[i]);
+            wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
+            x += l;
+            i += l;
+        } else if (isalpha((unsigned char)line[i]) || line[i] == '_') {
+            int wlen = scan_identifier(line, i);
+            if (wlen >= (int)sizeof(word))
+                wlen = (int)sizeof(word) - 1;
+            strncpy(word, &line[i], wlen);
+            word[wlen] = '\0';
+            int is_kw = 0;
+            for (int k = 0; k < SHELL_KEYWORDS_COUNT; k++) {
+                if (strcmp(word, SHELL_KEYWORDS[k]) == 0) {
+                    wattron(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
+                    mvwprintw(win, y, x, "%s", word);
+                    wattroff(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
+                    is_kw = 1;
+                    break;
+                }
+            }
+            if (!is_kw) {
+                mvwprintw(win, y, x, "%s", word);
+            }
+            x += wlen;
+            i += wlen;
+        } else {
+            mvwprintw(win, y, x++, "%c", line[i++]);
+        }
+    }
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -57,3 +57,15 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o ob
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_css_syntax.c \
     obj_test/syntax_css.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_css_syntax
 ./test_css_syntax
+
+# build and run shell syntax highlighting test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_shell.c -o obj_test/syntax_shell.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_shell_syntax.c \
+    obj_test/syntax_shell.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_shell_syntax
+./test_shell_syntax
+
+# build and run shebang detection test (uses stubs for other functions)
+gcc -Wall -Wextra -std=c99 -g -Isrc -c tests/stubs_file_ops.c -o obj_test/stubs_file_ops.o
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_shebang_detection.c src/file_ops.c \
+    obj_test/stubs_file_ops.o -lncurses -o test_shebang_detection
+./test_shebang_detection

--- a/tests/stubs_file_ops.c
+++ b/tests/stubs_file_ops.c
@@ -1,0 +1,24 @@
+#include <ncurses.h>
+#include "editor.h"
+#include "files.h"
+#include "file_manager.h"
+#include "ui.h"
+
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+FileManager file_manager = {0};
+
+void draw_text_buffer(FileState *fs, WINDOW *win){(void)fs;(void)win;}
+void allocation_failed(const char *msg){(void)msg;}
+void load_all_remaining_lines(FileState *fs){(void)fs;}
+int load_next_lines(FileState *fs,int c){(void)fs;(void)c;return 0;}
+FileState *initialize_file_state(const char *f,int m,int c){(void)f;(void)m;(void)c;return NULL;}
+void free_file_state(FileState *f,int m){(void)f;(void)m;}
+int fm_add(FileManager *fm, FileState *fs){(void)fm;(void)fs;return 0;}
+void fm_close(FileManager *fm,int i){(void)fm;(void)i;}
+FileState *fm_current(FileManager *fm){(void)fm;return NULL;}
+int fm_switch(FileManager *fm,int i){(void)fm;(void)i;return 0;}
+int show_open_file_dialog(char *p,int m){(void)p;(void)m;return 0;}
+int show_save_file_dialog(char *p,int m){(void)p;(void)m;return 0;}
+void update_status_bar(FileState *fs){(void)fs;}
+void redraw(void){}

--- a/tests/test_shebang_detection.c
+++ b/tests/test_shebang_detection.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "file_ops.h"
+#include "syntax.h"
+
+int main(void){
+    const char *pfile = "tmp_py.sh";
+    FILE *fp = fopen(pfile, "w");
+    fprintf(fp, "#!/usr/bin/env python\n");
+    fclose(fp);
+    assert(set_syntax_mode(pfile) == PYTHON_SYNTAX);
+    unlink(pfile);
+
+    const char *sfile = "tmp_sh.sh";
+    fp = fopen(sfile, "w");
+    fprintf(fp, "#!/bin/bash\n");
+    fclose(fp);
+    assert(set_syntax_mode(sfile) == SHELL_SYNTAX);
+    unlink(sfile);
+    return 0;
+}

--- a/tests/test_shell_syntax.c
+++ b/tests/test_shell_syntax.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#undef mvwprintw
+#include "syntax.h"
+#include "files.h"
+
+typedef struct { int dummy; } SIMPLE_WIN;
+static int current_attr;
+static int call_index;
+static char printed[50][64];
+static int attrs[50];
+
+WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int wattron(WINDOW*w,int a){(void)w;current_attr|=a;return 0;}
+int wattroff(WINDOW*w,int a){(void)w;current_attr&=~a;return 0;}
+int wattrset(WINDOW*w,int a){(void)w;current_attr=a;return 0;}
+int wattr_on(WINDOW*w,attr_t a,void*opts){(void)w;(void)opts;current_attr|=a;return 0;}
+int wattr_off(WINDOW*w,attr_t a,void*opts){(void)w;(void)opts;current_attr&=~a;return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;va_list ap;va_start(ap,fmt);vsnprintf(printed[call_index],sizeof(printed[call_index]),fmt,ap);va_end(ap);attrs[call_index]=current_attr;call_index++;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+    const char *line = "for i in 1; do echo $i; done";
+    highlight_shell_syntax(&fs,w,line,0);
+    int kw=0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i],"for")==0||strcmp(printed[i],"do")==0||strcmp(printed[i],"done")==0){
+            if(attrs[i] & COLOR_PAIR(SYNTAX_KEYWORD)) kw++;
+        }
+    }
+    assert(kw>=2);
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect syntax from shebang lines in `set_syntax_mode`
- add new `SHELL_SYNTAX` mode with basic highlighter
- support highlighting in syntax dispatcher
- provide unit tests for shell highlighting and shebang detection

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a3a9b90148324974d187cff5bc231