### PR TITLE
Ensure search replacement sets modified flag

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -151,6 +151,7 @@ static void replace_in_line(FileState *fs, int line, char *pos,
     push(&fs->undo_stack, change);
     strncpy(fs->text_buffer[line], new_line, fs->line_capacity - 1);
     fs->text_buffer[line][fs->line_capacity - 1] = '\0';
+    fs->modified = true;
     mark_comment_state_dirty(fs);
 }
 
@@ -172,6 +173,7 @@ void replace_next_occurrence(FileState *fs, const char *search,
     }
 
     replace_in_line(fs, found_line, found_position, search, replacement);
+    fs->modified = true;
 
     if (fs->line_count <= lines_per_screen) {
         fs->start_line = 0;
@@ -201,6 +203,7 @@ void replace_next_occurrence(FileState *fs, const char *search,
 
 void replace_all_occurrences(FileState *fs, const char *search,
                              const char *replacement) {
+    bool replaced = false;
     for (int line = 0; line < fs->line_count; ++line) {
         char *line_text = fs->text_buffer[line];
         char *pos = strstr(line_text, search);
@@ -265,7 +268,11 @@ void replace_all_occurrences(FileState *fs, const char *search,
         fs->text_buffer[line][fs->line_capacity - 1] = '\0';
         free(new_line);
         mark_comment_state_dirty(fs);
+        replaced = true;
     }
+
+    if (replaced)
+        fs->modified = true;
 
     werase(text_win);
     box(text_win, 0, 0);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -90,3 +90,7 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_regex_complex.
 # build and run search highlight test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_search_highlight.c src/search.c -lncurses -o test_search_highlight
 ./test_search_highlight
+
+# build and run replace modified test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc tests/test_replace_modified.c src/search.c -lncurses -o test_replace_modified
+./test_replace_modified

--- a/tests/test_replace_modified.c
+++ b/tests/test_replace_modified.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#undef mvprintw
+#undef wmove
+#undef wrefresh
+#undef werase
+#undef box
+
+#include "files.h"
+#include "search.h"
+#include "editor.h"
+
+/* minimal WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int werase(WINDOW*w){(void)w;return 0;}
+int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
+int wmove(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int mvprintw(int y,int x,const char*fmt,...){(void)y;(void)x;(void)fmt;return 0;}
+int wborder(WINDOW*w,chtype ls,chtype rs,chtype ts,chtype bs,chtype tl,chtype tr,chtype bl,chtype br){(void)w;(void)ls;(void)rs;(void)ts;(void)bs;(void)tl;(void)tr;(void)bl;(void)br;return 0;}
+
+/* required globals and stubs */
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+char search_text[256];
+int show_find_dialog(char*out,int sz,const char*def){(void)out;(void)sz;(void)def;return 0;}
+int show_replace_dialog(char*s,int ss,char*r,int rs){(void)s;(void)ss;(void)r;(void)rs;return 0;}
+
+void draw_text_buffer(FileState*fs, WINDOW*w){(void)fs;(void)w;}
+void push(Node **stack, Change change){(void)stack; free(change.old_text); free(change.new_text);} 
+void mark_comment_state_dirty(FileState*fs){(void)fs;}
+int get_line_number_offset(FileState*fs){(void)fs;return 0;}
+
+int main(void){
+    FileState fs = {0};
+    fs.line_capacity = 64;
+    fs.max_lines = 2;
+    fs.text_buffer = calloc(fs.max_lines, sizeof(char*));
+    for(int i=0;i<fs.max_lines;i++) fs.text_buffer[i]=calloc(fs.line_capacity, sizeof(char));
+    strcpy(fs.text_buffer[0], "foo bar");
+    fs.line_count = 1;
+    fs.cursor_x = 0; fs.cursor_y = 0;
+    fs.start_line = 0;
+
+    text_win = newwin(5,5,0,0);
+    active_file = &fs;
+
+    fs.modified = false;
+    replace_next_occurrence(&fs, "foo", "baz");
+
+    assert(strcmp(fs.text_buffer[0], "baz bar") == 0);
+    assert(fs.modified);
+
+    delwin(text_win);
+    for(int i=0;i<fs.max_lines;i++) free(fs.text_buffer[i]);
+    free(fs.text_buffer);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- mark file as modified inside `replace_in_line`
- ensure `replace_next_occurrence` and `replace_all_occurrences` update the modified flag when replacements occur
- add test to verify the modified flag changes after replacement
- run new test from `run_tests.sh`

## Testing
- `./tests/run_tests.sh > /tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_683a513d05e48324983f835a89ba9587