### PR TITLE
Adjust default help window size

### DIFF
--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -104,8 +104,8 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         }
         own = 1;
     } else {
-        win_height = LINES - 6;
-        win_width = COLS - 10;
+        win_height = LINES * 70 / 100;
+        win_width = COLS * 70 / 100;
         if (win_width > COLS - 2)
             win_width = COLS - 2;
         if (win_width < 2)
@@ -158,8 +158,8 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
                 if (win_width < 2)
                     win_width = 2;
             } else {
-                win_height = LINES - 6;
-                win_width = COLS - 10;
+                win_height = LINES * 70 / 100;
+                win_width = COLS * 70 / 100;
                 if (win_width > COLS - 2)
                     win_width = COLS - 2;
                 if (win_width < 2)


### PR DESCRIPTION
## Summary
- adjust scrollable window margin when no parent window
- keep margins consistent during resize

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a7eb77e8083249ec56b6e282c4ba6