### PR TITLE
Implement menu separators

### DIFF
--- a/src/menu.h
+++ b/src/menu.h
@@ -4,6 +4,7 @@
 typedef struct MenuItem {
     const char *label;
     void (*action)(void);
+    bool separator;
 } MenuItem;
 
 typedef struct Menu {

--- a/src/menu_draw.c
+++ b/src/menu_draw.c
@@ -35,10 +35,15 @@ bool drawMenu(Menu *menu, int currentItem, int startX, int startY) {
     box(menuWin, 0, 0);
 
     for (int i = 0; i < menu->itemCount; ++i) {
+        MenuItem *item = &menu->items[i];
+        if (item->separator) {
+            mvwhline(menuWin, 1 + i, 1, ACS_HLINE, boxWidth - 2);
+            continue;
+        }
         if (i == currentItem) {
             wattron(menuWin, A_REVERSE);
         }
-        mvwprintw(menuWin, 1 + i, 1, "%s", menu->items[i].label);
+        mvwprintw(menuWin, 1 + i, 1, "%s", item->label);
         if (i == currentItem) {
             wattroff(menuWin, A_REVERSE);
         }


### PR DESCRIPTION
## Summary
- add `separator` field to `MenuItem`
- draw separator lines in menu rendering
- skip separator items in menu navigation
- reorganize menu layout with separators and new menus

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a6f1f610083248966f64386fce629