### PR TITLE
Handle terminal resize signals asynchronously

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -2,6 +2,7 @@
 #define EDITOR_H
 
 #include <ncurses.h>
+#include <signal.h>
 #include <string.h>
 typedef struct Change {
     int line;
@@ -42,6 +43,7 @@ extern WINDOW *text_win;
 extern struct FileState *active_file;
 extern struct FileManager file_manager;
 extern char search_text[256];
+extern volatile sig_atomic_t resize_pending;
 extern int exiting;
 void handle_regular_mode(struct FileState *fs, int ch);
 void initialize(void);
@@ -56,7 +58,8 @@ void insert_new_line(struct FileState *fs);
 void update_status_bar(struct FileState *fs);
 void go_to_line(struct FileState *fs, int line);
 __attribute__((weak)) int get_line_number_offset(struct FileState *fs);
-void handle_resize(int sig);
+void on_sigwinch(int sig);
+void perform_resize(void);
 void cleanup_on_exit(struct FileManager *fm);
 void disable_ctrl_c_z(void);
 void apply_colors(void);

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -42,9 +42,9 @@ void initialize() {
     bkgd(enable_color ? COLOR_PAIR(1) : A_NORMAL);
     refresh();
     struct sigaction sa;
-    sa.sa_handler = handle_resize;
+    sa.sa_handler = on_sigwinch;
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = SA_RESTART;
+    sa.sa_flags = 0;
 #ifdef SIGWINCH
     /* Some platforms may not support SIGWINCH */
     sigaction(SIGWINCH, &sa, NULL);

--- a/src/files.c
+++ b/src/files.c
@@ -63,6 +63,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
         free(file_state);
         return NULL;
     }
+    wtimeout(file_state->text_win, 10);
     wbkgd(file_state->text_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
 
     file_state->fp = NULL;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -32,6 +32,12 @@ gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o o
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize_allocfail.c -lncurses -o test_resize_allocfail
 ./test_resize_allocfail
 
+# build and run resize signal handling test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_resize_signal.c obj_test/files.o obj_test/file_manager.o \
+    obj_test/stub_enable_color.o -lncurses -o test_resize_signal
+./test_resize_signal
+
 # build and run identifier overflow test with AddressSanitizer
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_c.c -o obj_test/syntax_c.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_csharp.c -o obj_test/syntax_csharp.o

--- a/tests/stub_enable_color.c
+++ b/tests/stub_enable_color.c
@@ -1,1 +1,5 @@
+#include <ncurses.h>
+
 int enable_color = 1;
+
+void wtimeout(WINDOW *w, int t){ (void)w; (void)t; }

--- a/tests/test_color_disable.c
+++ b/tests/test_color_disable.c
@@ -32,7 +32,7 @@ int wbkgd(WINDOW *w, chtype ch){ (void)w; wbkgd_attr = ch; return 0; }
 bool has_colors(void){ return false; }
 
 /* stub other functions referenced in editor_init.c */
-void handle_resize(int sig){ (void)sig; }
+void on_sigwinch(int sig){ (void)sig; }
 int define_key(const char *s, int k){ (void)s; (void)k; return 0; }
 void initialize_key_mappings(void){}
 void initializeMenus(void){}

--- a/tests/test_initialize_mouse.c
+++ b/tests/test_initialize_mouse.c
@@ -55,7 +55,7 @@ void freeMenus(void){}
 void syntax_cleanup(void){}
 void free_stack(Node*stack){ (void)stack; }
 void free_file_state(FileState*fs,int max){ (void)fs; (void)max; }
-void handle_resize(int sig){ (void)sig; }
+void on_sigwinch(int sig){ (void)sig; }
 
 /* minimal config_load stub */
 void config_load(AppConfig *cfg){ enable_mouse = cfg->enable_mouse; }

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -117,7 +117,7 @@ int enable_mouse = 0;
 Menu *menus = NULL; int menuCount = 0;
 WINDOW *stdscr = NULL;
 
-/* Include editor.c for handle_resize implementation */
+/* Include editor.c for perform_resize implementation */
 #include "../src/editor.c"
 
 int main(void){
@@ -140,7 +140,7 @@ int main(void){
     /* resize to smaller dimensions */
     LINES = 10; COLS = 30;
     drawBar_called = 0;
-    handle_resize(0);
+    perform_resize();
 
     assert(last_resize_win == fs->text_win);
     assert(last_resize_h == LINES - 2);
@@ -158,7 +158,7 @@ int main(void){
     int prev_capacity = fs->line_capacity;
     LINES = 25; COLS = 70;
     drawBar_called = 0;
-    handle_resize(0);
+    perform_resize();
 
     assert(last_resize_win == fs->text_win);
     assert(last_resize_h == LINES - 2);

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -1,20 +1,8 @@
 #include <assert.h>
-#include <stdlib.h>
 #include <string.h>
-#include <setjmp.h>
+#include <stdlib.h>
 #include <ncurses.h>
 #undef refresh
-#undef mvwchgat
-#undef mvprintw
-#undef wmove
-#undef wrefresh
-#undef werase
-#undef wnoutrefresh
-#undef doupdate
-#undef wattrset
-#undef wattron
-#undef wattroff
-#undef mvwprintw
 #undef clear
 #undef box
 #include "files.h"
@@ -22,20 +10,21 @@
 #include "editor.h"
 #include "menu.h"
 
-/* stub ncurses globals */
 int COLS = 80;
 int LINES = 24;
 
-/* simple WINDOW stub */
 typedef struct { int h,w,y,x; } SIMPLE_WIN;
-WINDOW *newwin(int nlines,int ncols,int y,int x){
+
+static WINDOW *resized_win;
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){
     SIMPLE_WIN *w = calloc(1,sizeof(SIMPLE_WIN));
     w->h=nlines; w->w=ncols; w->y=y; w->x=x;
     return (WINDOW*)w;
 }
 int delwin(WINDOW*w){free(w);return 0;}
-int wresize(WINDOW*w,int h,int c){(void)w;(void)h;(void)c;return 0;}
-int mvwin(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int wresize(WINDOW*w,int h,int c){resized_win=w; ((SIMPLE_WIN*)w)->h=h; ((SIMPLE_WIN*)w)->w=c; return 0;}
+int mvwin(WINDOW*w,int y,int x){((SIMPLE_WIN*)w)->y=y; ((SIMPLE_WIN*)w)->x=x; return 0;}
 int werase(WINDOW*w){(void)w;return 0;}
 int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
 int wrefresh(WINDOW*w){(void)w;return 0;}
@@ -46,14 +35,10 @@ int clear(void){return 0;}
 int resizeterm(int r,int c){(void)r;(void)c;return 0;}
 int wnoutrefresh(WINDOW*w){(void)w;return 0;}
 int doupdate(void){return 0;}
-void wtimeout(WINDOW *w,int t){(void)w;(void)t;}
-WINDOW* derwin(WINDOW*w,int nlines,int ncols,int y,int x){(void)w;return newwin(nlines,ncols,y,x);}
-int getmaxy(const WINDOW*w){return ((SIMPLE_WIN*)w)->h;}
-int getmaxx(const WINDOW*w){return ((SIMPLE_WIN*)w)->w;}
-int mvwprintw(WINDOW*w,int y,int x,const char*fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
-int mvwchgat(WINDOW*w,int y,int x,int n,attr_t attr,short c,const void*opts){(void)w;(void)y;(void)x;(void)n;(void)attr;(void)c;(void)opts;return 0;}
 
-/* editor dependency stubs */
+static int gcalls=0;
+int wgetch(WINDOW*w){(void)w;gcalls++; if(gcalls==2) exiting=1; return ERR;}
+
 void update_status_bar(FileState*fs){(void)fs;}
 void drawBar(void){}
 void handle_key_up(FileState*fs){(void)fs;}
@@ -74,10 +59,13 @@ void handle_ctrl_key_down(FileState*fs){(void)fs;}
 void handle_key_home(FileState*fs){(void)fs;}
 void handle_key_end(FileState*fs){(void)fs;}
 void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
-void handle_mouse_event(FileState*fs,MEVENT*ev){(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
 void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
 void end_selection_mode(FileState*fs){(void)fs;}
+void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
+void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
+int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
+void handle_mouse_event(FileState*fs,MEVENT*ev){(void)fs;(void)ev;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(FileState*fs){(void)fs;}
 void insert_new_line(FileState*fs){(void)fs;}
@@ -91,15 +79,12 @@ void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs,WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
 void show_about(void){}
 void show_help(void){}
-void find(FileState*fs,int new_search){(void)fs;(void)new_search;}
-void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
-void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
+void find(FileState*fs,int n){(void)fs;(void)n;}
 void replace(FileState*fs){(void)fs;}
 void save_file(FileState*fs){(void)fs;}
 void save_file_as(FileState*fs){(void)fs;}
 void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
 void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
 void menuNewFile(void){}
 void menuLoadFile(void){}
 void menuSaveFile(void){}
@@ -118,49 +103,26 @@ void menuHelp(void){}
 void menuTestwindow(void){}
 int show_goto_dialog(int*line){(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
-void ensure_line_loaded(FileState*fs,int idx){(void)fs;(void)idx;}
 
-/* globals */
-int enable_mouse = 0;
-Menu *menus = NULL; int menuCount = 0;
-WINDOW *stdscr = NULL;
-FileManager file_manager = {0};
-
-/* stub to force failure */
-int ensure_col_capacity(FileState*fs,int cols){(void)fs;(void)cols;return -1;}
-
-static jmp_buf jb;
+int enable_mouse=0;
+Menu*menus=NULL;int menuCount=0;
+WINDOW *stdscr=NULL;
 
 #include "../src/editor.c"
 
-void exit(int status){longjmp(jb,status);}
-
 int main(void){
-    FileState fs = {0};
-    fs.line_capacity = 20;
-    fs.max_lines = 2;
-    fs.text_buffer = calloc(fs.max_lines,sizeof(char*));
-    for(int i=0;i<fs.max_lines;i++)
-        fs.text_buffer[i] = calloc(fs.line_capacity,1);
-    fs.line_count = 1;
-    fs.text_win = newwin(LINES-2,COLS,1,0);
-    active_file = &fs;
+    fm_init(&file_manager);
+    LINES=20; COLS=50;
+    FileState *fs = initialize_file_state("x",2,COLS);
+    assert(fs);
+    fm_add(&file_manager,fs);
+    active_file=fs;
 
-    file_manager.files = calloc(1,sizeof(FileState*));
-    file_manager.files[0] = &fs;
-    file_manager.count = 1;
+    resize_pending = 1;
+    run_editor();
 
-    COLS = 40;
+    assert(resized_win==fs->text_win);
 
-    if(setjmp(jb) == 0){
-        perform_resize();
-        return 1;
-    }
-
-    for(int i=0;i<fs.max_lines;i++)
-        free(fs.text_buffer[i]);
-    free(fs.text_buffer);
-    free(file_manager.files);
-    delwin(fs.text_win);
+    free_file_state(fs, fs->max_lines);
     return 0;
 }

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -113,7 +113,7 @@ int enable_mouse = 0;
 Menu *menus = NULL; int menuCount = 0;
 WINDOW *stdscr = NULL;
 
-/* Include editor.c for handle_resize implementation */
+/* Include editor.c for perform_resize implementation */
 #include "../src/editor.c"
 
 int main(void){
@@ -131,7 +131,7 @@ int main(void){
 
     int new_LINES = 20, new_COLS = 22; /* shrink */
     LINES = new_LINES; COLS = new_COLS;
-    handle_resize(0);
+    perform_resize();
 
     assert(fs->line_capacity == original_capacity);
     assert(strlen(fs->text_buffer[0]) == original_len);


### PR DESCRIPTION
## Summary
- use a pending flag and signal handler for window resize
- rename `handle_resize` logic to `perform_resize`
- react to resize events inside the editor loop
- create windows with input timeout
- add regression test for resize pending flag

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a6879872c83248e17311a6af1a5be