### PR TITLE
Improve help window sizing

### DIFF
--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -76,7 +76,8 @@ int show_message(const char *msg) {
     return ch;
 }
 
-int show_scrollable_window(const char **options, int count, WINDOW *parent) {
+int show_scrollable_window(const char **options, int count, WINDOW *parent,
+                           int width) {
     curs_set(0);
     int highlight = 0;
     int ch;
@@ -87,12 +88,16 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
 
     int own = 0;
     int win_height, win_width;
+    int desired_width = width;
     WINDOW *win;
     if (parent) {
         int ph, pw;
         getmaxyx(parent, ph, pw);
         win_height = ph - 4;
-        win_width = pw - 4;
+        if (desired_width <= 0 || desired_width > pw - 4)
+            win_width = pw - 4;
+        else
+            win_width = desired_width;
         if (win_width > COLS - 2)
             win_width = COLS - 2;
         if (win_width < 2)
@@ -105,7 +110,10 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
         own = 1;
     } else {
         win_height = LINES * 70 / 100;
-        win_width = COLS * 70 / 100;
+        if (desired_width <= 0)
+            win_width = COLS * 70 / 100;
+        else
+            win_width = desired_width;
         if (win_width > COLS - 2)
             win_width = COLS - 2;
         if (win_width < 2)
@@ -133,7 +141,7 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
             int idx = i + start;
             if (idx == highlight)
                 wattron(win, A_REVERSE);
-            mvwprintw(win, i + 1, 1, "%s", options[idx]);
+            mvwprintw(win, i + 1, 1, "%.*s", win_width - 2, options[idx]);
             wattroff(win, A_REVERSE);
         }
 
@@ -152,14 +160,20 @@ int show_scrollable_window(const char **options, int count, WINDOW *parent) {
                 int ph, pw;
                 getmaxyx(parent, ph, pw);
                 win_height = ph - 4;
-                win_width = pw - 4;
+                if (desired_width <= 0 || desired_width > pw - 4)
+                    win_width = pw - 4;
+                else
+                    win_width = desired_width;
                 if (win_width > COLS - 2)
                     win_width = COLS - 2;
                 if (win_width < 2)
                     win_width = 2;
             } else {
                 win_height = LINES * 70 / 100;
-                win_width = COLS * 70 / 100;
+                if (desired_width <= 0)
+                    win_width = COLS * 70 / 100;
+                else
+                    win_width = desired_width;
                 if (win_width > COLS - 2)
                     win_width = COLS - 2;
                 if (win_width < 2)

--- a/src/ui_common.h
+++ b/src/ui_common.h
@@ -7,7 +7,8 @@
 WINDOW *create_centered_window(int height, int width, WINDOW *parent);
 WINDOW *create_popup_window(int height, int width, WINDOW *parent);
 int show_message(const char *msg);
-int show_scrollable_window(const char **options, int count, WINDOW *parent);
+int show_scrollable_window(const char **options, int count, WINDOW *parent,
+                           int width);
 void str_to_upper(char *dst, const char *src, size_t dst_size);
 
 #endif // UI_COMMON_H

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -41,7 +41,19 @@ void show_help() {
     };
 
     int help_count = sizeof(help_lines) / sizeof(help_lines[0]);
-    show_scrollable_window(help_lines, help_count, NULL);
+
+    int max_len = 0;
+    for (int i = 0; i < help_count; ++i) {
+        int len = (int)strlen(help_lines[i]);
+        if (len > max_len)
+            max_len = len;
+    }
+
+    int win_width = max_len + 4; // add padding for borders
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+
+    show_scrollable_window(help_lines, help_count, NULL, win_width);
     wrefresh(stdscr);
     curs_set(1);
 }


### PR DESCRIPTION
## Summary
- compute longest help text line
- size help dialog according to text length
- allow scrollable window width parameter
- truncate long lines in scrollable window

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a7fce7e388324bf02dcd589067e0a