### PR TITLE
Update dialog background color handling

### DIFF
--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -1,6 +1,7 @@
 #include "editor.h"
 #include "config.h"
 #include "ui_common.h"
+#include "syntax.h"
 #include <ncurses.h>
 #include <string.h>
 
@@ -17,7 +18,7 @@ void show_help() {
 
     WINDOW *help_win = newwin(win_height, win_width, win_y, win_x);
     keypad(help_win, TRUE);
-    wbkgd(help_win, enable_color ? COLOR_PAIR(1) : A_NORMAL);
+    wbkgd(help_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
     box(help_win, 0, 0);
 
@@ -78,7 +79,7 @@ void show_about() {
 
     WINDOW *about_win = newwin(win_height, win_width, win_y, win_x);
     keypad(about_win, TRUE);
-    wbkgd(about_win, enable_color ? COLOR_PAIR(1) : A_NORMAL);
+    wbkgd(about_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
     box(about_win, 0, 0);
 
@@ -110,7 +111,7 @@ void show_warning_dialog() {
 
     WINDOW *warning_win = newwin(win_height, win_width, win_y, win_x);
     keypad(warning_win, TRUE);
-    wbkgd(warning_win, enable_color ? COLOR_PAIR(1) : A_NORMAL);
+    wbkgd(warning_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
     box(warning_win, 0, 0);
 

--- a/tests/test_dialog_color_disable.c
+++ b/tests/test_dialog_color_disable.c
@@ -4,6 +4,7 @@
 #include "ui.h"
 #include "files.h"
 #include "config.h"
+#include "syntax.h"
 
 #undef curs_set
 #undef newwin
@@ -56,6 +57,8 @@ int show_message(const char*msg){ (void)msg; return 0; }
 
 int main(void){
     char buf[32];
+    /* color disabled */
+    enable_color = 0;
     printf("create_dialog\n");
     create_dialog("Test", buf, sizeof(buf));
     assert(wbkgd_attr_last == A_NORMAL);
@@ -71,6 +74,24 @@ int main(void){
     printf("show_warning\n");
     show_warning_dialog();
     assert(wbkgd_attr_last == A_NORMAL);
+
+    /* color enabled */
+    enable_color = 1;
+    printf("create_dialog color\n");
+    create_dialog("Test", buf, sizeof(buf));
+    assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
+
+    printf("show_help color\n");
+    show_help();
+    assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
+
+    printf("show_about color\n");
+    show_about();
+    assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
+
+    printf("show_warning color\n");
+    show_warning_dialog();
+    assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- use `COLOR_PAIR(SYNTAX_BG)` for dialog backgrounds
- include `syntax.h` for new constant usage
- extend dialog color test to cover enabled colors

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a6c4a32b88324aab37679ad4e36f9