### PR TITLE
Ensure status messages clear line

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -54,6 +54,8 @@ void find_next_occurrence(FileState *fs, const char *word) {
 
     if (!found_position) {
         mvprintw(LINES - 2, 0, "Word not found.");
+        clrtoeol();
+        refresh();
         fs->match_start_y = fs->match_end_y = -1;
         fs->match_start_x = fs->match_end_x = -1;
     } else {
@@ -80,8 +82,9 @@ void find_next_occurrence(FileState *fs, const char *word) {
         fs->match_end_x = fs->match_start_x + strlen(word) - 1;
 
         mvprintw(LINES - 2, 0, "Found at Line: %d, Column: %d", *cursor_y + fs->start_line + 1, *cursor_x + 1);
+        clrtoeol();
+        refresh();
     }
-    refresh();
     int off = get_line_number_offset ? get_line_number_offset(fs) : 0;
     wmove(text_win, *cursor_y,
           *cursor_x + off);
@@ -168,6 +171,7 @@ void replace_next_occurrence(FileState *fs, const char *search,
 
     if (!found_position) {
         mvprintw(LINES - 2, 0, "Word not found.");
+        clrtoeol();
         refresh();
         return;
     }
@@ -191,6 +195,7 @@ void replace_next_occurrence(FileState *fs, const char *search,
     *cursor_x = (found_position - fs->text_buffer[found_line]) + strlen(replacement) + 1;
 
     mvprintw(LINES - 2, 0, "Replaced at Line: %d, Column: %d", *cursor_y + fs->start_line + 1, *cursor_x);
+    clrtoeol();
     refresh();
     werase(text_win);
     box(text_win, 0, 0);
@@ -216,6 +221,7 @@ void replace_all_occurrences(FileState *fs, const char *search,
         char *old_text = strdup(line_text);
         if (!old_text) {
             mvprintw(LINES - 2, 0, "Memory allocation failed");
+            clrtoeol();
             refresh();
             continue;
         }
@@ -227,6 +233,7 @@ void replace_all_occurrences(FileState *fs, const char *search,
         if (!new_line) {
             free(old_text);
             mvprintw(LINES - 2, 0, "Memory allocation failed");
+            clrtoeol();
             refresh();
             continue;
         }
@@ -263,6 +270,7 @@ void replace_all_occurrences(FileState *fs, const char *search,
             free(old_text);
             free(new_line);
             mvprintw(LINES - 2, 0, "Memory allocation failed");
+            clrtoeol();
             refresh();
             continue;
         }
@@ -284,6 +292,7 @@ void replace_all_occurrences(FileState *fs, const char *search,
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
     mvprintw(LINES - 2, 0, "All occurrences replaced.");
+    clrtoeol();
     refresh();
     wrefresh(text_win);
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -106,6 +106,10 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_search_highlig
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc tests/test_replace_modified.c src/search.c -lncurses -o test_replace_modified
 ./test_replace_modified
 
+# build and run status line clear test
+gcc -Wall -Wextra -std=c99 -g tests/test_status_line_clear.c -lncurses -o test_status_line_clear
+./test_status_line_clear
+
 # build and run undo/redo modified flag test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_undo_redo_modified.c src/undo.c -lncurses -o test_undo_redo_modified
 ./test_undo_redo_modified

--- a/tests/test_status_line_clear.c
+++ b/tests/test_status_line_clear.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdio.h>
+#include <ncurses.h>
+#undef mvprintw
+#undef clrtoeol
+#undef refresh
+
+static char line[81];
+static char displayed[81];
+static int cursor_end;
+
+int mvprintw(int y,int x,const char*fmt,...){(void)y;va_list ap;va_start(ap,fmt);char buf[81];int n=vsnprintf(buf,sizeof(buf),fmt,ap);va_end(ap);if(n<0)n=0;if(x+n>80)n=80-x;memcpy(line+x,buf,n);cursor_end=x+n;return 0;}
+int clrtoeol(void){for(int i=cursor_end;i<80;++i)line[i]=' ';line[80]='\0';return 0;}
+int refresh(void){memcpy(displayed,line,sizeof(line));return 0;}
+
+static void rtrim(char*s){for(int i=79;i>=0&&s[i]==' ';--i)s[i]='\0';}
+
+int main(void){
+    memset(line,' ',sizeof(line));line[80]='\0';
+    mvprintw(22,0,"First long message");
+    clrtoeol();
+    refresh();
+    mvprintw(22,0,"Short");
+    clrtoeol();
+    refresh();
+    char buf[81];memcpy(buf,displayed,sizeof(buf));rtrim(buf);assert(strcmp(buf,"Short")==0);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- clear the remainder of the status line in `search.c`
- add regression test for consecutive status messages

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a8bedab408324b54ad2a45259aa1c