### PR TITLE
Fix menu click re-enables mouse

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -344,6 +344,7 @@ int menu_click_open(int x, int y) {
 
         int currentItem = 0;
         handleMenuNavigation(menus, menuCount, &currentMenu, &currentItem);
+        mousemask(enable_mouse ? ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION : 0, NULL);
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- call `mousemask` again after navigating menus to restore mouse state

## Testing
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_683a7593a3288324ba4c7348593e719a