### PR TITLE
Remove unused variable from select_theme

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -463,7 +463,6 @@ const char *select_theme(const char *current, WINDOW *parent) {
     }
 
     int start = 0;
-    int own = 0;
     int win_height, win_width;
     WINDOW *win;
     if (parent) {
@@ -493,7 +492,6 @@ const char *select_theme(const char *current, WINDOW *parent) {
         show_message("Unable to create window");
         return NULL;
     }
-    own = 1;
     keypad(win, TRUE);
 
     while (1) {


### PR DESCRIPTION
## Summary
- delete unused `own` variable from `select_theme`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683a7215d1c08324b3af06324f6fa8e9