### PR TITLE
Remove redundant cleanup in main

### DIFF
--- a/src/vento.c
+++ b/src/vento.c
@@ -41,11 +41,6 @@ int main(int argc, char *argv[]) {
 
     cleanup_on_exit(&file_manager);
 
-    free(file_manager.files);
-    file_manager.files = NULL;
-    file_manager.count = 0;
-    file_manager.active_index = -1;
-
     active_file = NULL;
 
     return 0;


### PR DESCRIPTION
## Summary
- stop double-freeing FileManager in `vento.c`
- rely solely on `cleanup_on_exit` to release FileManager resources

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a6b5214e08324846430d25c59dec4