### PR TITLE
Reset highlight coords on replace

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -199,6 +199,9 @@ void replace_next_occurrence(FileState *fs, const char *search,
     wmove(text_win, *cursor_y,
           *cursor_x + off);
     wrefresh(text_win);
+
+    fs->match_start_x = fs->match_end_x = -1;
+    fs->match_start_y = fs->match_end_y = -1;
 }
 
 void replace_all_occurrences(FileState *fs, const char *search,
@@ -270,6 +273,9 @@ void replace_all_occurrences(FileState *fs, const char *search,
         mark_comment_state_dirty(fs);
         replaced = true;
     }
+
+    fs->match_start_x = fs->match_end_x = -1;
+    fs->match_start_y = fs->match_end_y = -1;
 
     if (replaced)
         fs->modified = true;

--- a/tests/test_replace_modified.c
+++ b/tests/test_replace_modified.c
@@ -56,6 +56,10 @@ int main(void){
 
     assert(strcmp(fs.text_buffer[0], "baz bar") == 0);
     assert(fs.modified);
+    assert(fs.match_start_x == -1);
+    assert(fs.match_end_x == -1);
+    assert(fs.match_start_y == -1);
+    assert(fs.match_end_y == -1);
 
     delwin(text_win);
     for(int i=0;i<fs.max_lines;i++) free(fs.text_buffer[i]);


### PR DESCRIPTION
## Summary
- clear search highlight after performing replacements
- test reset of highlight coordinates

## Testing
- `bash -x tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a5c67d9cc83249ed7451bb2b402f3