### PR TITLE
Support multiple files on launch

### DIFF
--- a/docs/vento.1
+++ b/docs/vento.1
@@ -2,8 +2,7 @@
 .SH NAME
 vento \- a simple text editor
 .SH SYNOPSIS
-.B vento
-.RI [ options ] " [file...]"
+.BR vento " [options] [file...]"
 .SH DESCRIPTION
 .B Vento
 is a lightweight terminal based text editor focused on simplicity.  It supports editing multiple files at once, customizable color themes, optional line numbers and full mouse interaction.  A status bar shows the current line and column, and a scroll bar indicates your position in the document.  Basic syntax highlighting is provided for C, HTML and Python.  Files can be loaded from the command line or through a file dialog and a menu system exposes common actions.

--- a/src/vento.c
+++ b/src/vento.c
@@ -50,12 +50,20 @@ int main(int argc, char *argv[]) {
 
     fm_init(&file_manager);
 
+    int first_index = -1;
+
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0 ||
             strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
             continue;
         }
+
         load_file(NULL, argv[i]);
+        if (first_index == -1)
+            first_index = file_manager.active_index;
+        else
+            fm_switch(&file_manager, first_index);
+
         file_count++;
     }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -172,3 +172,8 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_confirm
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_cli_version.c -lncurses -o test_cli_version
 ./test_cli_version
+
+# build and run multi-file main loading test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_main_multifile.c -lncurses -o test_main_multifile
+./test_main_multifile

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -23,6 +23,7 @@ void fm_init(FileManager *fm){(void)fm;}
 void load_file(FileState *fs,const char*fn){(void)fs;(void)fn;}
 void new_file(FileState *fs){(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
+int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(void){}
 void run_editor(void){}
 void cleanup_on_exit(FileManager *fm){(void)fm;}

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -1,0 +1,78 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "files.h"
+#include "editor.h"
+#include "ui.h"
+#include "ui_common.h"
+#include "config.h"
+
+/* globals normally provided elsewhere */
+FileState *active_file = NULL;
+WINDOW *text_win = NULL;
+int COLS = 80;
+int LINES = 24;
+FileManager file_manager = {0};
+
+void fm_init(FileManager *fm){fm->files=NULL;fm->count=0;fm->active_index=-1;}
+FileState* fm_current(FileManager *fm){if(!fm||fm->active_index<0||fm->active_index>=fm->count)return NULL;return fm->files[fm->active_index];}
+int fm_add(FileManager *fm,FileState *fs){FileState **tmp=realloc(fm->files,sizeof(FileState*)*(fm->count+1));if(!tmp)abort();fm->files=tmp;fm->files[fm->count]=fs;fm->active_index=fm->count;return fm->count++;}
+int fm_switch(FileManager *fm,int idx){if(!fm||idx<0||idx>=fm->count)return -1;fm->active_index=idx;return idx;}
+
+/* stubs for unused functionality */
+bool any_file_modified(FileManager *fm){(void)fm;return false;}
+int show_message(const char*msg){(void)msg;return 0;}
+void initialize(void){}
+void show_warning_dialog(void){}
+void run_editor(void){}
+int endwin(void){return 0;}
+void cleanup_on_exit(FileManager *fm){(void)fm;}
+
+/* simplified file loader used by main */
+void load_file(FileState *fs_unused,const char *filename){
+    (void)fs_unused;
+    FileState *fs = calloc(1, sizeof(FileState));
+    assert(fs);
+    strncpy(fs->filename, filename, sizeof(fs->filename)-1);
+    int idx = fm_add(&file_manager, fs);
+    fm_switch(&file_manager, idx);
+    active_file = fm_current(&file_manager);
+}
+
+void new_file(FileState *fs_unused){
+    (void)fs_unused;
+    FileState *fs = calloc(1,sizeof(FileState));
+    assert(fs);
+    int idx = fm_add(&file_manager, fs);
+    fm_switch(&file_manager, idx);
+    active_file = fm_current(&file_manager);
+}
+
+#define main vento_main
+#include "../src/vento.c"
+#undef main
+
+int main(void){
+    /* create two temp files */
+    char t1[] = "file1XXXXXX";
+    char t2[] = "file2XXXXXX";
+    int fd1 = mkstemp(t1);
+    int fd2 = mkstemp(t2);
+    assert(fd1 >= 0 && fd2 >= 0);
+    close(fd1);
+    close(fd2);
+
+    char *argv[] = {"vento", t1, t2};
+    vento_main(3, argv);
+
+    assert(file_manager.count == 2);
+    assert(strcmp(file_manager.files[0]->filename, t1) == 0);
+    assert(strcmp(file_manager.files[1]->filename, t2) == 0);
+
+    unlink(t1);
+    unlink(t2);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- retain active buffer while loading multiple files in main
- document multiple file arguments in the man page
- stub `fm_switch` in the CLI version test
- add regression test exercising multi-file startup

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a9849706883248659a0aeda689d92