### PR TITLE
Handle window creation failures gracefully

### DIFF
--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -30,9 +30,7 @@ WINDOW *create_centered_window(int height, int width, WINDOW *parent) {
 
     WINDOW *win = newwin(height, width, win_y, win_x);
     if (!win) {
-        endwin();
-        fprintf(stderr, "Failed to create new window\n");
-        exit(EXIT_FAILURE);
+        return NULL;
     }
 
     box(win, 0, 0);
@@ -41,7 +39,12 @@ WINDOW *create_centered_window(int height, int width, WINDOW *parent) {
 }
 
 WINDOW *create_popup_window(int height, int width, WINDOW *parent) {
-    return create_centered_window(height, width, parent);
+    WINDOW *win = create_centered_window(height, width, parent);
+    if (!win) {
+        show_message("Unable to create window");
+        return NULL;
+    }
+    return win;
 }
 
 int show_message(const char *msg) {
@@ -94,6 +97,7 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         win = create_popup_window(win_height, win_width, parent);
         if (!win) {
             curs_set(1);
+            show_message("Unable to create window");
             return -1;
         }
         own = 1;
@@ -107,6 +111,7 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         win = create_popup_window(win_height, win_width, NULL);
         if (!win) {
             curs_set(1);
+            show_message("Unable to create window");
             return -1;
         }
         own = 1;

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -80,6 +80,7 @@ static int file_dialog_loop(char *path, int max_len,
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
     if (!win) {
         curs_set(1);
+        show_message("Unable to create window");
         return 0;
     }
     keypad(win, TRUE);

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -166,6 +166,7 @@ int show_settings_dialog(AppConfig *cfg) {
     WINDOW *win = create_popup_window(win_height, win_width, NULL);
     if (!win) {
         curs_set(1);
+        show_message("Unable to create window");
         return 0;
     }
     keypad(win, TRUE);
@@ -272,6 +273,7 @@ const char *select_color(const char *current, WINDOW *parent) {
         win = create_popup_window(win_height, win_width, parent);
         if (!win) {
             curs_set(1);
+            show_message("Unable to create window");
             return NULL;
         }
         own = 1;
@@ -285,6 +287,7 @@ const char *select_color(const char *current, WINDOW *parent) {
         win = create_popup_window(win_height, win_width, NULL);
         if (!win) {
             curs_set(1);
+            show_message("Unable to create window");
             return NULL;
         }
         own = 1;
@@ -478,6 +481,7 @@ const char *select_theme(const char *current, WINDOW *parent) {
             free(names[i]);
         free(names);
         curs_set(1);
+        show_message("Unable to create window");
         return NULL;
     }
     own = 1;
@@ -609,6 +613,7 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
         win = create_popup_window(win_height, win_width, parent);
         if (!win) {
             curs_set(1);
+            show_message("Unable to create window");
             return current;
         }
         own = 1;
@@ -616,6 +621,7 @@ int select_bool(const char *prompt, int current, WINDOW *parent) {
         win = create_popup_window(win_height, win_width, NULL);
         if (!win) {
             curs_set(1);
+            show_message("Unable to create window");
             return current;
         }
         own = 1;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -121,3 +121,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_dialog_color_disable.c src/ui.c src/ui_info.c -lncurses \
     -o test_dialog_color_disable
 ./test_dialog_color_disable
+
+# build and run newwin failure handling test
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_newwin_fail.c src/ui_common.c -lncurses -o test_newwin_fail
+./test_newwin_fail

--- a/tests/test_newwin_fail.c
+++ b/tests/test_newwin_fail.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <setjmp.h>
+#include <ncurses.h>
+#include "ui_common.h"
+#include "config.h"
+
+#undef newwin
+#undef box
+#undef mvwprintw
+#undef wrefresh
+#undef wgetch
+#undef wclear
+#undef delwin
+#undef curs_set
+
+int COLS = 80;
+int LINES = 24;
+int enable_color = 0;
+int enable_mouse = 0;
+int show_line_numbers = 0;
+AppConfig app_config;
+WINDOW *stdscr = NULL;
+
+WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return NULL;}
+int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char*fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int wgetch(WINDOW*w){(void)w;return 0;}
+int wclear(WINDOW*w){(void)w;return 0;}
+int delwin(WINDOW*w){(void)w;return 0;}
+int curs_set(int c){(void)c;return 0;}
+int endwin(void){return 0;}
+
+static jmp_buf jb;
+void exit(int status){longjmp(jb,1);} // catch unexpected exit
+
+int main(void){
+    if(setjmp(jb)!=0){
+        assert(!"program called exit");
+    }
+    WINDOW *w = create_popup_window(5, 10, NULL);
+    assert(w == NULL);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- avoid exiting when `newwin` fails in `create_centered_window`
- warn about failure in `create_popup_window`
- propagate failure handling to callers
- test that `newwin` failures no longer abort the program

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a63a643208324b7975d3354f27fc2