### PR TITLE
Add text color setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ dialog with changes, the updated configuration is automatically saved back to
 
 This file is created automatically with default values if it does not exist. Unknown keys are ignored when the file is parsed. You can also change these options interactively using the **Settings** dialog. Open it from *File → Settings* (press `CTRL-T` to open the menu) and navigate with the arrow keys. The recognized keys are:
 - `background_color`
+- `text_color`
 - `keyword_color`
 - `comment_color`
 - `string_color`

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -19,7 +19,7 @@ Print the program version and exit.
 .SH CONFIGURATION
 User preferences are stored in \fI~/.ventorc\fP.  The file is created automatically if it does not exist.  Recognized keys include:
 .IP \[bu] 2
-background_color, keyword_color, comment_color, string_color, type_color, symbol_color
+background_color, text_color, keyword_color, comment_color, string_color, type_color, symbol_color
 .IP \[bu] 2
 theme \- base name of a file in the theme directory (\fBVENTO_THEME_DIR\fP or the compiled \fBTHEME_DIR\fP)
 .IP \[bu] 2

--- a/docs/vento.ctl
+++ b/docs/vento.ctl
@@ -1,4 +1,5 @@
 background_color=BLUE
+text_color=WHITE
 keyword_color=CYAN
 comment_color=GREEN
 string_color=YELLOW

