### PR TITLE
Add theme preview in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Vento currently supports the following features:
   keys or mouse clicks to choose options. Mouse support can be enabled or
   disabled in this dialog, and all dialogs accept mouse input.
 - **Theme Selection**: Choose from predefined color themes located in the
-  `themes/` directory.
+  `themes/` directory. The picker shows a live preview of the highlighted
+  colors while you navigate the list.
 - **Basic Syntax Highlighting**: Simple syntax highlighting for C, HTML, and Python files.
 - **Status Bar**: Displays the current line and column number.
 - **Scroll Bar**: Indicates your position within the document.

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -81,7 +81,7 @@ enable_mouse - enable or disable mouse support
 .IP \[bu] 2
 show_line_numbers - display line numbers in the editor
 .PP
-Set \fBtheme\fP to the basename of a file in the \fBthemes\fP directory (without the \fB.theme\fP extension). Colors from that theme are loaded before applying any individual color overrides. These options can also be modified using the Settings dialog found under \fBFile\fP -> \fBSettings\fP. Exiting the dialog automatically writes the configuration back to \fB~/.ventorc\fP.
+Set \fBtheme\fP to the basename of a file in the \fBthemes\fP directory (without the \fB.theme\fP extension). Colors from that theme are loaded before applying any individual color overrides. While browsing themes, the picker displays a preview of the selected colors. These options can also be modified using the Settings dialog found under \fBFile\fP -> \fBSettings\fP. Exiting the dialog automatically writes the configuration back to \fB~/.ventorc\fP.
 .SH KEYBOARD SHORTCUTS
 .TP 
 .B CTRL-H

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -46,6 +46,50 @@ static const Option options[] = {
 
 #define FIELD_COUNT ((int)(sizeof(options) / sizeof(options[0])))
 
+static void render_theme_sample(const AppConfig *cfg, WINDOW *win, int row) {
+    if (!cfg || !win)
+        return;
+
+    short bg = get_color_code(cfg->background_color);
+    short kw = get_color_code(cfg->keyword_color);
+    short cm = get_color_code(cfg->comment_color);
+    short st = get_color_code(cfg->string_color);
+    short ty = get_color_code(cfg->type_color);
+    short sy = get_color_code(cfg->symbol_color);
+
+    const short base = 60;
+    init_pair(base, COLOR_WHITE, bg);
+    init_pair(base + 1, kw, bg);
+    init_pair(base + 2, cm, bg);
+    init_pair(base + 3, st, bg);
+    init_pair(base + 4, ty, bg);
+    init_pair(base + 5, sy, bg);
+
+    int width = getmaxx(win) - 2;
+    wattron(win, COLOR_PAIR(base));
+    mvwhline(win, row, 1, ' ', width);
+    int col = 2;
+
+    wattron(win, COLOR_PAIR(base + 1) | A_BOLD);
+    mvwprintw(win, row, col, "keyword ");
+    col = getcurx(win);
+
+    wattron(win, COLOR_PAIR(base + 2));
+    mvwprintw(win, row, col, "comment ");
+    col = getcurx(win);
+
+    wattron(win, COLOR_PAIR(base + 3));
+    mvwprintw(win, row, col, "string ");
+    col = getcurx(win);
+
+    wattron(win, COLOR_PAIR(base + 4));
+    mvwprintw(win, row, col, "type ");
+    col = getcurx(win);
+
+    wattron(win, COLOR_PAIR(base + 5));
+    mvwprintw(win, row, col, "symbol");
+}
+
 static void edit_option(AppConfig *cfg, WINDOW *win, const Option *opt) {
     if (opt->type == OPT_BOOL) {
         int *val = (int *)((char *)cfg + opt->offset);
@@ -242,6 +286,7 @@ const char *select_color(const char *current, WINDOW *parent) {
             mvwprintw(win, i + 1, 1, "%*s", win_width - 2, "");
         }
 
+
         mvwprintw(win, win_height - 1, 1, "Arrows: move  Enter: select  ESC: cancel");
         wrefresh(win);
 
@@ -407,7 +452,7 @@ const char *select_theme(const char *current, WINDOW *parent) {
         werase(win);
         box(win, 0, 0);
 
-        int max_display = win_height - 2;
+        int max_display = win_height - 3;
         if (highlight < start)
             start = highlight;
         if (highlight >= start + max_display)
@@ -424,6 +469,10 @@ const char *select_theme(const char *current, WINDOW *parent) {
         for (int i = count - start; i < max_display; ++i) {
             mvwprintw(win, i + 1, 1, "%*s", win_width - 2, "");
         }
+
+        AppConfig preview = app_config;
+        load_theme(names[highlight], &preview);
+        render_theme_sample(&preview, win, win_height - 2);
 
         mvwprintw(win, win_height - 1, 1,
                   "Arrows: move  Enter: select  ESC: cancel");
@@ -461,7 +510,7 @@ const char *select_theme(const char *current, WINDOW *parent) {
                 getbegyx(win, wy, wx);
                 int row = ev.y - wy - 1;
                 int col = ev.x - wx - 1;
-                int max_display = win_height - 2;
+                int max_display = win_height - 3;
                 if (row >= 0 && row < max_display &&
                     col >= 0 && col < win_width - 2) {
                     int idx = start + row;


### PR DESCRIPTION
## Summary
- show a preview when selecting themes
- document the preview in README and man page

## Testing
- `make test` *(fails: "sh tests/run_tests.sh")*

------
https://chatgpt.com/codex/tasks/task_e_683a4cd28ab083249972631855929195