### PR TITLE
Fix missing include in editor_init.c

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -1,5 +1,6 @@
 #include <ncurses.h>
 #include <signal.h>
+#include <stdlib.h>
 #include "editor.h"
 #include "config.h"
 #include "ui.h"


### PR DESCRIPTION
## Summary
- add `<stdlib.h>` include to `src/editor_init.c`
- rebuild to ensure compilation succeeds

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_683a665732f483248c92556bdaf8cf61