### PR TITLE
Fix show_message newwin NULL handling

### DIFF
--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -64,6 +64,11 @@ int show_message(const char *msg) {
         win_x = 0;
 
     WINDOW *win = newwin(win_height, win_width, win_y, win_x);
+    if (!win) {
+        fprintf(stderr, "%s\n", msg);
+        curs_set(1);
+        return ERR;
+    }
     box(win, 0, 0);
     mvwprintw(win, 1, 2, "%s", msg);
     wrefresh(win);

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -53,7 +53,8 @@ void show_help() {
     if (win_width > COLS - 2)
         win_width = COLS - 2;
 
-    show_scrollable_window(help_lines, help_count, NULL, win_width);
+    if (show_scrollable_window(help_lines, help_count, NULL, win_width) == ERR)
+        return;
     wrefresh(stdscr);
     curs_set(1);
 }
@@ -71,7 +72,8 @@ void show_about() {
 
     WINDOW *about_win = newwin(win_height, win_width, win_y, win_x);
     if (!about_win) {
-        show_message("Unable to create window");
+        if (show_message("Unable to create window") == ERR)
+            return;
         return;
     }
     keypad(about_win, TRUE);
@@ -107,7 +109,8 @@ void show_warning_dialog() {
 
     WINDOW *warning_win = newwin(win_height, win_width, win_y, win_x);
     if (!warning_win) {
-        show_message("Unable to create window");
+        if (show_message("Unable to create window") == ERR)
+            return;
         return;
     }
     keypad(warning_win, TRUE);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -148,6 +148,10 @@ gcc obj_test/test_dialog_color_disable.o obj_test/ui.o obj_test/ui_info.o obj_te
 gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_newwin_fail.c src/ui_common.c -lncurses -o test_newwin_fail
 ./test_newwin_fail
 
+# build and run show_message newwin failure test
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_show_message_fail.c src/ui_common.c -lncurses -o test_show_message_fail
+./test_show_message_fail
+
 # build and run info window creation failure test
 gcc -Wall -Wextra -std=c99 -g -Isrc -c tests/test_info_newwin_fail.c -o obj_test/test_info_newwin_fail.o
 gcc -Wall -Wextra -std=c99 -g -Isrc -c src/ui_info.c -o obj_test/ui_info_fail.o

--- a/tests/test_show_message_fail.c
+++ b/tests/test_show_message_fail.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <setjmp.h>
+#include <ncurses.h>
+#include "ui_common.h"
+#include "config.h"
+
+#undef newwin
+#undef curs_set
+
+int COLS = 80;
+int LINES = 24;
+int enable_color = 0;
+int enable_mouse = 0;
+int show_line_numbers = 0;
+AppConfig app_config;
+WINDOW *stdscr = NULL;
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){(void)nlines;(void)ncols;(void)y;(void)x;return NULL;}
+int curs_set(int c){(void)c;return 0;}
+int endwin(void){return 0;}
+
+static jmp_buf jb;
+void exit(int status){longjmp(jb,1);} // catch unexpected exit
+
+int main(void){
+    if(setjmp(jb)!=0){
+        assert(!"program called exit");
+    }
+    int r = show_message("test message");
+    assert(r == ERR);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- check the result of `newwin` in `show_message`
- propagate errors from `show_message` to info helpers
- add unit test for show_message failing to create a window

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a95fb1318832484df198c1f32e66d