### PR TITLE
Fix dialog wbkgd with enable_color flag

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -3,6 +3,7 @@
 #include "files.h"
 #include "editor.h"
 #include "syntax.h"
+#include "config.h"
 #include <limits.h>
 
 // Function to initialize a new FileState for a given filename
@@ -62,7 +63,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
         free(file_state);
         return NULL;
     }
-    wbkgd(file_state->text_win, COLOR_PAIR(SYNTAX_BG));
+    wbkgd(file_state->text_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
 
     file_state->fp = NULL;
     file_state->file_complete = true;

--- a/src/ui.c
+++ b/src/ui.c
@@ -30,7 +30,7 @@ void create_dialog(const char *message, char *output, int max_input_len) {
         return;
     }
     keypad(dialog_win, TRUE);
-    wbkgd(dialog_win, COLOR_PAIR(SYNTAX_BG));
+    wbkgd(dialog_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
 
     box(dialog_win, 0, 0);
@@ -103,7 +103,7 @@ int show_find_dialog(char *output, int max_input_len, const char *preset) {
         return 0;
     }
     keypad(dialog_win, TRUE);
-    wbkgd(dialog_win, COLOR_PAIR(SYNTAX_BG));
+    wbkgd(dialog_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
 
     box(dialog_win, 0, 0);

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -17,7 +17,7 @@ void show_help() {
 
     WINDOW *help_win = newwin(win_height, win_width, win_y, win_x);
     keypad(help_win, TRUE);
-    wbkgd(help_win, COLOR_PAIR(1));
+    wbkgd(help_win, enable_color ? COLOR_PAIR(1) : A_NORMAL);
     wrefresh(stdscr);
     box(help_win, 0, 0);
 
@@ -78,7 +78,7 @@ void show_about() {
 
     WINDOW *about_win = newwin(win_height, win_width, win_y, win_x);
     keypad(about_win, TRUE);
-    wbkgd(about_win, COLOR_PAIR(1));
+    wbkgd(about_win, enable_color ? COLOR_PAIR(1) : A_NORMAL);
     wrefresh(stdscr);
     box(about_win, 0, 0);
 
@@ -110,7 +110,7 @@ void show_warning_dialog() {
 
     WINDOW *warning_win = newwin(win_height, win_width, win_y, win_x);
     keypad(warning_win, TRUE);
-    wbkgd(warning_win, COLOR_PAIR(1));
+    wbkgd(warning_win, enable_color ? COLOR_PAIR(1) : A_NORMAL);
     wrefresh(stdscr);
     box(warning_win, 0, 0);
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,24 +7,25 @@ mkdir obj_test
 # compile sources for paste test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/clipboard.c -o obj_test/clipboard.o
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/files.c -o obj_test/files.o
+gcc -Wall -Wextra -std=c99 -g -Isrc -c tests/stub_enable_color.c -o obj_test/stub_enable_color.o
 
 # build and run paste test (provides its own stubs)
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_paste.c obj_test/clipboard.o obj_test/files.o -lncurses -o test_paste
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_paste.c obj_test/clipboard.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_paste
 ./test_paste
 
 # compile additional source for file state test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/file_manager.c -o obj_test/file_manager.o
 
 # build and run file state initialization/switching test
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_file_state
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_file_state
 ./test_file_state
 
 # build and run resize handling test (provides many stubs)
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_resize
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_resize
 ./test_resize
 
 # build and run line truncation resize test
-gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o obj_test/file_manager.o -lncurses -o test_resize_trunc
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_resize_trunc
 ./test_resize_trunc
 
 # build and run identifier overflow test with AddressSanitizer
@@ -42,37 +43,37 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_js.c -o obj
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o obj_test/syntax_css.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_comment.c \
     obj_test/syntax_html.o obj_test/syntax_js.o obj_test/syntax_css.o \
-    obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_html_comment
+    obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_html_comment
 ./test_html_comment
 
 # build and run python syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_python.c -o obj_test/syntax_python.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_python_syntax.c \
-    obj_test/syntax_python.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_python_syntax
+    obj_test/syntax_python.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_python_syntax
 ./test_python_syntax
 
 # build and run JavaScript syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_js.c -o obj_test/syntax_js.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_js_syntax.c \
-    obj_test/syntax_js.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_js_syntax
+    obj_test/syntax_js.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_js_syntax
 ./test_js_syntax
 
 # build and run CSS syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_css.c -o obj_test/syntax_css.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_css_syntax.c \
-    obj_test/syntax_css.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_css_syntax
+    obj_test/syntax_css.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_css_syntax
 ./test_css_syntax
 
 # build and run HTML nested syntax test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_html_nested.c \
     obj_test/syntax_html.o obj_test/syntax_js.o obj_test/syntax_css.o \
-    obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_html_nested
+    obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_html_nested
 ./test_html_nested
 
 # build and run shell syntax highlighting test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_shell.c -o obj_test/syntax_shell.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_shell_syntax.c \
-    obj_test/syntax_shell.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_shell_syntax
+    obj_test/syntax_shell.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_shell_syntax
 ./test_shell_syntax
 
 # build and run shebang detection test (uses stubs for other functions)
@@ -84,7 +85,7 @@ gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_shebang_detection.c src/file_ops.
 # build and run regex complex construct test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_c.c -o obj_test/syntax_c.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_regex_complex.c \
-    obj_test/syntax_c.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o -lncurses -o test_regex_complex
+    obj_test/syntax_c.o obj_test/syntax_common.o obj_test/syntax_regex.o obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_regex_complex
 ./test_regex_complex
 
 # build and run search highlight test
@@ -100,7 +101,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_undo_re
 ./test_undo_redo_modified
 
 # build and run long line loading test
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_line_load.c obj_test/files.o -lncurses -o test_long_line_load
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_line_load.c obj_test/files.o obj_test/stub_enable_color.o -lncurses -o test_long_line_load
 ./test_long_line_load
 
 # build and run long indent enter test
@@ -110,3 +111,9 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_in
 # build and run color disable test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c -lncurses -o test_color_disable
 ./test_color_disable
+
+# build and run dialog color disable regression test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_dialog_color_disable.c src/ui.c src/ui_info.c -lncurses \
+    -o test_dialog_color_disable
+./test_dialog_color_disable

--- a/tests/stub_enable_color.c
+++ b/tests/stub_enable_color.c
@@ -1,0 +1,1 @@
+int enable_color = 1;

--- a/tests/test_dialog_color_disable.c
+++ b/tests/test_dialog_color_disable.c
@@ -1,0 +1,76 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <ncurses.h>
+#include "ui.h"
+#include "files.h"
+#include "config.h"
+
+#undef curs_set
+#undef newwin
+#undef delwin
+#undef keypad
+#undef wbkgd
+#undef wrefresh
+#undef box
+#undef wattron
+#undef mvwprintw
+#undef wattroff
+#undef wmove
+#undef wgetch
+#undef wclear
+#undef werase
+#undef wborder
+
+/* minimal WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+static SIMPLE_WIN dummy_win;
+WINDOW *stdscr = (WINDOW*)&dummy_win;
+WINDOW *text_win = (WINDOW*)&dummy_win;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+int enable_color = 0; /* disable color globally */
+
+int wbkgd_attr_last = -2;
+
+int curs_set(int c){ (void)c; return 0; }
+WINDOW *newwin(int nlines,int ncols,int y,int x){ (void)nlines;(void)ncols;(void)y;(void)x; return (WINDOW*)&dummy_win; }
+int delwin(WINDOW*w){ (void)w; return 0; }
+int keypad(WINDOW*w, bool b){ (void)w; (void)b; return 0; }
+int wbkgd(WINDOW*w, chtype ch){ (void)w; wbkgd_attr_last = ch; return 0; }
+int wrefresh(WINDOW*w){ (void)w; return 0; }
+int box(WINDOW*w, chtype v, chtype h){ (void)w; (void)v; (void)h; return 0; }
+int wattron(WINDOW*w, int a){ (void)w; (void)a; return 0; }
+int wattroff(WINDOW*w, int a){ (void)w; (void)a; return 0; }
+int mvwprintw(WINDOW*w,int y,int x,const char*fmt,...){ (void)w;(void)y;(void)x;(void)fmt; return 0; }
+int wmove(WINDOW*w,int y,int x){ (void)w;(void)y;(void)x; return 0; }
+int wgetch(WINDOW*w){ (void)w; return '\n'; }
+int wclear(WINDOW*w){ (void)w; return 0; }
+int werase(WINDOW*w){ (void)w; return 0; }
+int wborder(WINDOW*w,chtype ls,chtype rs,chtype ts,chtype bs,chtype tl,chtype tr,chtype bl,chtype br){(void)w;(void)ls;(void)rs;(void)ts;(void)bs;(void)tl;(void)tr;(void)bl;(void)br; return 0; }
+
+/* stubs for other functions */
+void draw_text_buffer(FileState*fs, WINDOW*w){ (void)fs; (void)w; }
+void update_status_bar(FileState*fs){ (void)fs; }
+int show_message(const char*msg){ (void)msg; return 0; }
+
+int main(void){
+    char buf[32];
+    printf("create_dialog\n");
+    create_dialog("Test", buf, sizeof(buf));
+    assert(wbkgd_attr_last == A_NORMAL);
+
+    printf("show_help\n");
+    show_help();
+    assert(wbkgd_attr_last == A_NORMAL);
+
+    printf("show_about\n");
+    show_about();
+    assert(wbkgd_attr_last == A_NORMAL);
+
+    printf("show_warning\n");
+    show_warning_dialog();
+    assert(wbkgd_attr_last == A_NORMAL);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- respect `enable_color` in dialog window backgrounds
- apply same check when creating file windows
- ensure info dialogs also respect color flag
- add regression test for no-color dialogs
- link tests with a stub `enable_color` variable

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a5e35432083249052b99bb5e3b8d2