### PR TITLE
Add command line options and version test

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ make CFLAGS="-D_DARWIN_C_SOURCE"
 The code already guards `SIGWINCH`, but enabling additional feature macros may
 be required for full functionality.
 
+## Command Line Options
+
+You can pass a few simple flags when starting Vento:
+
+```
+vento [options] [file...]
+```
+
+- `-h`, `--help` &mdash; show a short help message and exit.
+- `-v`, `--version` &mdash; print the current version number and exit.
+
+Any additional arguments are treated as files to load on startup.
+
 ## Enabling Debug Output
 
 Vento includes optional debug messages within the configuration loader. To see

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -14,6 +14,9 @@ Vento has been tested on Linux and macOS and should also build on BSD derivative
 .TP
 .BR \-h , \-\-help
 Display the help screen and exit.
+.TP
+.BR \-v , \-\-version
+Print the program version and exit.
 .SH CONFIGURATION
 User preferences are stored in \fI~/.ventorc\fP.  The file is created automatically if it does not exist.  Recognized keys include:
 .IP \[bu] 2

--- a/src/vento.c
+++ b/src/vento.c
@@ -32,14 +32,34 @@ bool confirm_quit(void) {
  * @return 0 on successful execution.
  */
 int main(int argc, char *argv[]) {
+    int file_count = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            printf("Usage: %s [options] [file...]\n", argv[0]);
+            printf("  -h, --help     Show this help and exit\n");
+            printf("  -v, --version  Print version information and exit\n");
+            return 0;
+        } else if (strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
+            printf("%s\n", VERSION);
+            return 0;
+        }
+    }
+
     initialize();
 
     fm_init(&file_manager);
 
-    // Load initial file or create a new one
-    if (argc > 1) {
-        load_file(NULL, argv[1]);
-    } else {
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0 ||
+            strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
+            continue;
+        }
+        load_file(NULL, argv[i]);
+        file_count++;
+    }
+
+    if (file_count == 0) {
         new_file(NULL);
     }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -167,3 +167,8 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_utf8_pr
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_confirm_quit.c \
     obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_confirm_quit
 ./test_confirm_quit
+
+# build and run version option test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_cli_version.c -lncurses -o test_cli_version
+./test_cli_version

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "files.h"
+#include "editor.h"
+#include "ui.h"
+#include "ui_common.h"
+#include "config.h"
+
+FileManager file_manager;
+FileState *active_file = NULL;
+WINDOW *text_win = NULL;
+int COLS = 80;
+int LINES = 24;
+
+bool any_file_modified(FileManager *fm){(void)fm;return false;}
+int show_message(const char*msg){(void)msg;return 0;}
+void initialize(void){}
+void fm_init(FileManager *fm){(void)fm;}
+void load_file(FileState *fs,const char*fn){(void)fs;(void)fn;}
+void new_file(FileState *fs){(void)fs;}
+FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
+void show_warning_dialog(void){}
+void run_editor(void){}
+void cleanup_on_exit(FileManager *fm){(void)fm;}
+
+#define main vento_main
+#include "../src/vento.c"
+#undef main
+
+int main(void){
+    char *argv[] = {"vento", "--version"};
+    FILE *tmp = tmpfile();
+    assert(tmp);
+    int fd = fileno(tmp);
+    int saved = dup(1);
+    dup2(fd,1);
+    vento_main(2, argv);
+    fflush(stdout);
+    dup2(saved,1);
+    lseek(fd,0,SEEK_SET);
+    char buf[64];
+    size_t n = fread(buf,1,sizeof(buf)-1,tmp);
+    buf[n] = '\0';
+    assert(strstr(buf, VERSION) != NULL);
+    fclose(tmp);
+    close(saved);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `--help` and `--version` handling in `main`
- document these options in `README.md` and `docs/vento.1`
- add a regression test for `--version`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a97305a688324bf64ad2212903075