### PR TITLE
Handle newwin failure in info dialogs

### DIFF
--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -17,6 +17,10 @@ void show_help() {
         win_x = 0;
 
     WINDOW *help_win = newwin(win_height, win_width, win_y, win_x);
+    if (!help_win) {
+        show_message("Unable to create window");
+        return;
+    }
     keypad(help_win, TRUE);
     wbkgd(help_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
@@ -78,6 +82,10 @@ void show_about() {
         win_x = 0;
 
     WINDOW *about_win = newwin(win_height, win_width, win_y, win_x);
+    if (!about_win) {
+        show_message("Unable to create window");
+        return;
+    }
     keypad(about_win, TRUE);
     wbkgd(about_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);
@@ -110,6 +118,10 @@ void show_warning_dialog() {
         win_x = 0;
 
     WINDOW *warning_win = newwin(win_height, win_width, win_y, win_x);
+    if (!warning_win) {
+        show_message("Unable to create window");
+        return;
+    }
     keypad(warning_win, TRUE);
     wbkgd(warning_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -135,3 +135,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
 # build and run newwin failure handling test
 gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_newwin_fail.c src/ui_common.c -lncurses -o test_newwin_fail
 ./test_newwin_fail
+
+# build and run info window creation failure test
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_info_newwin_fail.c src/ui_info.c -lncurses -o test_info_newwin_fail
+./test_info_newwin_fail

--- a/tests/test_info_newwin_fail.c
+++ b/tests/test_info_newwin_fail.c
@@ -1,0 +1,66 @@
+#include <assert.h>
+#include <ncurses.h>
+#include "ui.h"
+#include "editor.h"
+#include "files.h"
+#include "config.h"
+
+#undef newwin
+#undef keypad
+#undef wbkgd
+#undef wrefresh
+#undef box
+#undef mvwprintw
+#undef wgetch
+#undef wclear
+#undef delwin
+#undef curs_set
+#undef werase
+
+/* simple WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+static SIMPLE_WIN dummy_win;
+
+WINDOW *stdscr = (WINDOW*)&dummy_win;
+WINDOW *text_win = (WINDOW*)&dummy_win;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+int enable_color = 0;
+int enable_mouse = 0;
+int show_line_numbers = 0;
+AppConfig app_config;
+
+static int show_message_called = 0;
+int show_message(const char *msg){ (void)msg; show_message_called++; return 0; }
+
+WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return NULL;}
+int keypad(WINDOW*w, bool b){(void)w;(void)b;return 0;}
+int wbkgd(WINDOW*w, chtype ch){(void)w;(void)ch;return 0;}
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char*fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
+int wgetch(WINDOW*w){(void)w;return 0;}
+int wclear(WINDOW*w){(void)w;return 0;}
+int delwin(WINDOW*w){(void)w;return 0;}
+int curs_set(int c){(void)c;return 0;}
+int werase(WINDOW*w){(void)w;return 0;}
+
+void draw_text_buffer(FileState*fs, WINDOW*w){(void)fs;(void)w;}
+void update_status_bar(FileState*fs){(void)fs;}
+
+int main(void){
+    show_message_called = 0;
+    show_help();
+    assert(show_message_called == 1);
+
+    show_message_called = 0;
+    show_about();
+    assert(show_message_called == 1);
+
+    show_message_called = 0;
+    show_warning_dialog();
+    assert(show_message_called == 1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- check return value of `newwin` in `show_help`, `show_about`, and `show_warning_dialog`
- add a regression test simulating `newwin` failure for these dialogs
- run the new test in `run_tests.sh`

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a6d1f056c8324bcc9f20769e6884a