### PR TITLE
Fix shebang detection with mixed case

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -1,5 +1,6 @@
 #include <ncurses.h>
 #include <string.h>
+#include <ctype.h>
 #include <stdio.h>
 #include "editor.h"
 #include "ui.h"
@@ -238,12 +239,18 @@ int set_syntax_mode(const char *filename) {
     if (fp) {
         char first[256];
         if (fgets(first, sizeof(first), fp)) {
-            if (strncmp(first, "#!", 2) == 0) {
-                if (strstr(first, "python")) {
+            char lower[256];
+            size_t i;
+            for (i = 0; i < sizeof(lower) - 1 && first[i]; i++) {
+                lower[i] = (char)tolower((unsigned char)first[i]);
+            }
+            lower[i] = '\0';
+            if (strncmp(lower, "#!", 2) == 0) {
+                if (strstr(lower, "python")) {
                     fclose(fp);
                     return PYTHON_SYNTAX;
                 }
-                if (strstr(first, "bash") || strstr(first, "sh")) {
+                if (strstr(lower, "bash") || strstr(lower, "sh")) {
                     fclose(fp);
                     return SHELL_SYNTAX;
                 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -92,6 +92,11 @@ gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_shebang_detection.c src/file_ops.
     obj_test/stubs_file_ops.o obj_test/syntax_regex.o -lncurses -o test_shebang_detection
 ./test_shebang_detection
 
+# build and run shebang case-insensitive detection test
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_shebang_case.c src/file_ops.c \
+    obj_test/stubs_file_ops.o obj_test/syntax_regex.o -lncurses -o test_shebang_case
+./test_shebang_case
+
 # build and run regex complex construct test
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_c.c -o obj_test/syntax_c.o
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc tests/test_regex_complex.c \

--- a/tests/test_shebang_case.c
+++ b/tests/test_shebang_case.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "file_ops.h"
+#include "syntax.h"
+
+int main(void){
+    const char *file = "tmp_py_case.sh";
+    FILE *fp = fopen(file, "w");
+    fprintf(fp, "#!/usr/bin/Python\n");
+    fclose(fp);
+    assert(set_syntax_mode(file) == PYTHON_SYNTAX);
+    unlink(file);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure shebang line is compared in lowercase
- test mixed-case shebang handling

## Testing
- `sh tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a92c1243c8324838f4ed44b9bf990