### PR TITLE
Free file array during cleanup

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -75,6 +75,10 @@ void cleanup_on_exit(FileManager *fm) {
         free_file_state(fs, fs->max_lines);
     }
     freeMenus();
+    free(fm->files);
+    fm->files = NULL;
+    fm->count = 0;
+    fm->active_index = -1;
 }
 
 void close_editor() {


### PR DESCRIPTION
## Summary
- release the FileManager array at the end of `cleanup_on_exit`
- reset FileManager fields after freeing

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a5ff35f108324bb7ccd4d34d49a5d