### PR TITLE
Fix replace_in_line memory usage

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -126,7 +126,12 @@ static void replace_in_line(FileState *fs, int line, char *pos,
     size_t suffix_len = strlen(pos + search_len);
     size_t replacement_len = strlen(replacement);
 
-    char new_line[fs->line_capacity];
+    char *new_line = malloc(fs->line_capacity);
+    if (!new_line) {
+        free(old_text);
+        allocation_failed("replace_in_line malloc");
+    }
+
     if (prefix_len >= (size_t)fs->line_capacity)
         prefix_len = fs->line_capacity - 1;
     strncpy(new_line, line_text, prefix_len);
@@ -154,6 +159,7 @@ static void replace_in_line(FileState *fs, int line, char *pos,
     push(&fs->undo_stack, change);
     strncpy(fs->text_buffer[line], new_line, fs->line_capacity - 1);
     fs->text_buffer[line][fs->line_capacity - 1] = '\0';
+    free(new_line);
     fs->modified = true;
     mark_comment_state_dirty(fs);
 }

--- a/tests/test_replace_modified.c
+++ b/tests/test_replace_modified.c
@@ -33,13 +33,14 @@ int show_find_dialog(char*out,int sz,const char*def){(void)out;(void)sz;(void)de
 int show_replace_dialog(char*s,int ss,char*r,int rs){(void)s;(void)ss;(void)r;(void)rs;return 0;}
 
 void draw_text_buffer(FileState*fs, WINDOW*w){(void)fs;(void)w;}
-void push(Node **stack, Change change){(void)stack; free(change.old_text); free(change.new_text);} 
+void push(Node **stack, Change change){(void)stack; free(change.old_text); free(change.new_text);}
 void mark_comment_state_dirty(FileState*fs){(void)fs;}
 int get_line_number_offset(FileState*fs){(void)fs;return 0;}
+void allocation_failed(const char*msg){(void)msg; abort();}
 
 int main(void){
     FileState fs = {0};
-    fs.line_capacity = 64;
+    fs.line_capacity = 2048;
     fs.max_lines = 2;
     fs.text_buffer = calloc(fs.max_lines, sizeof(char*));
     for(int i=0;i<fs.max_lines;i++) fs.text_buffer[i]=calloc(fs.line_capacity, sizeof(char));


### PR DESCRIPTION
## Summary
- avoid a VLA in `replace_in_line` by dynamically allocating a buffer
- add allocation failure handling and free the buffer
- update replace test to work with larger line capacities

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a90758d088324975b7a4a9421ee98