### PR TITLE
Fix menu overlay clearing on switch

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -118,12 +118,18 @@ void initializeMenus() {
 void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *currentItem) {
     int ch;
     bool inMenu = true;
+    int prevMenu = -1;
 
     curs_set(0);
     /* Keep the existing text content displayed while the menu is open */
     wnoutrefresh(text_win);
 
     while (inMenu) {
+        if (*currentMenu != prevMenu) {
+            touchwin(text_win);
+            wnoutrefresh(text_win);
+            prevMenu = *currentMenu;
+        }
         if (*currentMenu < 0 || *currentMenu >= menuCount) {
             inMenu = false;
             continue;
@@ -267,6 +273,10 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
                 break;
         }
     }
+    touchwin(text_win);
+    wnoutrefresh(text_win);
+    wnoutrefresh(stdscr);
+    doupdate();
     curs_set(1);
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -174,6 +174,11 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_menu_no_clear.c -lncurses -o test_menu_no_clear
 ./test_menu_no_clear
 
+# build and run menu switch clear regression test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_menu_switch.c -lncurses -o test_menu_switch
+./test_menu_switch
+
 # build and run version option test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_cli_version.c -lncurses -o test_cli_version


### PR DESCRIPTION
## Summary
- refresh the text window whenever changing dropdown menus
- clear dropdown menu after exiting
- stub `touchwin` in existing menu test
- add regression test for switching menus

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683b452858008324b66db34a229b6e67