### PR TITLE
Implement syntax cleanup routine

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -64,6 +64,7 @@ void cleanup_on_exit(FileManager *fm) {
         freeMenus();
         return;
     }
+    syntax_cleanup();
     for (int i = 0; i < fm->count; ++i) {
         FileState *fs = fm->files[i];
         if (!fs) continue;

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -31,3 +31,54 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
             break;
     }
 }
+
+/* Cleanup compiled regular expressions for all syntax modules */
+void syntax_cleanup(void) {
+    /* C syntax */
+    extern SyntaxRegex C_PATTERNS[];
+    extern const int C_PATTERNS_COUNT;
+    extern int c_regex_compiled;
+    if (c_regex_compiled) {
+        free_regex_set(C_PATTERNS, C_PATTERNS_COUNT);
+    }
+
+    /* C# syntax */
+    extern SyntaxRegex CSHARP_PATTERNS[];
+    extern const int CSHARP_PATTERNS_COUNT;
+    extern int csharp_regex_compiled;
+    if (csharp_regex_compiled) {
+        free_regex_set(CSHARP_PATTERNS, CSHARP_PATTERNS_COUNT);
+    }
+
+    /* JavaScript syntax */
+    extern SyntaxRegex JS_PATTERNS[];
+    extern const int JS_PATTERNS_COUNT;
+    extern int js_regex_compiled;
+    if (js_regex_compiled) {
+        free_regex_set(JS_PATTERNS, JS_PATTERNS_COUNT);
+    }
+
+    /* CSS syntax */
+    extern SyntaxRegex CSS_PATTERNS[];
+    extern const int CSS_PATTERNS_COUNT;
+    extern int css_regex_compiled;
+    if (css_regex_compiled) {
+        free_regex_set(CSS_PATTERNS, CSS_PATTERNS_COUNT);
+    }
+
+    /* Python syntax */
+    extern SyntaxRegex PYTHON_PATTERNS[];
+    extern const int PYTHON_PATTERNS_COUNT;
+    extern int python_regex_compiled;
+    if (python_regex_compiled) {
+        free_regex_set(PYTHON_PATTERNS, PYTHON_PATTERNS_COUNT);
+    }
+
+    /* Shell syntax */
+    extern SyntaxRegex SHELL_PATTERNS[];
+    extern const int SHELL_PATTERNS_COUNT;
+    extern int shell_regex_compiled;
+    if (shell_regex_compiled) {
+        free_regex_set(SHELL_PATTERNS, SHELL_PATTERNS_COUNT);
+    }
+}

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -57,4 +57,7 @@ int scan_number(const char *line, int start);
 int scan_string(const char *line, int start, char quote, bool *closed);
 int scan_multiline_string(const char *line, int start, char quote, bool *closed);
 
+/* Free any compiled regular expressions */
+void syntax_cleanup(void);
+
 #endif // SYNTAX_H

--- a/src/syntax_c.c
+++ b/src/syntax_c.c
@@ -10,15 +10,15 @@
     "struct|switch|typedef|union|unsigned|void|volatile|while|_Alignas|_Alignof|_Atomic|" \
     "_Bool|_Complex|_Generic|_Imaginary|_Noreturn|_Static_assert|_Thread_local)\\b"
 
