### PR TITLE
Add mousemask disable branch and test

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -35,6 +35,8 @@ void initialize() {
     meta(stdscr, TRUE);
     if (enable_mouse)
         mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
+    else
+        mousemask(0, NULL);
     timeout(10);
     bkgd(enable_color ? COLOR_PAIR(1) : A_NORMAL);
     refresh();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -116,6 +116,10 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_long_in
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c -lncurses -o test_color_disable
 ./test_color_disable
 
+# build and run initialize mouse test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_initialize_mouse.c -lncurses -o test_initialize_mouse
+./test_initialize_mouse
+
 # build and run dialog color disable regression test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_dialog_color_disable.c src/ui.c src/ui_info.c -lncurses \

--- a/tests/test_initialize_mouse.c
+++ b/tests/test_initialize_mouse.c
@@ -1,0 +1,71 @@
+#include <assert.h>
+#include <ncurses.h>
+#include <signal.h>
+#include "config.h"
+#include "file_manager.h"
+#include "files.h"
+#include "editor.h"
+
+#undef initscr
+#undef cbreak
+#undef noecho
+#undef keypad
+#undef meta
+#undef mousemask
+#undef timeout
+#undef bkgd
+#undef wbkgd
+#undef refresh
+#undef sigaction
+#undef define_key
+
+/* global state required by editor_init.c */
+WINDOW *stdscr = (WINDOW*)1;
+FileManager file_manager = {0};
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+int exiting = 0;
+int enable_color = 0;
+int enable_mouse = 0;
+int show_line_numbers = 0;
+AppConfig app_config;
+
+/* track mousemask argument */
+static mmask_t recorded_mask = (mmask_t)0xffff;
+
+/* stub ncurses functions */
+WINDOW *initscr(void){ return (WINDOW*)1; }
+int cbreak(void){ return 0; }
+int noecho(void){ return 0; }
+int keypad(WINDOW*w,bool b){ (void)w; (void)b; return 0; }
+int meta(WINDOW*w,bool b){ (void)w; (void)b; return 0; }
+mmask_t mousemask(mmask_t newmask, mmask_t *old){ if(old) *old = 0; recorded_mask = newmask; return 0; }
+void timeout(int t){ (void)t; }
+int bkgd(chtype ch){ (void)ch; return 0; }
+int wbkgd(WINDOW*w, chtype ch){ (void)w; (void)ch; return 0; }
+int refresh(void){ return 0; }
+int sigaction(int s,const struct sigaction*a, struct sigaction*o){ (void)s;(void)a;(void)o; return 0; }
+int define_key(const char*s,int k){ (void)s; (void)k; return 0; }
+void initialize_key_mappings(void){}
+void initializeMenus(void){}
+void update_status_bar(FileState*fs){ (void)fs; }
+void freeMenus(void){}
+void syntax_cleanup(void){}
+void free_stack(Node*stack){ (void)stack; }
+void free_file_state(FileState*fs,int max){ (void)fs; (void)max; }
+void handle_resize(int sig){ (void)sig; }
+
+/* minimal config_load stub */
+void config_load(AppConfig *cfg){ enable_mouse = cfg->enable_mouse; }
+
+#include "../src/editor_init.c"
+
+int main(void){
+    app_config.enable_mouse = 0;
+    recorded_mask = (mmask_t)0xffff;
+    initialize();
+    assert(recorded_mask == 0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- handle disabled mouse in `initialize`
- test that `initialize` calls `mousemask(0, NULL)` when mouse support is disabled
- run the new test in `run_tests.sh`

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a652706e883248eeadc12d8b42e1b