### PR TITLE
Support nested JS and CSS in HTML highlighter

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -59,6 +59,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->in_multiline_comment = false;
     file_state->in_multiline_string = false;
     file_state->string_delim = '\0';
+    file_state->nested_mode = 0;
     file_state->last_scanned_line = 0;
     file_state->last_comment_state = false;
     file_state->text_win = newwin(LINES - 2, COLS, 1, 0); // Create a new window for the file
@@ -215,5 +216,6 @@ int load_file_into_buffer(FileState *file_state) {
     file_state->in_multiline_comment = false;
     file_state->in_multiline_string = false;
     file_state->string_delim = '\0';
+    file_state->nested_mode = 0;
     return (res >= 0) ? 0 : -1;
 }

--- a/src/files.h
+++ b/src/files.h
@@ -28,6 +28,7 @@ typedef struct FileState {
     int last_scanned_line;
     /* Comment state after scanning last_scanned_line */
     bool last_comment_state;
+    int nested_mode; /* 0=none,1=JS,2=CSS */
     WINDOW *text_win;
     FILE *fp;          /* Open file handle for lazy loading */
     bool file_complete;/* True when the entire file is loaded */

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -9,7 +9,7 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
             highlight_c_syntax(fs, win, line, y);
             break;
         case HTML_SYNTAX:
-            highlight_html_syntax(win, line, y);
+            highlight_html_syntax(fs, win, line, y);
             break;
         case PYTHON_SYNTAX:
             highlight_python_syntax(fs, win, line, y);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -23,7 +23,7 @@ typedef enum {
 
 void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_c_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
-void highlight_html_syntax(WINDOW *win, const char *line, int y);
+void highlight_html_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);
 void handle_html_tag(WINDOW *win, const char *line, int *i, int y, int *x);
 void handle_html_comment(WINDOW *win, const char *line, int *i, int y, int *x);
 void print_char_with_attr(WINDOW *win, int y, int *x, char c, int attr);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -37,7 +37,11 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_long_identifie
 
 # build and run HTML comment boundary test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_html.c -o obj_test/syntax_html.o
-gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c obj_test/syntax_html.o -lncurses -o test_html_comment
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_js.c -o obj_test/syntax_js.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o obj_test/syntax_css.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c \
+    obj_test/syntax_html.o obj_test/syntax_js.o obj_test/syntax_css.o \
+    obj_test/syntax_common.o obj_test/files.o -lncurses -o test_html_comment
 ./test_html_comment
 
 # build and run python syntax test
@@ -57,6 +61,12 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o ob
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_css_syntax.c \
     obj_test/syntax_css.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_css_syntax
 ./test_css_syntax
+
+# build and run HTML nested syntax test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_nested.c \
+    obj_test/syntax_html.o obj_test/syntax_js.o obj_test/syntax_css.o \
+    obj_test/syntax_common.o obj_test/files.o -lncurses -o test_html_nested
+./test_html_nested
 
 # build and run shell syntax highlighting test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_shell.c -o obj_test/syntax_shell.o

--- a/tests/test_html_comment.c
+++ b/tests/test_html_comment.c
@@ -6,6 +6,7 @@
 #undef wattroff
 #undef wattrset
 #include "syntax.h"
+#include "files.h"
 
 /* minimal WINDOW stub */
 typedef struct { int dummy; } SIMPLE_WIN;
@@ -23,9 +24,10 @@ int wattroff(WINDOW*w,int a){(void)w;(void)a;return 0;}
 int wattrset(WINDOW*w,int a){(void)w;(void)a;return 0;}
 
 int main(void){
+    FileState fs = {0};
     WINDOW *w = newwin(1,1,0,0);
     const char *line = "<!--";
-    highlight_html_syntax(w, line, 0);
+    highlight_html_syntax(&fs, w, line, 0);
     assert(first_x == 1);
     delwin(w);
     return 0;

--- a/tests/test_html_nested.c
+++ b/tests/test_html_nested.c
@@ -1,0 +1,66 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#undef mvwprintw
+#include "syntax.h"
+#include "files.h"
+
+/* simple WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+static int current_attr;
+static int call_index;
+static char printed[30][64];
+static int attrs[30];
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int wattron(WINDOW*w,int a){(void)w; current_attr |= a; return 0;}
+int wattroff(WINDOW*w,int a){(void)w; current_attr &= ~a; return 0;}
+int wattrset(WINDOW*w,int a){(void)w; current_attr = a; return 0;}
+int wattr_on(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr|=a; return 0;}
+int wattr_off(WINDOW*w, attr_t a, void*opts){(void)w;(void)opts; current_attr&=~a; return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;va_list ap;va_start(ap,fmt);vsnprintf(printed[call_index],sizeof(printed[call_index]),fmt,ap);va_end(ap);attrs[call_index]=current_attr;call_index++;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+
+    highlight_html_syntax(&fs, w, "<script>", 0);
+    assert(fs.nested_mode == 1);
+
+    call_index = 0; current_attr = 0;
+    highlight_html_syntax(&fs, w, "if (x) return 42;", 0);
+    int kw=0,num=0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i], "if") == 0 || strcmp(printed[i], "return") == 0){
+            if(attrs[i] & COLOR_PAIR(SYNTAX_KEYWORD)) kw++;}
+        if(strcmp(printed[i], "42") == 0){if(attrs[i] & COLOR_PAIR(SYNTAX_TYPE)) num=1;}
+    }
+    assert(kw>=2); assert(num);
+
+    highlight_html_syntax(&fs, w, "</script>", 0);
+    assert(fs.nested_mode == 0);
+
+    highlight_html_syntax(&fs, w, "<style>", 0);
+    assert(fs.nested_mode == 2);
+
+    call_index = 0; current_attr = 0;
+    highlight_html_syntax(&fs, w, "margin: 10px;", 0);
+    kw = num = 0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i], "margin") == 0){ if(attrs[i] & COLOR_PAIR(SYNTAX_KEYWORD)) kw=1; }
+        if(strcmp(printed[i], "10px") == 0 || strcmp(printed[i], "10") == 0){ if(attrs[i] & COLOR_PAIR(SYNTAX_TYPE)) num=1; }
+    }
+    assert(kw); assert(num);
+
+    highlight_html_syntax(&fs, w, "</style>", 0);
+    assert(fs.nested_mode == 0);
+
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- store nested syntax state per file
- track `<script>`/`<style>` blocks in the HTML highlighter
- delegate nested code to JS or CSS highlighters
- exercise nested highlighting in new test

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a3be1326c83248d316e7d07ee7a7f