-static SyntaxRegex C_PATTERNS[] = {
+SyntaxRegex C_PATTERNS[] = {
     { .pattern = "^//.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = C_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static int c_regex_compiled = 0;
-static const int C_PATTERNS_COUNT = sizeof(C_PATTERNS) / sizeof(C_PATTERNS[0]);
+int c_regex_compiled = 0;
+const int C_PATTERNS_COUNT = sizeof(C_PATTERNS) / sizeof(C_PATTERNS[0]);
 
 void highlight_c_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     if (!c_regex_compiled) {

--- a/src/syntax_csharp.c
+++ b/src/syntax_csharp.c
@@ -7,15 +7,15 @@
 #define CSHARP_KEYWORDS_PATTERN \
     "^(abstract|as|base|bool|break|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|do|double|else|enum|event|explicit|extern|false|finally|fixed|float|for|foreach|goto|if|implicit|in|int|interface|internal|is|lock|long|namespace|new|null|object|operator|out|override|params|private|protected|public|readonly|ref|return|sbyte|sealed|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unsafe|ushort|using|virtual|void|volatile|while)\\b"
 
-static SyntaxRegex CSHARP_PATTERNS[] = {
+SyntaxRegex CSHARP_PATTERNS[] = {
     { .pattern = "^//.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = CSHARP_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static int csharp_regex_compiled = 0;
-static const int CSHARP_PATTERNS_COUNT = sizeof(CSHARP_PATTERNS)/sizeof(CSHARP_PATTERNS[0]);
+int csharp_regex_compiled = 0;
+const int CSHARP_PATTERNS_COUNT = sizeof(CSHARP_PATTERNS)/sizeof(CSHARP_PATTERNS[0]);
 
 void highlight_csharp_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     (void)fs;

--- a/src/syntax_css.c
+++ b/src/syntax_css.c
@@ -7,14 +7,14 @@
 #define CSS_KEYWORDS_PATTERN \
     "^(color|background|margin|padding|border|font|display|position|top|left|right|bottom|width|height|flex|grid|float|clear)\\b"
 
-static SyntaxRegex CSS_PATTERNS[] = {
+SyntaxRegex CSS_PATTERNS[] = {
     { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+[a-zA-Z%]*)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = CSS_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static int css_regex_compiled = 0;
-static const int CSS_PATTERNS_COUNT = sizeof(CSS_PATTERNS) / sizeof(CSS_PATTERNS[0]);
+int css_regex_compiled = 0;
+const int CSS_PATTERNS_COUNT = sizeof(CSS_PATTERNS) / sizeof(CSS_PATTERNS[0]);
 
 void highlight_css_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     (void)fs;

--- a/src/syntax_js.c
+++ b/src/syntax_js.c
@@ -7,15 +7,15 @@
 #define JS_KEYWORDS_PATTERN \
     "^(break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|function|if|import|in|instanceof|let|new|return|super|switch|this|throw|try|typeof|var|void|while|with|yield|static)\\b"
 
-static SyntaxRegex JS_PATTERNS[] = {
+SyntaxRegex JS_PATTERNS[] = {
     { .pattern = "^//.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^/\\*.*\\*/", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = JS_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static int js_regex_compiled = 0;
-static const int JS_PATTERNS_COUNT = sizeof(JS_PATTERNS) / sizeof(JS_PATTERNS[0]);
+int js_regex_compiled = 0;
+const int JS_PATTERNS_COUNT = sizeof(JS_PATTERNS) / sizeof(JS_PATTERNS[0]);
 
 void highlight_js_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     (void)fs;

--- a/src/syntax_python.c
+++ b/src/syntax_python.c
@@ -8,14 +8,14 @@
 #define PYTHON_KEYWORDS_PATTERN \
     "^(False|None|True|and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
 
-static SyntaxRegex PYTHON_PATTERNS[] = {
+SyntaxRegex PYTHON_PATTERNS[] = {
     { .pattern = "^#.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = PYTHON_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static int python_regex_compiled = 0;
-static const int PYTHON_PATTERNS_COUNT = sizeof(PYTHON_PATTERNS)/sizeof(PYTHON_PATTERNS[0]);
+int python_regex_compiled = 0;
+const int PYTHON_PATTERNS_COUNT = sizeof(PYTHON_PATTERNS)/sizeof(PYTHON_PATTERNS[0]);
 
 void highlight_python_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     int i = 0;

--- a/src/syntax_shell.c
+++ b/src/syntax_shell.c
@@ -8,14 +8,14 @@
 #define SHELL_KEYWORDS_PATTERN \
     "^(if|then|else|fi|for|in|do|done|while|case|esac|function)\\b"
 
-static SyntaxRegex SHELL_PATTERNS[] = {
+SyntaxRegex SHELL_PATTERNS[] = {
     { .pattern = "^#.*", .attr = COLOR_PAIR(SYNTAX_COMMENT) | A_BOLD },
     { .pattern = "^(\"([^\"\\]|\\.)*\"|'([^'\\]|\\.)*')", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^(0[xX][0-9A-Fa-f]+|[0-9]+)", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = SHELL_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
 };
-static int shell_regex_compiled = 0;
-static const int SHELL_PATTERNS_COUNT = sizeof(SHELL_PATTERNS)/sizeof(SHELL_PATTERNS[0]);
+int shell_regex_compiled = 0;
+const int SHELL_PATTERNS_COUNT = sizeof(SHELL_PATTERNS)/sizeof(SHELL_PATTERNS[0]);
 
 void highlight_shell_syntax(FileState *fs, WINDOW *win, const char *line, int y) {
     (void)fs;


### PR DESCRIPTION
## Summary
- add a `syntax_cleanup` helper that frees compiled regex patterns
- make regex pattern data accessible across files
- call `syntax_cleanup` from `cleanup_on_exit`

## Testing
- `make test`
- `sh tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a53b17494832485fd41da40988b39