### PR TITLE
Fix color initialization to use configured background

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -247,16 +247,21 @@ void config_load(AppConfig *cfg) {
             short bg = get_color_code(cfg->background_color);
             if (bg == -1) bg = -1;
             init_pair(SYNTAX_BG, COLOR_WHITE, bg);
+
             code = get_color_code(cfg->keyword_color);
-            if (code != -1) init_pair(SYNTAX_KEYWORD, code, -1);
+            if (code != -1) init_pair(SYNTAX_KEYWORD, code, bg);
+
             code = get_color_code(cfg->comment_color);
-            if (code != -1) init_pair(SYNTAX_COMMENT, code, -1);
+            if (code != -1) init_pair(SYNTAX_COMMENT, code, bg);
+
             code = get_color_code(cfg->string_color);
-            if (code != -1) init_pair(SYNTAX_STRING, code, -1);
+            if (code != -1) init_pair(SYNTAX_STRING, code, bg);
+
             code = get_color_code(cfg->type_color);
-            if (code != -1) init_pair(SYNTAX_TYPE, code, -1);
+            if (code != -1) init_pair(SYNTAX_TYPE, code, bg);
+
             code = get_color_code(cfg->symbol_color);
-            if (code != -1) init_pair(SYNTAX_SYMBOL, code, -1);
+            if (code != -1) init_pair(SYNTAX_SYMBOL, code, bg);
         }
     }
 }


### PR DESCRIPTION
## Summary
- use the configured background color when initializing syntax color pairs

## Testing
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_683a66f4cfb4832483dd97341438dfb1