### PR TITLE
Initialize locale before curses

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -1,6 +1,7 @@
 #include <ncurses.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <locale.h>
 #include "editor.h"
 #include "config.h"
 #include "ui.h"
@@ -27,6 +28,7 @@ void apply_colors() {
 }
 
 void initialize() {
+    setlocale(LC_ALL, "");
     initscr();
     config_load(&app_config);
     apply_colors();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -145,3 +145,7 @@ gcc -Wall -Wextra -std=c99 -g -Isrc -c src/ui_info.c -o obj_test/ui_info_fail.o
 gcc -Wall -Wextra -std=c99 -g -Isrc -DUSE_WEAK_MESSAGE -c src/ui_common.c -o obj_test/ui_common_fail.o
 gcc obj_test/test_info_newwin_fail.o obj_test/ui_info_fail.o obj_test/ui_common_fail.o -lncurses -o test_info_newwin_fail
 ./test_info_newwin_fail
+
+# build and run UTF-8 print regression test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_utf8_print.c -lncurses -o test_utf8_print
+./test_utf8_print

--- a/tests/test_utf8_print.c
+++ b/tests/test_utf8_print.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <ncurses.h>
+#include <signal.h>
+#include "config.h"
+#include "file_manager.h"
+#include "files.h"
+#include "editor.h"
+
+#undef initscr
+#undef cbreak
+#undef noecho
+#undef keypad
+#undef meta
+#undef mousemask
+#undef timeout
+#undef bkgd
+#undef wbkgd
+#undef refresh
+#undef sigaction
+#undef define_key
+#undef addstr
+
+/* global state required by editor_init.c */
+WINDOW *stdscr = (WINDOW*)1;
+FileManager file_manager = {0};
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+int exiting = 0;
+int enable_color = 0;
+int enable_mouse = 0;
+int show_line_numbers = 0;
+AppConfig app_config;
+
+static const char *printed = NULL;
+
+/* stub ncurses functions */
+WINDOW *initscr(void){ return (WINDOW*)1; }
+int cbreak(void){ return 0; }
+int noecho(void){ return 0; }
+int keypad(WINDOW*w,bool b){ (void)w; (void)b; return 0; }
+int meta(WINDOW*w,bool b){ (void)w; (void)b; return 0; }
+mmask_t mousemask(mmask_t newmask, mmask_t *old){ if(old) *old = 0; (void)newmask; return 0; }
+void timeout(int t){ (void)t; }
+int bkgd(chtype ch){ (void)ch; return 0; }
+int wbkgd(WINDOW*w, chtype ch){ (void)w; (void)ch; return 0; }
+int refresh(void){ return 0; }
+int sigaction(int s,const struct sigaction*a, struct sigaction*o){ (void)s;(void)a;(void)o; return 0; }
+int define_key(const char*s,int k){ (void)s; (void)k; return 0; }
+int addstr(const char*s){ printed = s; return 0; }
+
+void initialize_key_mappings(void){}
+void initializeMenus(void){}
+void update_status_bar(FileState*fs){ (void)fs; }
+void freeMenus(void){}
+void syntax_cleanup(void){}
+void free_stack(Node*stack){ (void)stack; }
+void free_file_state(FileState*fs,int max){ (void)fs; (void)max; }
+void on_sigwinch(int sig){ (void)sig; }
+
+/* minimal config_load stub */
+void config_load(AppConfig *cfg){ (void)cfg; }
+
+#include "../src/editor_init.c"
+
+int main(void){
+    initialize();
+    addstr("UTF-8: \xCF\x80");
+    assert(printed != NULL);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- set locale before initializing ncurses
- add regression test exercising UTF‑8 output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a8a1d54f88324919c4112fb1cc57a