--- a/src/config.c
+++ b/src/config.c
@@ -17,6 +17,7 @@ int show_line_numbers = 0; // global line number flag
 // default application configuration
 AppConfig app_config = {
     .background_color = "BLACK",
+    .text_color = "WHITE",
     .keyword_color = "CYAN",
     .comment_color = "GREEN",
     .string_color = "YELLOW",
@@ -125,6 +126,9 @@ void load_theme(const char *name, AppConfig *cfg) {
         if (strcmp(key, "background_color") == 0) {
             strncpy(cfg->background_color, value, sizeof(cfg->background_color)-1);
             cfg->background_color[sizeof(cfg->background_color)-1] = '\0';
+        } else if (strcmp(key, "text_color") == 0) {
+            strncpy(cfg->text_color, value, sizeof(cfg->text_color)-1);
+            cfg->text_color[sizeof(cfg->text_color)-1] = '\0';
         } else if (strcmp(key, "keyword_color") == 0) {
             strncpy(cfg->keyword_color, value, sizeof(cfg->keyword_color)-1);
             cfg->keyword_color[sizeof(cfg->keyword_color)-1] = '\0';
@@ -148,6 +152,7 @@ void load_theme(const char *name, AppConfig *cfg) {
 void config_save(const AppConfig *cfg) {
     static const char *keys[] = {
         "background_color",
+        "text_color",
         "keyword_color",
         "comment_color",
         "string_color",
@@ -166,16 +171,17 @@ void config_save(const AppConfig *cfg) {
     if (!f) return;
 
     fprintf(f, "%s=%s\n", keys[0], cfg->background_color);
-    fprintf(f, "%s=%s\n", keys[1], cfg->keyword_color);
-    fprintf(f, "%s=%s\n", keys[2], cfg->comment_color);
-    fprintf(f, "%s=%s\n", keys[3], cfg->string_color);
-    fprintf(f, "%s=%s\n", keys[4], cfg->type_color);
-    fprintf(f, "%s=%s\n", keys[5], cfg->symbol_color);
-    fprintf(f, "%s=%s\n", keys[6], cfg->theme);
-    fprintf(f, "%s=%s\n", keys[7], cfg->enable_color ? "true" : "false");
-    fprintf(f, "%s=%s\n", keys[8], cfg->enable_mouse ? "true" : "false");
-    fprintf(f, "%s=%s\n", keys[9], cfg->show_line_numbers ? "true" : "false");
-    fprintf(f, "%s=%d\n", keys[10], cfg->tab_width);
+    fprintf(f, "%s=%s\n", keys[1], cfg->text_color);
+    fprintf(f, "%s=%s\n", keys[2], cfg->keyword_color);
+    fprintf(f, "%s=%s\n", keys[3], cfg->comment_color);
+    fprintf(f, "%s=%s\n", keys[4], cfg->string_color);
+    fprintf(f, "%s=%s\n", keys[5], cfg->type_color);
+    fprintf(f, "%s=%s\n", keys[6], cfg->symbol_color);
+    fprintf(f, "%s=%s\n", keys[7], cfg->theme);
+    fprintf(f, "%s=%s\n", keys[8], cfg->enable_color ? "true" : "false");
+    fprintf(f, "%s=%s\n", keys[9], cfg->enable_mouse ? "true" : "false");
+    fprintf(f, "%s=%s\n", keys[10], cfg->show_line_numbers ? "true" : "false");
+    fprintf(f, "%s=%d\n", keys[11], cfg->tab_width);
     fclose(f);
 }
 
@@ -242,6 +248,9 @@ void config_load(AppConfig *cfg) {
         if (strcmp(key, "background_color") == 0) {
             strncpy(tmp.background_color, value, sizeof(tmp.background_color)-1);
             tmp.background_color[sizeof(tmp.background_color)-1] = '\0';
+        } else if (strcmp(key, "text_color") == 0) {
+            strncpy(tmp.text_color, value, sizeof(tmp.text_color)-1);
+            tmp.text_color[sizeof(tmp.text_color)-1] = '\0';
         } else if (strcmp(key, "keyword_color") == 0) {
             strncpy(tmp.keyword_color, value, sizeof(tmp.keyword_color)-1);
             tmp.keyword_color[sizeof(tmp.keyword_color)-1] = '\0';
@@ -291,7 +300,9 @@ void config_load(AppConfig *cfg) {
             short code;
             short bg = get_color_code(cfg->background_color);
             if (bg == -1) bg = -1;
-            init_pair(SYNTAX_BG, COLOR_WHITE, bg);
+            short fg = get_color_code(cfg->text_color);
+            if (fg == -1) fg = COLOR_WHITE;
+            init_pair(SYNTAX_BG, fg, bg);
 
             code = get_color_code(cfg->keyword_color);
             if (code != -1) init_pair(SYNTAX_KEYWORD, code, bg);

--- a/src/config.h
+++ b/src/config.h
@@ -16,6 +16,7 @@ extern int show_line_numbers;
 
 typedef struct {
     char background_color[16];
+    char text_color[16];
     char keyword_color[16];
     char comment_color[16];
     char string_color[16];

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -43,6 +43,7 @@ static const Option options[] = {
     {"Tab width", OPT_INT, offsetof(AppConfig, tab_width), NULL},
     {"Theme", OPT_THEME, offsetof(AppConfig, theme), NULL},
     {"Background color", OPT_COLOR, offsetof(AppConfig, background_color), NULL},
+    {"Text color", OPT_COLOR, offsetof(AppConfig, text_color), NULL},
     {"Keyword color", OPT_COLOR, offsetof(AppConfig, keyword_color), NULL},
     {"Comment color", OPT_COLOR, offsetof(AppConfig, comment_color), NULL},
     {"String color", OPT_COLOR, offsetof(AppConfig, string_color), NULL},
@@ -57,6 +58,7 @@ static void render_theme_sample(const AppConfig *cfg, WINDOW *win, int row) {
         return;
 
     short bg = get_color_code(cfg->background_color);
+    short fg = get_color_code(cfg->text_color);
     short kw = get_color_code(cfg->keyword_color);
     short cm = get_color_code(cfg->comment_color);
     short st = get_color_code(cfg->string_color);
@@ -69,7 +71,7 @@ static void render_theme_sample(const AppConfig *cfg, WINDOW *win, int row) {
     if (base + 5 >= COLOR_PAIRS)
         return;
 
-    init_pair(base, COLOR_WHITE, bg);
+    init_pair(base, fg == -1 ? COLOR_WHITE : fg, bg);
     init_pair(base + 1, kw, bg);
     init_pair(base + 2, cm, bg);
     init_pair(base + 3, st, bg);

--- a/themes/default.theme
+++ b/themes/default.theme
@@ -1,4 +1,5 @@
 background_color=BLACK
+text_color=WHITE
 keyword_color=CYAN
 comment_color=GREEN
 string_color=YELLOW


### PR DESCRIPTION
## Summary
- add `text_color` entry to `AppConfig`
- load, save and display text color from config and themes
- show "Text color" option in the settings UI
- update docs and default theme

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683ba5e4214c832489d1b5542771169a