### PR TITLE
Set modified flag on undo/redo

### DIFF
--- a/src/undo.c
+++ b/src/undo.c
@@ -76,6 +76,7 @@ void undo(FileState *fs) {
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
     wrefresh(text_win);
+    fs->modified = true;
 }
 
 void redo(FileState *fs) {
@@ -117,6 +118,7 @@ void redo(FileState *fs) {
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
+    fs->modified = true;
 }
 
 void free_stack(Node *stack) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -94,3 +94,7 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_search_highlig
 # build and run replace modified test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc tests/test_replace_modified.c src/search.c -lncurses -o test_replace_modified
 ./test_replace_modified
+
+# build and run undo/redo modified flag test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_undo_redo_modified.c src/undo.c -lncurses -o test_undo_redo_modified
+./test_undo_redo_modified

--- a/tests/test_undo_redo_modified.c
+++ b/tests/test_undo_redo_modified.c
@@ -1,0 +1,56 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#undef wrefresh
+#undef werase
+#undef box
+
+#include "undo.h"
+#include "files.h"
+
+/* stub simple WINDOW functions */
+int wrefresh(WINDOW *w){ (void)w; return 0; }
+int werase(WINDOW *w){ (void)w; return 0; }
+int box(WINDOW *w, chtype a, chtype b){ (void)w; (void)a; (void)b; return 0; }
+
+void draw_text_buffer(FileState *fs, WINDOW *win){ (void)fs; (void)win; }
+void allocation_failed(const char *msg){ (void)msg; abort(); }
+int ensure_line_capacity(FileState *fs, int min_needed){ (void)fs; (void)min_needed; return 0; }
+
+/* globals referenced by undo.c */
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+
+int main(void){
+    FileState fs = {0};
+    fs.line_capacity = 32;
+    fs.max_lines = 1;
+    fs.text_buffer = calloc(fs.max_lines, sizeof(char*));
+    fs.text_buffer[0] = calloc(fs.line_capacity, sizeof(char));
+    strcpy(fs.text_buffer[0], "new");
+    fs.line_count = 1;
+
+    active_file = &fs;
+
+    /* prepare undo stack with edit change */
+    Change ch = {0, strdup("old"), strdup("new")};
+    push(&fs.undo_stack, ch);
+
+    fs.modified = false;
+    undo(&fs);
+    assert(strcmp(fs.text_buffer[0], "old") == 0);
+    assert(fs.modified);
+
+    fs.modified = false;
+    redo(&fs);
+    assert(strcmp(fs.text_buffer[0], "new") == 0);
+    assert(fs.modified);
+
+    free_stack(fs.undo_stack);
+    free_stack(fs.redo_stack);
+    free(fs.text_buffer[0]);
+    free(fs.text_buffer);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- mark buffer as modified after undo/redo
- add test verifying undo/redo update the modified flag
- run undo/redo test in test suite

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a52b57b2883249256058a3abe63f1