### PR TITLE
Add quit confirmation logic

### DIFF
--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdbool.h>
 #include "file_manager.h"
 
 FileManager file_manager;
@@ -48,5 +49,15 @@ int fm_switch(FileManager *fm, int index) {
     if (!fm || index < 0 || index >= fm->count) return -1;
     fm->active_index = index;
     return fm->active_index;
+}
+
+bool any_file_modified(FileManager *fm) {
+    if (!fm) return false;
+    for (int i = 0; i < fm->count; i++) {
+        FileState *fs = fm->files[i];
+        if (fs && fs->modified)
+            return true;
+    }
+    return false;
 }
 

--- a/src/file_manager.h
+++ b/src/file_manager.h
@@ -2,6 +2,7 @@
 #define FILE_MANAGER_H
 
 #include "files.h"
+#include <stdbool.h>
 
 typedef struct FileManager {
     FileState **files;
@@ -16,5 +17,6 @@ FileState *fm_current(FileManager *fm);
 int fm_add(FileManager *fm, FileState *fs);
 void fm_close(FileManager *fm, int index);
 int fm_switch(FileManager *fm, int index);
+bool any_file_modified(FileManager *fm);
 
 #endif // FILE_MANAGER_H

--- a/src/menu.c
+++ b/src/menu.c
@@ -9,6 +9,9 @@
 #include "undo.h"
 #include "config.h"
 
+/* confirm_quit implemented in vento.c */
+bool confirm_quit(void);
+
 Menu *menus = NULL;
 int menuCount = 0;
 int *menuPositions = NULL;
@@ -313,7 +316,8 @@ void menuSettings() {
 }
 
 void menuQuitEditor() {
-    close_editor();
+    if (confirm_quit())
+        close_editor();
 }
 
 void menuUndo() {

--- a/src/vento.c
+++ b/src/vento.c
@@ -8,6 +8,20 @@
 #include "ui.h"
 #include "files.h"
 #include "file_manager.h"
+#include "ui_common.h"
+#include <stdbool.h>
+
+bool confirm_quit(void) {
+    if (!any_file_modified(&file_manager))
+        return true;
+
+    int ch = show_message("Unsaved changes. Quit anyway? (y/n)");
+    if (ch == 'y' || ch == 'Y')
+        return true;
+    if (ch == 'n' || ch == 'N')
+        return false;
+    return false;
+}
 
 
 /**

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -158,3 +158,8 @@ gcc obj_test/test_info_newwin_fail.o obj_test/ui_info_fail.o obj_test/ui_common_
 # build and run UTF-8 print regression test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_utf8_print.c -lncurses -o test_utf8_print
 ./test_utf8_print
+
+# build and run confirm quit regression test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_confirm_quit.c \
+    obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_confirm_quit
+./test_confirm_quit

--- a/tests/test_confirm_quit.c
+++ b/tests/test_confirm_quit.c
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "menu.h"
+#include "editor.h"
+#include "config.h"
+#include "ui_common.h"
+
+#undef refresh
+#undef getch
+#undef box
+#undef mousemask
+#undef getmouse
+#undef wrefresh
+#undef wclear
+#undef mvwprintw
+#undef werase
+#undef curs_set
+
+/* stub ncurses functions */
+int COLS = 80;
+int LINES = 24;
+WINDOW *text_win = NULL;
+WINDOW *stdscr = NULL;
+int curs_set(int c){(void)c;return 0;}
+int werase(WINDOW*w){(void)w;return 0;}
+int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int refresh(void){return 0;}
+int getch(void){return 0;}
+int getmouse(MEVENT*ev){(void)ev;return 0;}
+mmask_t mousemask(mmask_t newmask, mmask_t *oldmask){(void)newmask;(void)oldmask;return 0;}
+int wclear(WINDOW*w){(void)w;return 0;}
+int mvwprintw(WINDOW*w,int y,int x,const char*fmt,...){(void)w;(void)y;(void)x;(void)fmt;return 0;}
+
+/* globals used by menu.c */
+FileState *active_file = NULL;
+int enable_mouse = 0;
+AppConfig app_config;
+
+/* stubs for external editor functions */
+void draw_text_buffer(FileState*fs,WINDOW*w){(void)fs;(void)w;}
+void update_status_bar(FileState*fs){(void)fs;}
+bool drawMenu(Menu*menu,int ci,int sx,int sy){(void)menu;(void)ci;(void)sx;(void)sy;return true;}
+void drawMenuBar(Menu*m,int mc){(void)m;(void)mc;}
+void new_file(FileState*fs){(void)fs;}
+void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
+void save_file(FileState*fs){(void)fs;}
+void save_file_as(FileState*fs){(void)fs;}
+void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void next_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void prev_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+int show_settings_dialog(AppConfig*cfg){(void)cfg;return 0;}
+void config_save(const AppConfig*cfg){(void)cfg;}
+void config_load(AppConfig*cfg){(void)cfg;}
+void apply_colors(void){}
+void redraw(void){}
+void drawBar(void){}
+void undo(FileState*fs){(void)fs;}
+void redo(FileState*fs){(void)fs;}
+void find(FileState*fs,int n){(void)fs;(void)n;}
+void replace(FileState*fs){(void)fs;}
+void show_about(void){}
+void show_help(void){}
+void allocation_failed(const char*msg){(void)msg;abort();}
+void initialize(void){}
+void show_warning_dialog(void){}
+void run_editor(void){}
+void cleanup_on_exit(FileManager*fm){(void)fm;}
+
+/* intercept close_editor */
+static int close_called = 0;
+void close_editor(void){close_called++;}
+
+/* stub show_message returning 'n' */
+int show_message(const char*msg){(void)msg;return 'n';}
+
+/* include implementation */
+#define main vento_main
+#include "../src/vento.c"
+#undef main
+#include "../src/menu.c"
+
+int main(void){
+    fm_init(&file_manager);
+    FileState fs = {0};
+    fs.modified = true;
+    file_manager.files = malloc(sizeof(FileState*));
+    file_manager.files[0] = &fs;
+    file_manager.count = 1;
+    file_manager.active_index = 0;
+    active_file = &fs;
+
+    close_called = 0;
+    menuQuitEditor();
+    assert(close_called == 0);
+
+    free(file_manager.files);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- detect if any file in the manager is modified
- prompt before quitting when unsaved changes exist
- gate `menuQuitEditor` behind confirmation
- regression test for quit confirmation

## Testing
- `bash tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a94323d8c8324b70d7bbc1a32bd70