### PR TITLE
Handle NUL input in editor loop

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -397,7 +397,8 @@ void run_editor() {
     wmove(text_win, active_file->cursor_y,
           active_file->cursor_x + get_line_number_offset(active_file));
 
-    while ((ch = wgetch(text_win)) && exiting == 0) { // Exit on ESC key
+    while (exiting == 0) {
+        ch = wgetch(text_win);
         if (resize_pending || ch == KEY_RESIZE) {
             perform_resize();
             resize_pending = 0;


### PR DESCRIPTION
## Summary
- keep reading input even when NUL is returned
- loop while `exiting` is `0`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a8af3ccc48324b9d60cd8816c0484