### PR TITLE
Fix config path fallback and document behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Vento currently supports the following features:
 
 ## Configuration File
 
-Vento reads settings from a `.ventorc` file in your home directory.  The file is
-written in the same key order as the defaults.  When you exit the settings
+Vento reads settings from a `.ventorc` file in your home directory.  If no home
+directory can be determined, it falls back to the current working directory.
+The file is written in the same key order as the defaults.  When you exit the settings
 dialog with changes, the updated configuration is automatically saved back to
 `~/.ventorc`.
 

--- a/src/config.c
+++ b/src/config.c
@@ -43,7 +43,8 @@ short get_color_code(const char *color_name) {
 static void get_config_path(char *buf, size_t size) {
     struct passwd *pw = getpwuid(getuid());
     const char *homedir = pw ? pw->pw_dir : getenv("HOME");
-    if (!homedir) homedir = "";
+    if (!homedir || homedir[0] == '\0')
+        homedir = ".";
     snprintf(buf, size, "%s/.ventorc", homedir);
 }
 


### PR DESCRIPTION
## Summary
- use current working directory when user home directory is unavailable
- document this fallback in README

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a591153848324bb5ae8b3a4708a6e