### PR TITLE
Fix dialog window bounds

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -295,8 +295,14 @@ void replace(FileState *fs) {
     int opt_count = 3;
     int win_height = opt_count + 2;
     int win_width = 20;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
     int win_y = (LINES - win_height) / 2;
     int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
     WINDOW *win = newwin(win_height, win_width, win_y, win_x);
     keypad(win, TRUE);
     box(win, 0, 0);

--- a/src/ui.c
+++ b/src/ui.c
@@ -12,8 +12,14 @@ void create_dialog(const char *message, char *output, int max_input_len) {
     /* Use existing color pairs configured by the application */
 
     int win_y = LINES / 3;
-    int win_x = (COLS - strlen(message) - 30) / 2;
-    int win_width = strlen(message) + 30;
+    int win_width = (int)strlen(message) + 30;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
+    int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
     int win_height = 7;
 
     WINDOW *dialog_win = newwin(win_height, win_width, win_y, win_x);
@@ -78,8 +84,14 @@ int show_find_dialog(char *output, int max_input_len, const char *preset) {
     /* Use configured color pairs for dialog display */
 
     int win_y = LINES / 3;
-    int win_x = (COLS - 40) / 2;
     int win_width = 40;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
+    int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
     int win_height = 7;
 
     WINDOW *dialog_win = newwin(win_height, win_width, win_y, win_x);

--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -8,15 +8,24 @@
 WINDOW *create_centered_window(int height, int width, WINDOW *parent) {
     int win_y, win_x;
 
+    if (width > COLS - 2)
+        width = COLS - 2;
+    if (width < 2)
+        width = 2;
+
     if (parent) {
         int py, px, ph, pw;
         getbegyx(parent, py, px);
         getmaxyx(parent, ph, pw);
         win_y = py + (ph - height) / 2;
         win_x = px + (pw - width) / 2;
+        if (win_x < 0)
+            win_x = 0;
     } else {
         win_y = (LINES - height) / 2;
         win_x = (COLS - width) / 2;
+        if (win_x < 0)
+            win_x = 0;
     }
 
     WINDOW *win = newwin(height, width, win_y, win_x);
@@ -39,8 +48,14 @@ int show_message(const char *msg) {
     curs_set(0);
     int win_height = 3;
     int win_width = (int)strlen(msg) + 4;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
     int win_y = (LINES - win_height) / 2;
     int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
 
     WINDOW *win = newwin(win_height, win_width, win_y, win_x);
     box(win, 0, 0);
@@ -72,6 +87,10 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         getmaxyx(parent, ph, pw);
         win_height = ph - 4;
         win_width = pw - 4;
+        if (win_width > COLS - 2)
+            win_width = COLS - 2;
+        if (win_width < 2)
+            win_width = 2;
         win = create_popup_window(win_height, win_width, parent);
         if (!win) {
             curs_set(1);
@@ -81,6 +100,10 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
     } else {
         win_height = LINES - 4;
         win_width = COLS - 4;
+        if (win_width > COLS - 2)
+            win_width = COLS - 2;
+        if (win_width < 2)
+            win_width = 2;
         win = create_popup_window(win_height, win_width, NULL);
         if (!win) {
             curs_set(1);

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -73,6 +73,10 @@ static int file_dialog_loop(char *path, int max_len,
 
     int win_height = LINES - 4;
     int win_width = COLS - 4;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
     if (!win) {
         curs_set(1);

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -8,8 +8,12 @@ void show_help() {
     curs_set(0);
     int win_height = 18;
     int win_width = COLS - 40;
+    if (win_width > COLS - 2 || win_width < 2)
+        win_width = COLS - 2;
     int win_y = (LINES - win_height) / 2;
     int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
 
     WINDOW *help_win = newwin(win_height, win_width, win_y, win_x);
     keypad(help_win, TRUE);
@@ -65,8 +69,12 @@ void show_about() {
     curs_set(0);
     int win_height = 10;
     int win_width = COLS - 20;
+    if (win_width > COLS - 2 || win_width < 2)
+        win_width = COLS - 2;
     int win_y = (LINES - win_height) / 2;
     int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
 
     WINDOW *about_win = newwin(win_height, win_width, win_y, win_x);
     keypad(about_win, TRUE);
@@ -93,8 +101,12 @@ void show_warning_dialog() {
     curs_set(0);
     int win_height = 7;
     int win_width = COLS - 20;
+    if (win_width > COLS - 2 || win_width < 2)
+        win_width = COLS - 2;
     int win_y = (LINES - win_height) / 2;
     int win_x = (COLS - win_width) / 2;
+    if (win_x < 0)
+        win_x = 0;
 
     WINDOW *warning_win = newwin(win_height, win_width, win_y, win_x);
     keypad(warning_win, TRUE);

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -143,6 +143,10 @@ int show_settings_dialog(AppConfig *cfg) {
     int win_width = longest + 4;
     if (win_width < 50)
         win_width = 50;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
 
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
     if (!win) {
@@ -246,6 +250,10 @@ const char *select_color(const char *current, WINDOW *parent) {
         getmaxyx(parent, ph, pw);
         win_height = ph - 4;
         win_width = pw - 4;
+        if (win_width > COLS - 2)
+            win_width = COLS - 2;
+        if (win_width < 2)
+            win_width = 2;
         win = create_popup_window(win_height, win_width, parent);
         if (!win) {
             curs_set(1);
@@ -255,6 +263,10 @@ const char *select_color(const char *current, WINDOW *parent) {
     } else {
         win_height = LINES - 4;
         win_width = COLS - 4;
+        if (win_width > COLS - 2)
+            win_width = COLS - 2;
+        if (win_width < 2)
+            win_width = 2;
         win = create_popup_window(win_height, win_width, NULL);
         if (!win) {
             curs_set(1);
@@ -432,10 +444,18 @@ const char *select_theme(const char *current, WINDOW *parent) {
         getmaxyx(parent, ph, pw);
         win_height = ph - 4;
         win_width = pw - 4;
+        if (win_width > COLS - 2)
+            win_width = COLS - 2;
+        if (win_width < 2)
+            win_width = 2;
         win = create_popup_window(win_height, win_width, parent);
     } else {
         win_height = LINES - 4;
         win_width = COLS - 4;
+        if (win_width > COLS - 2)
+            win_width = COLS - 2;
+        if (win_width < 2)
+            win_width = 2;
         win = create_popup_window(win_height, win_width, NULL);
     }
     if (!win) {
@@ -562,6 +582,10 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
     int own = 0;
     int win_height = 6;
     int win_width = 20;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
     WINDOW *win;
     if (parent) {
         win = create_popup_window(win_height, win_width, parent);


### PR DESCRIPTION
## Summary
- prevent dialogs from exceeding screen width by clamping win_width to `COLS-2`
- adjust dialog x-position if too far left
- apply same bounds checks to common popup helpers
- update various dialogs to use the new clamping

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a55e15b6c8324b4b4d0d419dcf119