### PR TITLE
Handle terminals without color support

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -237,22 +237,26 @@ void config_load(AppConfig *cfg) {
     show_line_numbers = cfg->show_line_numbers;
 
     if (enable_color) {
-        start_color();
-        use_default_colors();
-        short code;
-        short bg = get_color_code(cfg->background_color);
-        if (bg == -1) bg = -1;
-        init_pair(SYNTAX_BG, COLOR_WHITE, bg);
-        code = get_color_code(cfg->keyword_color);
-        if (code != -1) init_pair(SYNTAX_KEYWORD, code, -1);
-        code = get_color_code(cfg->comment_color);
-        if (code != -1) init_pair(SYNTAX_COMMENT, code, -1);
-        code = get_color_code(cfg->string_color);
-        if (code != -1) init_pair(SYNTAX_STRING, code, -1);
-        code = get_color_code(cfg->type_color);
-        if (code != -1) init_pair(SYNTAX_TYPE, code, -1);
-        code = get_color_code(cfg->symbol_color);
-        if (code != -1) init_pair(SYNTAX_SYMBOL, code, -1);
+        if (!has_colors()) {
+            enable_color = 0;
+        } else {
+            start_color();
+            use_default_colors();
+            short code;
+            short bg = get_color_code(cfg->background_color);
+            if (bg == -1) bg = -1;
+            init_pair(SYNTAX_BG, COLOR_WHITE, bg);
+            code = get_color_code(cfg->keyword_color);
+            if (code != -1) init_pair(SYNTAX_KEYWORD, code, -1);
+            code = get_color_code(cfg->comment_color);
+            if (code != -1) init_pair(SYNTAX_COMMENT, code, -1);
+            code = get_color_code(cfg->string_color);
+            if (code != -1) init_pair(SYNTAX_STRING, code, -1);
+            code = get_color_code(cfg->type_color);
+            if (code != -1) init_pair(SYNTAX_TYPE, code, -1);
+            code = get_color_code(cfg->symbol_color);
+            if (code != -1) init_pair(SYNTAX_SYMBOL, code, -1);
+        }
     }
 }
 

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -36,7 +36,7 @@ void initialize() {
     if (enable_mouse)
         mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
     timeout(10);
-    bkgd(COLOR_PAIR(1));
+    bkgd(enable_color ? COLOR_PAIR(1) : A_NORMAL);
     refresh();
     struct sigaction sa;
     sa.sa_handler = handle_resize;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -102,3 +102,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_undo_re
 # build and run long line loading test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_line_load.c obj_test/files.o -lncurses -o test_long_line_load
 ./test_long_line_load
+
+# build and run color disable test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c -lncurses -o test_color_disable
+./test_color_disable

--- a/tests/test_color_disable.c
+++ b/tests/test_color_disable.c
@@ -1,0 +1,99 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <ncurses.h>
+#include <signal.h>
+#include <pwd.h>
+#include "config.h"
+#include "file_manager.h"
+#include "files.h"
+#include "editor.h"
+
+#undef start_color
+#undef use_default_colors
+#undef init_pair
+#undef bkgd
+#undef wbkgd
+#undef has_colors
+
+/* stub ncurses functions and tracking variables */
+int start_color_called = 0;
+int init_pair_called = 0;
+int bkgd_attr = -2;
+int wbkgd_attr = -2;
+
+int start_color(void){ start_color_called++; return 0; }
+int use_default_colors(void){ return 0; }
+int init_pair(short p, short f, short b){ (void)p; (void)f; (void)b; init_pair_called++; return 0; }
+int bkgd(chtype ch){ bkgd_attr = ch; return 0; }
+int wbkgd(WINDOW *w, chtype ch){ (void)w; wbkgd_attr = ch; return 0; }
+bool has_colors(void){ return false; }
+
+/* stub other functions referenced in editor_init.c */
+void handle_resize(int sig){ (void)sig; }
+int define_key(const char *s, int k){ (void)s; (void)k; return 0; }
+void initialize_key_mappings(void){}
+void initializeMenus(void){}
+void update_status_bar(FileState *fs){ (void)fs; }
+void freeMenus(void){}
+void syntax_cleanup(void){}
+void free_stack(Node *stack){ (void)stack; }
+void free_file_state(FileState *fs, int max){ (void)fs; (void)max; }
+mmask_t mousemask(mmask_t newmask, mmask_t *old){ (void)newmask; if(old) *old = 0; return 0; }
+int cbreak(void){ return 0; }
+int noecho(void){ return 0; }
+int keypad(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+int meta(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+void wtimeout(WINDOW *w, int t){ (void)w; (void)t; }
+int wrefresh(WINDOW *w){ (void)w; return 0; }
+WINDOW *initscr(void){ return (WINDOW*)1; }
+int sigaction(int s, const struct sigaction *a, struct sigaction *o){ (void)s;(void)a;(void)o; return 0; }
+
+/* stub getpwuid so HOME is used */
+struct passwd *getpwuid(uid_t uid){ (void)uid; return NULL; }
+
+/* required globals */
+WINDOW *stdscr = (WINDOW*)1;
+FileManager file_manager = {0};
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+int exiting = 0;
+
+/* include source files under test */
+#include "../src/config.c"
+#include "../src/editor_init.c"
+
+int main(void){
+    /* set HOME to temp dir */
+    const char *tmpdir = "./tmp_home_test";
+    mkdir(tmpdir, 0700);
+    setenv("HOME", tmpdir, 1);
+
+    config_load(&app_config);
+
+    /* has_colors stub forces disable */
+    assert(enable_color == 0);
+    /* prepare dummy file and window */
+    FileState fs = {0};
+    fs.text_win = (WINDOW*)2;
+    FileState *arr[1];
+    arr[0] = &fs;
+    file_manager.files = arr;
+    file_manager.count = 1;
+
+    apply_colors();
+
+    assert(start_color_called == 0);
+    assert(init_pair_called == 0);
+    assert(bkgd_attr == A_NORMAL);
+    assert(wbkgd_attr == A_NORMAL);
+
+    /* cleanup */
+    unlink("./tmp_home_test/.ventorc");
+    rmdir(tmpdir);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- check `has_colors()` before initializing ncurses colors
- fall back to monochrome when colors aren't available
- respect the flag when setting stdscr background
- add regression test verifying color init is skipped when `has_colors()` is false

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a578e178c8324b413b71912bb307a