### PR TITLE
Introduce regex-based syntax highlighting

### DIFF
--- a/src/syntax.h
+++ b/src/syntax.h
@@ -2,6 +2,7 @@
 #define SYNTAX_H
 
 #include "editor.h"
+#include <regex.h>
 
 #define NO_SYNTAX 0
 #define C_SYNTAX 1
@@ -20,6 +21,18 @@ typedef enum {
     SYNTAX_TYPE,
     SYNTAX_SYMBOL
 } SyntaxColor;
+
+typedef struct {
+    const char *pattern;
+    int attr;
+    regex_t regex;
+    int compiled;
+} SyntaxRegex;
+
+int compile_regex_set(SyntaxRegex *set, int count);
+void free_regex_set(SyntaxRegex *set, int count);
+void highlight_regex_line(WINDOW *win, int y, int x_start, const char *line,
+                          SyntaxRegex *patterns, int count);
 
 void apply_syntax_highlighting(struct FileState *fs, WINDOW *win, const char *line, int y);
 void highlight_c_syntax(struct FileState *fs, WINDOW *win, const char *line, int y);

--- a/src/syntax_c.c
+++ b/src/syntax_c.c
@@ -4,14 +4,36 @@
 #include "syntax.h"
 #include "files.h"
 
-static const char *C_KEYWORDS[] = {
-    "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else", "enum", "extern", "float",
-    "for", "goto", "if", "inline", "int", "long", "register", "restrict", "return", "short", "signed", "sizeof", "static",
-    "struct", "switch", "typedef", "union", "unsigned", "void", "volatile", "while", "_Alignas", "_Alignof", "_Atomic",
-    "_Bool", "_Complex", "_Generic", "_Imaginary", "_Noreturn", "_Static_assert", "_Thread_local"
+#define C_KEYWORDS_PATTERN \
+    "^(auto|break|case|char|const|continue|default|do|double|else|enum|extern|float|" \
+    "for|goto|if|inline|int|long|register|restrict|return|short|signed|sizeof|static|" \
+    "struct|switch|typedef|union|unsigned|void|volatile|while|_Alignas|_Alignof|_Atomic|" \
+    "_Bool|_Complex|_Generic|_Imaginary|_Noreturn|_Static_assert|_Thread_local)\\b"
+
+static SyntaxRegex C_PATTERNS[] = {
+    { .pattern = "^//.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = C_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static const int C_KEYWORDS_COUNT = sizeof(C_KEYWORDS) / sizeof(C_KEYWORDS[0]);
+static int c_regex_compiled = 0;
+static const int C_PATTERNS_COUNT = sizeof(C_PATTERNS) / sizeof(C_PATTERNS[0]);
 
 void highlight_c_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
-    highlight_with_keywords(fs, win, line, y, C_KEYWORDS, C_KEYWORDS_COUNT);
+    if (!c_regex_compiled) {
+        c_regex_compiled = compile_regex_set(C_PATTERNS, C_PATTERNS_COUNT);
+    }
+    if (c_regex_compiled > 0) {
+        highlight_regex_line(win, y, 1, line, C_PATTERNS, C_PATTERNS_COUNT);
+    } else {
+        static const char *C_KEYWORDS[] = {
+            "auto","break","case","char","const","continue","default","do","double","else","enum","extern","float",
+            "for","goto","if","inline","int","long","register","restrict","return","short","signed","sizeof","static",
+            "struct","switch","typedef","union","unsigned","void","volatile","while","_Alignas","_Alignof","_Atomic",
+            "_Bool","_Complex","_Generic","_Imaginary","_Noreturn","_Static_assert","_Thread_local"
+        };
+        static const int COUNT = sizeof(C_KEYWORDS)/sizeof(C_KEYWORDS[0]);
+        highlight_with_keywords(fs, win, line, y, C_KEYWORDS, COUNT);
+    }
 }

--- a/src/syntax_csharp.c
+++ b/src/syntax_csharp.c
@@ -4,21 +4,37 @@
 #include "syntax.h"
 #include "files.h"
 
-static const char *CSHARP_KEYWORDS[] = {
-    "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char",
-    "checked", "class", "const", "continue",
-    "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false", "finally",
-    "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
-    "long", "namespace", "new", "null", "object", "operator", "out", "override",
-    "params", "private", "protected",
-    "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof",
-    "stackalloc", "static", "string",
-    "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong",
-    "unchecked", "unsafe", "ushort",
-    "using", "virtual", "void", "volatile", "while"
+#define CSHARP_KEYWORDS_PATTERN \
+    "^(abstract|as|base|bool|break|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|do|double|else|enum|event|explicit|extern|false|finally|fixed|float|for|foreach|goto|if|implicit|in|int|interface|internal|is|lock|long|namespace|new|null|object|operator|out|override|params|private|protected|public|readonly|ref|return|sbyte|sealed|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unsafe|ushort|using|virtual|void|volatile|while)\\b"
+
+static SyntaxRegex CSHARP_PATTERNS[] = {
+    { .pattern = "^//.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = CSHARP_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static const int CSHARP_KEYWORDS_COUNT = sizeof(CSHARP_KEYWORDS) / sizeof(CSHARP_KEYWORDS[0]);
+static int csharp_regex_compiled = 0;
+static const int CSHARP_PATTERNS_COUNT = sizeof(CSHARP_PATTERNS)/sizeof(CSHARP_PATTERNS[0]);
 
 void highlight_csharp_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
-    highlight_with_keywords(fs, win, line, y, CSHARP_KEYWORDS, CSHARP_KEYWORDS_COUNT);
+    (void)fs;
+    if (!csharp_regex_compiled) {
+        csharp_regex_compiled = compile_regex_set(CSHARP_PATTERNS, CSHARP_PATTERNS_COUNT);
+    }
+    if (csharp_regex_compiled > 0) {
+        highlight_regex_line(win, y, 1, line, CSHARP_PATTERNS, CSHARP_PATTERNS_COUNT);
+    } else {
+        static const char *CSHARP_KEYWORDS[] = {
+            "abstract","as","base","bool","break","byte","case","catch","char","checked","class","const","continue",
+            "decimal","default","delegate","do","double","else","enum","event","explicit","extern","false","finally",
+            "fixed","float","for","foreach","goto","if","implicit","in","int","interface","internal","is","lock",
+            "long","namespace","new","null","object","operator","out","override","params","private","protected",
+            "public","readonly","ref","return","sbyte","sealed","short","sizeof","stackalloc","static","string",
+            "struct","switch","this","throw","true","try","typeof","uint","ulong","unchecked","unsafe","ushort",
+            "using","virtual","void","volatile","while"
+        };
+        static const int COUNT = sizeof(CSHARP_KEYWORDS)/sizeof(CSHARP_KEYWORDS[0]);
+        highlight_with_keywords(fs, win, line, y, CSHARP_KEYWORDS, COUNT);
+    }
 }

--- a/src/syntax_css.c
+++ b/src/syntax_css.c
@@ -4,13 +4,31 @@
 #include "syntax.h"
 #include "files.h"
 
-static const char *CSS_KEYWORDS[] = {
-    "color", "background", "margin", "padding", "border", "font",
-    "display", "position", "top", "left", "right", "bottom",
-    "width", "height", "flex", "grid", "float", "clear"
+#define CSS_KEYWORDS_PATTERN \
+    "^(color|background|margin|padding|border|font|display|position|top|left|right|bottom|width|height|flex|grid|float|clear)\\b"
+
+static SyntaxRegex CSS_PATTERNS[] = {
+    { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+[a-zA-Z%]*)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = CSS_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static const int CSS_KEYWORDS_COUNT = sizeof(CSS_KEYWORDS) / sizeof(CSS_KEYWORDS[0]);
+static int css_regex_compiled = 0;
+static const int CSS_PATTERNS_COUNT = sizeof(CSS_PATTERNS) / sizeof(CSS_PATTERNS[0]);
 
 void highlight_css_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
-    highlight_with_keywords(fs, win, line, y, CSS_KEYWORDS, CSS_KEYWORDS_COUNT);
+    (void)fs;
+    if (!css_regex_compiled) {
+        css_regex_compiled = compile_regex_set(CSS_PATTERNS, CSS_PATTERNS_COUNT);
+    }
+    if (css_regex_compiled > 0) {
+        highlight_regex_line(win, y, 1, line, CSS_PATTERNS, CSS_PATTERNS_COUNT);
+    } else {
+        static const char *CSS_KEYWORDS[] = {
+            "color","background","margin","padding","border","font","display","position","top","left","right","bottom",
+            "width","height","flex","grid","float","clear"
+        };
+        static const int COUNT = sizeof(CSS_KEYWORDS)/sizeof(CSS_KEYWORDS[0]);
+        highlight_with_keywords(fs, win, line, y, CSS_KEYWORDS, COUNT);
+    }
 }

--- a/src/syntax_js.c
+++ b/src/syntax_js.c
@@ -4,15 +4,34 @@
 #include "syntax.h"
 #include "files.h"
 
-static const char *JS_KEYWORDS[] = {
-    "break", "case", "catch", "class", "const", "continue", "debugger", "default",
-    "delete", "do", "else", "export", "extends", "finally", "for", "function",
-    "if", "import", "in", "instanceof", "let", "new", "return", "super",
-    "switch", "this", "throw", "try", "typeof", "var", "void", "while",
-    "with", "yield", "static"
+#define JS_KEYWORDS_PATTERN \
+    "^(break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|function|if|import|in|instanceof|let|new|return|super|switch|this|throw|try|typeof|var|void|while|with|yield|static)\\b"
+
+static SyntaxRegex JS_PATTERNS[] = {
+    { .pattern = "^//.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = JS_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static const int JS_KEYWORDS_COUNT = sizeof(JS_KEYWORDS) / sizeof(JS_KEYWORDS[0]);
+static int js_regex_compiled = 0;
+static const int JS_PATTERNS_COUNT = sizeof(JS_PATTERNS) / sizeof(JS_PATTERNS[0]);
 
 void highlight_js_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
-    highlight_with_keywords(fs, win, line, y, JS_KEYWORDS, JS_KEYWORDS_COUNT);
+    (void)fs;
+    if (!js_regex_compiled) {
+        js_regex_compiled = compile_regex_set(JS_PATTERNS, JS_PATTERNS_COUNT);
+    }
+    if (js_regex_compiled > 0) {
+        highlight_regex_line(win, y, 1, line, JS_PATTERNS, JS_PATTERNS_COUNT);
+    } else {
+        static const char *JS_KEYWORDS[] = {
+            "break","case","catch","class","const","continue","debugger","default",
+            "delete","do","else","export","extends","finally","for","function",
+            "if","import","in","instanceof","let","new","return","super","switch",
+            "this","throw","try","typeof","var","void","while","with","yield","static"
+        };
+        static const int COUNT = sizeof(JS_KEYWORDS)/sizeof(JS_KEYWORDS[0]);
+        highlight_with_keywords(fs, win, line, y, JS_KEYWORDS, COUNT);
+    }
 }

--- a/src/syntax_python.c
+++ b/src/syntax_python.c
@@ -5,90 +5,107 @@
 #include "syntax.h"
 #include "files.h"
 
-#define PYTHON_KEYWORDS_COUNT 35
-static const char *PYTHON_KEYWORDS[PYTHON_KEYWORDS_COUNT] = {
-    "False", "None", "True", "and", "as", "assert", "async", "await", "break",
-    "class", "continue", "def", "del", "elif", "else", "except", "finally",
-    "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal",
-    "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"
+#define PYTHON_KEYWORDS_PATTERN \
+    "^(False|None|True|and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
+
+static SyntaxRegex PYTHON_PATTERNS[] = {
+    { .pattern = "^#.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = PYTHON_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
+static int python_regex_compiled = 0;
+static const int PYTHON_PATTERNS_COUNT = sizeof(PYTHON_PATTERNS)/sizeof(PYTHON_PATTERNS[0]);
 
 void highlight_python_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
-    wattrset(win, COLOR_PAIR(SYNTAX_BG));
-    int length = strlen(line);
     int i = 0;
     int x = 1;
+    wattrset(win, COLOR_PAIR(SYNTAX_BG));
 
-    while (i < length) {
-        if (fs->in_multiline_string) {
-            bool closed;
-            int len = scan_multiline_string(line, i, fs->string_delim, &closed);
-            wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            mvwprintw(win, y, x, "%.*s", len, &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            fs->in_multiline_string = !closed;
-            x += len;
-            i += len;
-            continue;
-        }
+    if (fs->in_multiline_string) {
+        bool closed;
+        int len = scan_multiline_string(line, 0, fs->string_delim, &closed);
+        wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+        mvwprintw(win, y, x, "%.*s", len, line);
+        wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+        fs->in_multiline_string = !closed;
+        x += len;
+        i += len;
+    } else if ((line[0]=='"' || line[0]=='\'') && line[1]==line[0] && line[2]==line[0]) {
+        fs->in_multiline_string = true;
+        fs->string_delim = line[0];
+        bool closed;
+        int len = scan_multiline_string(line, 0, fs->string_delim, &closed);
+        wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+        mvwprintw(win, y, x, "%.*s", len, line);
+        wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+        fs->in_multiline_string = !closed;
+        x += len;
+        i += len;
+    }
 
-        if (isalpha((unsigned char)line[i]) || line[i] == '_') {
-            int len = scan_identifier(line, i);
-            char word[256];
-            if (len >= (int)sizeof(word))
-                len = (int)sizeof(word) - 1;
-            strncpy(word, &line[i], len);
-            word[len] = '\0';
-
-            int is_keyword = 0;
-            for (int j = 0; j < PYTHON_KEYWORDS_COUNT; j++) {
-                if (strcmp(word, PYTHON_KEYWORDS[j]) == 0) {
-                    wattron(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
-                    mvwprintw(win, y, x, "%s", word);
-                    wattroff(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
-                    is_keyword = 1;
-                    break;
-                }
+    if (!python_regex_compiled) {
+        python_regex_compiled = compile_regex_set(PYTHON_PATTERNS, PYTHON_PATTERNS_COUNT);
+    }
+    if (python_regex_compiled > 0) {
+        highlight_regex_line(win, y, x, line + i, PYTHON_PATTERNS, PYTHON_PATTERNS_COUNT);
+    } else {
+        int length = strlen(line);
+        while (i < length) {
+            if (fs->in_multiline_string) {
+                bool closed;
+                int len = scan_multiline_string(line, i, fs->string_delim, &closed);
+                wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+                mvwprintw(win, y, x, "%.*s", len, &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+                fs->in_multiline_string = !closed;
+                x += len;
+                i += len;
+                continue;
             }
-            if (!is_keyword) {
-                mvwprintw(win, y, x, "%s", word);
+            if ((line[i] == '"' || line[i] == '\'' ) && i + 2 < length && line[i+1]==line[i] && line[i+2]==line[i]) {
+                fs->in_multiline_string = true;
+                fs->string_delim = line[i];
+                bool closed;
+                int len = scan_multiline_string(line, i, fs->string_delim, &closed);
+                wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+                mvwprintw(win, y, x, "%.*s", len, &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+                fs->in_multiline_string = !closed;
+                x += len;
+                i += len;
+            } else if (isalpha((unsigned char)line[i]) || line[i] == '_') {
+                int len = scan_identifier(line, i);
+                char word[256];
+                if (len >= (int)sizeof(word))
+                    len = (int)sizeof(word) - 1;
+                strncpy(word, &line[i], len);
+                word[len] = '\0';
+                int is_keyword = 0;
+                static const char *KW[] = {"False","None","True","and","as","assert","async","await","break","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","nonlocal","not","or","pass","raise","return","try","while","with","yield"};
+                for (int j=0;j<35;j++){ if(strcmp(word,KW[j])==0){ is_keyword=1; break; }}
+                if (is_keyword){ wattron(win,COLOR_PAIR(SYNTAX_KEYWORD)|A_BOLD); mvwprintw(win,y,x,"%s",word); wattroff(win,COLOR_PAIR(SYNTAX_KEYWORD)|A_BOLD);} else { mvwprintw(win,y,x,"%s",word); }
+                x+=len; i+=len;
+            } else if (isdigit((unsigned char)line[i])) {
+                int len = scan_number(line, i);
+                wattron(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
+                mvwprintw(win, y, x, "%.*s", len, &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
+                x+=len; i+=len;
+            } else if (line[i] == '#') {
+                wattron(win, COLOR_PAIR(SYNTAX_COMMENT)|A_BOLD);
+                mvwprintw(win, y, x, "%s", &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_COMMENT)|A_BOLD);
+                break;
+            } else if (line[i]=='"' || line[i]=='\'') {
+                bool closed; int len = scan_string(line,i,line[i],&closed);
+                wattron(win,COLOR_PAIR(SYNTAX_STRING)|A_BOLD);
+                mvwprintw(win,y,x,"%.*s",len,&line[i]);
+                wattroff(win,COLOR_PAIR(SYNTAX_STRING)|A_BOLD);
+                x+=len; i+=len;
+            } else {
+                mvwprintw(win,y,x++,"%c",line[i++]);
             }
-            x += len;
-            i += len;
-        } else if (isdigit((unsigned char)line[i])) {
-            int len = scan_number(line, i);
-            wattron(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-            mvwprintw(win, y, x, "%.*s", len, &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-            x += len;
-            i += len;
-        } else if (line[i] == '#') {
-            wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
-            mvwprintw(win, y, x, "%s", &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
-            break;
-        } else if ((line[i] == '"' || line[i] == '\'' ) &&
-                   i + 2 < length && line[i + 1] == line[i] && line[i + 2] == line[i]) {
-            fs->in_multiline_string = true;
-            fs->string_delim = line[i];
-            bool closed;
-            int len = scan_multiline_string(line, i, fs->string_delim, &closed);
-            wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            mvwprintw(win, y, x, "%.*s", len, &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            fs->in_multiline_string = !closed;
-            x += len;
-            i += len;
-        } else if (line[i] == '"' || line[i] == '\'') {
-            bool closed;
-            int len = scan_string(line, i, line[i], &closed);
-            wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            mvwprintw(win, y, x, "%.*s", len, &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            x += len;
-            i += len;
-        } else {
-            mvwprintw(win, y, x++, "%c", line[i++]);
         }
     }
 }

--- a/src/syntax_regex.c
+++ b/src/syntax_regex.c
@@ -1,0 +1,57 @@
+#include "syntax.h"
+#include <string.h>
+
+int compile_regex_set(SyntaxRegex *set, int count) {
+    int ok = 0;
+    for (int i = 0; i < count; i++) {
+        if (!set[i].pattern) {
+            set[i].compiled = 0;
+            continue;
+        }
+        if (regcomp(&set[i].regex, set[i].pattern, REG_EXTENDED)) {
+            set[i].compiled = 0;
+        } else {
+            set[i].compiled = 1;
+            ok++;
+        }
+    }
+    return ok;
+}
+
+void free_regex_set(SyntaxRegex *set, int count) {
+    for (int i = 0; i < count; i++) {
+        if (set[i].compiled) {
+            regfree(&set[i].regex);
+            set[i].compiled = 0;
+        }
+    }
+}
+
+void highlight_regex_line(WINDOW *win, int y, int x_start, const char *line,
+                          SyntaxRegex *patterns, int count) {
+    int x = x_start;
+    wattrset(win, COLOR_PAIR(SYNTAX_BG));
+    const char *p = line;
+    while (*p) {
+        int matched = 0;
+        for (int i = 0; i < count; i++) {
+            if (!patterns[i].compiled)
+                continue;
+            regmatch_t m;
+            if (regexec(&patterns[i].regex, p, 1, &m, 0) == 0 && m.rm_so == 0) {
+                wattron(win, patterns[i].attr);
+                mvwprintw(win, y, x, "%.*s", (int)m.rm_eo, p);
+                wattroff(win, patterns[i].attr);
+                x += m.rm_eo;
+                p += m.rm_eo;
+                matched = 1;
+                break;
+            }
+        }
+        if (!matched) {
+            mvwprintw(win, y, x++, "%c", *p);
+            p++;
+        }
+    }
+}
+

--- a/src/syntax_shell.c
+++ b/src/syntax_shell.c
@@ -5,64 +5,79 @@
 #include "syntax.h"
 #include "files.h"
 
-static const char *SHELL_KEYWORDS[] = {
-    "if", "then", "else", "fi", "for", "in", "do", "done",
-    "while", "case", "esac", "function"
+#define SHELL_KEYWORDS_PATTERN \
+    "^(if|then|else|fi|for|in|do|done|while|case|esac|function)\\b"
+
+static SyntaxRegex SHELL_PATTERNS[] = {
+    { .pattern = "^#.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
+    { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = SHELL_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static const int SHELL_KEYWORDS_COUNT = sizeof(SHELL_KEYWORDS) / sizeof(SHELL_KEYWORDS[0]);
+static int shell_regex_compiled = 0;
+static const int SHELL_PATTERNS_COUNT = sizeof(SHELL_PATTERNS)/sizeof(SHELL_PATTERNS[0]);
 
 void highlight_shell_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     (void)fs;
-    wattrset(win, COLOR_PAIR(SYNTAX_BG));
-    int len = strlen(line);
-    int i = 0;
-    int x = 1;
-    char word[256];
+    if (!shell_regex_compiled) {
+        shell_regex_compiled = compile_regex_set(SHELL_PATTERNS, SHELL_PATTERNS_COUNT);
+    }
+    if (shell_regex_compiled > 0) {
+        highlight_regex_line(win, y, 1, line, SHELL_PATTERNS, SHELL_PATTERNS_COUNT);
+    } else {
+        wattrset(win, COLOR_PAIR(SYNTAX_BG));
+        int len = strlen(line);
+        int i = 0;
+        int x = 1;
+        char word[256];
+        static const char *SHELL_KEYWORDS[] = {"if","then","else","fi","for","in","do","done","while","case","esac","function"};
+        static const int COUNT = sizeof(SHELL_KEYWORDS)/sizeof(SHELL_KEYWORDS[0]);
 
-    while (i < len) {
-        if (line[i] == '#') {
-            wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
-            mvwprintw(win, y, x, "%s", &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
-            break;
-        } else if (line[i] == '"' || line[i] == '\'') {
-            bool closed;
-            int l = scan_string(line, i, line[i], &closed);
-            wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            mvwprintw(win, y, x, "%.*s", l, &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
-            x += l;
-            i += l;
-        } else if (isdigit((unsigned char)line[i])) {
-            int l = scan_number(line, i);
-            wattron(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-            mvwprintw(win, y, x, "%.*s", l, &line[i]);
-            wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
-            x += l;
-            i += l;
-        } else if (isalpha((unsigned char)line[i]) || line[i] == '_') {
-            int wlen = scan_identifier(line, i);
-            if (wlen >= (int)sizeof(word))
-                wlen = (int)sizeof(word) - 1;
-            strncpy(word, &line[i], wlen);
-            word[wlen] = '\0';
-            int is_kw = 0;
-            for (int k = 0; k < SHELL_KEYWORDS_COUNT; k++) {
-                if (strcmp(word, SHELL_KEYWORDS[k]) == 0) {
-                    wattron(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
-                    mvwprintw(win, y, x, "%s", word);
-                    wattroff(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
-                    is_kw = 1;
-                    break;
+        while (i < len) {
+            if (line[i] == '#') {
+                wattron(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+                mvwprintw(win, y, x, "%s", &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD);
+                break;
+            } else if (line[i] == '"' || line[i] == '\'' ) {
+                bool closed;
+                int l = scan_string(line, i, line[i], &closed);
+                wattron(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+                mvwprintw(win, y, x, "%.*s", l, &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_STRING) | A_BOLD);
+                x += l;
+                i += l;
+            } else if (isdigit((unsigned char)line[i])) {
+                int l = scan_number(line, i);
+                wattron(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
+                mvwprintw(win, y, x, "%.*s", l, &line[i]);
+                wattroff(win, COLOR_PAIR(SYNTAX_TYPE) | A_BOLD);
+                x += l;
+                i += l;
+            } else if (isalpha((unsigned char)line[i]) || line[i] == '_') {
+                int wlen = scan_identifier(line, i);
+                if (wlen >= (int)sizeof(word))
+                    wlen = (int)sizeof(word) - 1;
+                strncpy(word, &line[i], wlen);
+                word[wlen] = '\0';
+                int is_kw = 0;
+                for (int k = 0; k < COUNT; k++) {
+                    if (strcmp(word, SHELL_KEYWORDS[k]) == 0) {
+                        wattron(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
+                        mvwprintw(win, y, x, "%s", word);
+                        wattroff(win, COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD);
+                        is_kw = 1;
+                        break;
+                    }
                 }
+                if (!is_kw) {
+                    mvwprintw(win, y, x, "%s", word);
+                }
+                x += wlen;
+                i += wlen;
+            } else {
+                mvwprintw(win, y, x++, "%c", line[i++]);
             }
-            if (!is_kw) {
-                mvwprintw(win, y, x, "%s", word);
-            }
-            x += wlen;
-            i += wlen;
-        } else {
-            mvwprintw(win, y, x++, "%c", line[i++]);
         }
     }
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -31,8 +31,9 @@ gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_c.c -o obj_test/syntax_c.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_csharp.c -o obj_test/syntax_csharp.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_common.c -o obj_test/syntax_common.o
+gcc -Wall -Wextra -std=c99 -g -Isrc -c src/syntax_regex.c -o obj_test/syntax_regex.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_long_identifier.c \
-    obj_test/syntax_c.o obj_test/syntax_csharp.o obj_test/syntax_common.o -lncurses -o test_long_identifier
+    obj_test/syntax_c.o obj_test/syntax_csharp.o obj_test/syntax_common.o obj_test/syntax_regex.o -lncurses -o test_long_identifier
 ./test_long_identifier
 
 # build and run HTML comment boundary test
@@ -41,41 +42,47 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_js.c -o obj
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o obj_test/syntax_css.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c \
     obj_test/syntax_html.o obj_test/syntax_js.o obj_test/syntax_css.o \
-    obj_test/syntax_common.o obj_test/files.o -lncurses -o test_html_comment
+    obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_html_comment
 ./test_html_comment
 
 # build and run python syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_python.c -o obj_test/syntax_python.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_python_syntax.c \
-    obj_test/syntax_python.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_python_syntax
+    obj_test/syntax_python.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_python_syntax
 ./test_python_syntax
 
 # build and run JavaScript syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_js.c -o obj_test/syntax_js.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_js_syntax.c \
-    obj_test/syntax_js.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_js_syntax
+    obj_test/syntax_js.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_js_syntax
 ./test_js_syntax
 
 # build and run CSS syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o obj_test/syntax_css.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_css_syntax.c \
-    obj_test/syntax_css.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_css_syntax
+    obj_test/syntax_css.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_css_syntax
 ./test_css_syntax
 
 # build and run HTML nested syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_nested.c \
     obj_test/syntax_html.o obj_test/syntax_js.o obj_test/syntax_css.o \
-    obj_test/syntax_common.o obj_test/files.o -lncurses -o test_html_nested
+    obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_html_nested
 ./test_html_nested
 
 # build and run shell syntax highlighting test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_shell.c -o obj_test/syntax_shell.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_shell_syntax.c \
-    obj_test/syntax_shell.o obj_test/syntax_common.o obj_test/files.o -lncurses -o test_shell_syntax
+    obj_test/syntax_shell.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_shell_syntax
 ./test_shell_syntax
 
 # build and run shebang detection test (uses stubs for other functions)
 gcc -Wall -Wextra -std=c99 -g -Isrc -c tests/stubs_file_ops.c -o obj_test/stubs_file_ops.o
 gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_shebang_detection.c src/file_ops.c \
-    obj_test/stubs_file_ops.o -lncurses -o test_shebang_detection
+    obj_test/stubs_file_ops.o obj_test/syntax_regex.o -lncurses -o test_shebang_detection
 ./test_shebang_detection
+
+# build and run regex complex construct test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_c.c -o obj_test/syntax_c.o
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_regex_complex.c \
+    obj_test/syntax_c.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_regex_complex
+./test_regex_complex

--- a/tests/test_regex_complex.c
+++ b/tests/test_regex_complex.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <ncurses.h>
+#undef wattron
+#undef wattroff
+#undef wattrset
+#undef mvwprintw
+#include "syntax.h"
+#include "files.h"
+
+typedef struct { int dummy; } SIMPLE_WIN;
+static int current_attr;
+static int call_index;
+static char printed[200][64];
+static int attrs[200];
+
+WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int wattron(WINDOW*w,int a){(void)w;current_attr|=a;return 0;}
+int wattroff(WINDOW*w,int a){(void)w;current_attr&=~a;return 0;}
+int wattrset(WINDOW*w,int a){(void)w;current_attr=a;return 0;}
+int wattr_on(WINDOW*w,attr_t a,void*opts){(void)w;(void)opts;current_attr|=a;return 0;}
+int wattr_off(WINDOW*w,attr_t a,void*opts){(void)w;(void)opts;current_attr&=~a;return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char *fmt,...){(void)w;(void)y;(void)x;va_list ap;va_start(ap,fmt);vsnprintf(printed[call_index],sizeof(printed[call_index]),fmt,ap);va_end(ap);attrs[call_index]=current_attr;call_index++;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    WINDOW *w = newwin(1,1,0,0);
+    const char *line = "const char *s = \"hello\"; int x = 0x1A;";
+    highlight_c_syntax(&fs,w,line,0);
+    int found_str=0, found_hex=0;
+    for(int i=0;i<call_index;i++){
+        if(strcmp(printed[i],"\"hello\"")==0){
+            assert(attrs[i] & COLOR_PAIR(SYNTAX_STRING));
+            found_str=1;
+        }
+        if(strcmp(printed[i],"0x1A")==0){
+            assert(attrs[i] & COLOR_PAIR(SYNTAX_TYPE));
+            found_hex=1;
+        }
+    }
+    assert(found_str && found_hex);
+    delwin(w);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add helper regex module for syntax highlighting
- convert language highlighters to use regex patterns with fallback to old method
- support highlighting of hex numbers and strings via regex
- test regex matching of complex constructs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a3df4ecac8324b6f5a1762ad0bc32