### PR TITLE
Remove unused menuTestwindow

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -65,7 +65,7 @@ void initializeMenus() {
     menus[1] = editMenu;
 
     // Create the help menu
-    MenuItem *helpMenuItems = malloc(3 * sizeof(MenuItem));
+    MenuItem *helpMenuItems = malloc(2 * sizeof(MenuItem));
     if (helpMenuItems == NULL) {
         fprintf(stderr, "Failed to allocate memory for help menu items\n");
         freeMenus();
@@ -73,10 +73,8 @@ void initializeMenus() {
     }
     helpMenuItems[0] = (MenuItem){"About Vento", menuAbout};
     helpMenuItems[1] = (MenuItem){"Help Screen", menuHelp};
-    helpMenuItems[2] = (MenuItem){"Test Window", menuTestwindow};
-
     // Initialize and assign the help menu
-    Menu helpMenu = {"Help", helpMenuItems, 3};
+    Menu helpMenu = {"Help", helpMenuItems, 2};
     menus[2] = helpMenu;
 
     drawMenuBar(menus, menuCount);
@@ -279,19 +277,6 @@ void menuHelp() {
     show_help();
 }
 
-void menuTestwindow() {
-    char selected_path[100] = "";
-    int result = show_open_file_dialog(selected_path, sizeof(selected_path));
-    if (result) {
-        mvprintw(LINES - 2, 2, "Selected: %s", selected_path);
-        refresh();
-        getch();
-        mvprintw(LINES - 2, 2, "                             ");
-        refresh();
-    }
-    redraw();
-    drawBar();
-}
 
 /**
  * Frees the memory allocated for all menus and their menu items.

--- a/src/menu.h
+++ b/src/menu.h
@@ -31,7 +31,6 @@ void menuFind(void);
 void menuReplace(void);
 void menuAbout(void);
 void menuHelp(void);
-void menuTestwindow(void);
 void drawBar(void);
 /**
  * Frees the memory allocated for the menus and menu items.

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -108,7 +108,6 @@ void menuFind(void){}
 void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
-void menuTestwindow(void){}
 int show_goto_dialog(int *line){(void)line;return 0;}
 void go_to_line(FileState *fs,int line){(void)fs;(void)line;}
 

--- a/tests/test_resize_allocfail.c
+++ b/tests/test_resize_allocfail.c
@@ -115,7 +115,6 @@ void menuFind(void){}
 void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
-void menuTestwindow(void){}
 int show_goto_dialog(int*line){(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
 void ensure_line_loaded(FileState*fs,int idx){(void)fs;(void)idx;}

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -100,7 +100,6 @@ void menuFind(void){}
 void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
-void menuTestwindow(void){}
 int show_goto_dialog(int*line){(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
 

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -104,7 +104,6 @@ void menuFind(void){}
 void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
-void menuTestwindow(void){}
 int show_goto_dialog(int *line){(void)line;return 0;}
 void go_to_line(FileState *fs,int line){(void)fs;(void)line;}
 

--- a/tests/test_search_highlight.c
+++ b/tests/test_search_highlight.c
@@ -117,7 +117,6 @@ void menuFind(void){}
 void menuReplace(void){}
 void menuAbout(void){}
 void menuHelp(void){}
-void menuTestwindow(void){}
 int show_goto_dialog(int*line){(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
 int enable_mouse = 0;


### PR DESCRIPTION
## Summary
- drop `menuTestwindow` prototype from `menu.h`
- remove `menuTestwindow` item from Help menu and adjust item count
- delete `menuTestwindow` implementation
- clean up test stubs referencing `menuTestwindow`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a6e7298988324bc2c918cbf0fdab8