### PR TITLE
Improve integer parsing and add tests

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -3,6 +3,8 @@
 #include "config.h"
 #include <ncurses.h>
 #include <stdio.h>
+#include <errno.h>
+#include <limits.h>
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
@@ -748,8 +750,12 @@ int select_int(const char *prompt, int current, WINDOW *parent) {
     }
     if (buf[0] == '\0')
         return current;
-    int val = atoi(buf);
-    if (val <= 0)
-        val = current;
-    return val;
+
+    errno = 0;
+    char *end;
+    long val = strtol(buf, &end, 10);
+    if (errno != 0 || *end != '\0' || val > INT_MAX || val <= 0)
+        return current;
+
+    return (int)val;
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -5,6 +5,7 @@ rm -rf obj_test
 mkdir obj_test
 
 # compile sources for paste test
+gcc -Wall -Wextra -std=c99 -g -Isrc -c tests/stub_ui_settings_deps.c -o obj_test/stub_ui_settings_deps.o
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/clipboard.c -o obj_test/clipboard.o
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/files.c -o obj_test/files.o
 gcc -Wall -Wextra -std=c99 -g -Isrc -c tests/stub_enable_color.c -o obj_test/stub_enable_color.o
@@ -177,3 +178,15 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_main_multifile.c -lncurses -o test_main_multifile
 ./test_main_multifile
+
+# build and run select_int valid input test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_select_int_valid.c src/ui_settings.c \
+    obj_test/stub_ui_settings_deps.o -lncurses -o test_select_int_valid
+./test_select_int_valid
+
+# build and run select_int invalid input test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_select_int_invalid.c src/ui_settings.c \
+    obj_test/stub_ui_settings_deps.o -lncurses -o test_select_int_invalid
+./test_select_int_invalid

--- a/tests/stub_ui_settings_deps.c
+++ b/tests/stub_ui_settings_deps.c
@@ -1,0 +1,19 @@
+#include <ncurses.h>
+#include "config.h"
+#undef wrefresh
+#undef touchwin
+
+WINDOW *stdscr = (WINDOW*)1;
+int enable_color = 0;
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int touchwin(WINDOW*w){(void)w;return 0;}
+int enable_mouse = 0;
+int show_line_numbers = 0;
+AppConfig app_config = {0};
+
+WINDOW *create_popup_window(int h, int w, WINDOW *parent){(void)h;(void)w;(void)parent;return (WINDOW*)1;}
+int show_message(const char*msg){(void)msg;return 0;}
+short get_color_code(const char*name){(void)name;return 0;}
+void load_theme(const char*name, AppConfig*cfg){(void)name;(void)cfg;}
+
+

--- a/tests/test_select_int_invalid.c
+++ b/tests/test_select_int_invalid.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <string.h>
+#include <ncurses.h>
+#include "ui.h"
+#include "config.h"
+int select_int(const char *prompt, int current, WINDOW *parent);
+
+// We'll run several cases: negative, non-digit, overflow
+static const char *inputs[] = {"-1", "abc", "99999999999999999999999999"};
+static int case_index = 0;
+
+void create_dialog(const char *message, char *output, int max_input_len){
+    (void)message;
+    strncpy(output, inputs[case_index], max_input_len);
+    if(max_input_len>0) output[max_input_len-1]='\0';
+}
+
+int main(void){
+    for(case_index=0; case_index<3; ++case_index){
+        int result = select_int("Num", 5, NULL);
+        assert(result == 5); // should return current
+    }
+    return 0;
+}

--- a/tests/test_select_int_valid.c
+++ b/tests/test_select_int_valid.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <string.h>
+#include <ncurses.h>
+#include "ui.h"
+#include "config.h"
+int select_int(const char *prompt, int current, WINDOW *parent);
+
+// stub create_dialog to provide valid numeric input
+void create_dialog(const char *message, char *output, int max_input_len){
+    (void)message;
+    strncpy(output, "42", max_input_len);
+    if(max_input_len>0) output[max_input_len-1]='\0';
+}
+
+int main(void){
+    int result = select_int("Num", 7, NULL);
+    assert(result == 42);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- use `strtol` in `select_int` with full validation
- provide stubs and unit tests for numeric input handling

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683a9f0695148324a0d43bb4cdb1b02a