### PR TITLE
Fix indent allocation

### DIFF
--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -109,7 +109,12 @@ void handle_key_enter(FileState *fs) {
     int indent_len = 0;
     while (line[indent_len] == ' ' || line[indent_len] == '\t')
         indent_len++;
-    char indent[indent_len + 1];
+    char *indent = malloc(indent_len + 1);
+    if (!indent) {
+        free(old_text);
+        allocation_failed("malloc failed");
+        return;
+    }
     strncpy(indent, line, indent_len);
     indent[indent_len] = '\0';
 
@@ -133,6 +138,7 @@ void handle_key_enter(FileState *fs) {
     char *new_text = strdup(line);
     if (!new_text) {
         free(old_text);
+        free(indent);
         allocation_failed("strdup failed");
         return;
     }
@@ -140,6 +146,7 @@ void handle_key_enter(FileState *fs) {
 
     char *insert_text = strdup(new_line);
     if (!insert_text) {
+        free(indent);
         allocation_failed("strdup failed");
         return;
     }
@@ -155,6 +162,7 @@ void handle_key_enter(FileState *fs) {
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
     mark_comment_state_dirty(fs);
+    free(indent);
 }
 
 void handle_key_page_up(FileState *fs) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -103,6 +103,10 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_undo_re
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_line_load.c obj_test/files.o -lncurses -o test_long_line_load
 ./test_long_line_load
 
+# build and run long indent enter test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_indent.c src/input_keyboard.c -lncurses -o test_long_indent
+./test_long_indent
+
 # build and run color disable test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c -lncurses -o test_color_disable
 ./test_color_disable

--- a/tests/test_long_indent.c
+++ b/tests/test_long_indent.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include "files.h"
+#include "editor.h"
+#include "input.h"
+
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+
+void draw_text_buffer(FileState *fs, WINDOW *w){ (void)fs; (void)w; }
+void mark_comment_state_dirty(FileState *fs){ (void)fs; }
+void allocation_failed(const char *msg){ (void)msg; abort(); }
+int ensure_line_capacity(FileState *fs, int min_needed){ (void)fs; (void)min_needed; return 0; }
+void push(Node **stack, Change ch){ (void)stack; free(ch.old_text); free(ch.new_text); }
+void ensure_line_loaded(FileState *fs, int idx){ (void)fs; (void)idx; }
+void load_all_remaining_lines(FileState *fs){ (void)fs; }
+
+int main(void){
+    FileState fs = {0};
+    fs.line_capacity = 2000;
+    fs.max_lines = 5;
+    fs.text_buffer = calloc(fs.max_lines, sizeof(char*));
+    for(int i=0;i<fs.max_lines;i++)
+        fs.text_buffer[i] = calloc(fs.line_capacity, 1);
+    fs.line_count = 1;
+
+    memset(fs.text_buffer[0], ' ', 1100);
+    fs.text_buffer[0][1100] = 'x';
+    fs.text_buffer[0][1101] = '\0';
+    fs.cursor_x = 1101; // position after spaces
+    fs.cursor_y = 1;
+    fs.start_line = 0;
+
+    active_file = &fs;
+
+    handle_key_enter(&fs);
+
+    assert(fs.line_count == 2);
+    assert(strlen(fs.text_buffer[0]) == 1100);
+    for(int i=0;i<1100;i++)
+        assert(fs.text_buffer[0][i] == ' ');
+    for(int i=0;i<1100;i++)
+        assert(fs.text_buffer[1][i] == ' ');
+    assert(fs.text_buffer[1][1100] == 'x');
+
+    for(int i=0;i<fs.max_lines;i++)
+        free(fs.text_buffer[i]);
+    free(fs.text_buffer);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allocate indent buffer dynamically in `handle_key_enter`
- free indent buffer in all code paths
- add regression test for long indented lines

## Testing
- `./tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683a5ada9a908324ab2a5538450473c1