### PR TITLE
Add configurable search highlight color

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This file is created automatically with default values if it does not exist. Unk
 - `string_color`
 - `type_color`
 - `symbol_color`
+- `search_color`
 - `theme`
 - `enable_color`
 - `enable_mouse`

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -19,7 +19,7 @@ Print the program version and exit.
 .SH CONFIGURATION
 User preferences are stored in \fI~/.ventorc\fP.  The file is created automatically if it does not exist.  Recognized keys include:
 .IP \[bu] 2
-background_color, text_color, keyword_color, comment_color, string_color, type_color, symbol_color
+background_color, text_color, keyword_color, comment_color, string_color, type_color, symbol_color, search_color
 .IP \[bu] 2
 theme \- base name of a file in the theme directory (\fBVENTO_THEME_DIR\fP or the compiled \fBTHEME_DIR\fP)
 .IP \[bu] 2

--- a/docs/vento.ctl
+++ b/docs/vento.ctl
@@ -5,3 +5,4 @@ comment_color=GREEN
 string_color=YELLOW
 type_color=MAGENTA
 symbol_color=RED
+search_color=YELLOW

--- a/src/config.c
+++ b/src/config.c
@@ -23,6 +23,7 @@ AppConfig app_config = {
     .string_color = "YELLOW",
     .type_color = "MAGENTA",
     .symbol_color = "RED",
+    .search_color = "YELLOW",
     .theme = "",
     .enable_color = 1,
     .enable_mouse = 1,
@@ -144,6 +145,9 @@ void load_theme(const char *name, AppConfig *cfg) {
         } else if (strcmp(key, "symbol_color") == 0) {
             strncpy(cfg->symbol_color, value, sizeof(cfg->symbol_color)-1);
             cfg->symbol_color[sizeof(cfg->symbol_color)-1] = '\0';
+        } else if (strcmp(key, "search_color") == 0) {
+            strncpy(cfg->search_color, value, sizeof(cfg->search_color)-1);
+            cfg->search_color[sizeof(cfg->search_color)-1] = '\0';
         }
     }
     fclose(f);
@@ -158,6 +162,7 @@ void config_save(const AppConfig *cfg) {
         "string_color",
         "type_color",
         "symbol_color",
+        "search_color",
         "theme",
         "enable_color",
         "enable_mouse",
@@ -177,11 +182,12 @@ void config_save(const AppConfig *cfg) {
     fprintf(f, "%s=%s\n", keys[4], cfg->string_color);
     fprintf(f, "%s=%s\n", keys[5], cfg->type_color);
     fprintf(f, "%s=%s\n", keys[6], cfg->symbol_color);
-    fprintf(f, "%s=%s\n", keys[7], cfg->theme);
-    fprintf(f, "%s=%s\n", keys[8], cfg->enable_color ? "true" : "false");
-    fprintf(f, "%s=%s\n", keys[9], cfg->enable_mouse ? "true" : "false");
-    fprintf(f, "%s=%s\n", keys[10], cfg->show_line_numbers ? "true" : "false");
-    fprintf(f, "%s=%d\n", keys[11], cfg->tab_width);
+    fprintf(f, "%s=%s\n", keys[7], cfg->search_color);
+    fprintf(f, "%s=%s\n", keys[8], cfg->theme);
+    fprintf(f, "%s=%s\n", keys[9], cfg->enable_color ? "true" : "false");
+    fprintf(f, "%s=%s\n", keys[10], cfg->enable_mouse ? "true" : "false");
+    fprintf(f, "%s=%s\n", keys[11], cfg->show_line_numbers ? "true" : "false");
+    fprintf(f, "%s=%d\n", keys[12], cfg->tab_width);
     fclose(f);
 }
 
@@ -266,6 +272,9 @@ void config_load(AppConfig *cfg) {
         } else if (strcmp(key, "symbol_color") == 0) {
             strncpy(tmp.symbol_color, value, sizeof(tmp.symbol_color)-1);
             tmp.symbol_color[sizeof(tmp.symbol_color)-1] = '\0';
+        } else if (strcmp(key, "search_color") == 0) {
+            strncpy(tmp.search_color, value, sizeof(tmp.search_color)-1);
+            tmp.search_color[sizeof(tmp.search_color)-1] = '\0';
         } else if (strcmp(key, "theme") == 0) {
             strncpy(tmp.theme, value, sizeof(tmp.theme)-1);
             tmp.theme[sizeof(tmp.theme)-1] = '\0';
@@ -318,6 +327,9 @@ void config_load(AppConfig *cfg) {
 
             code = get_color_code(cfg->symbol_color);
             if (code != -1) init_pair(SYNTAX_SYMBOL, code, bg);
+
+            code = get_color_code(cfg->search_color);
+            if (code != -1) init_pair(SYNTAX_SEARCH, code, bg);
         }
     }
 }

--- a/src/config.h
+++ b/src/config.h
@@ -22,6 +22,7 @@ typedef struct {
     char string_color[16];
     char type_color[16];
     char symbol_color[16];
+    char search_color[16];
     char theme[32];
     int enable_color;
     int enable_mouse;

--- a/src/editor.c
+++ b/src/editor.c
@@ -536,7 +536,8 @@ void draw_text_buffer(FileState *fs, WINDOW *win) {
             if (start_x < COLS - 2 && len > 0) {
                 if (start_x + len > COLS - 2)
                     len = COLS - 2 - start_x;
-                mvwchgat(win, i + 1, start_x + 1, len, A_REVERSE, 0, NULL);
+                mvwchgat(win, i + 1, start_x + 1, len,
+                         COLOR_PAIR(SYNTAX_SEARCH) | A_BOLD, 0, NULL);
             }
         }
     }

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -19,7 +19,8 @@ typedef enum {
     SYNTAX_COMMENT,
     SYNTAX_STRING,
     SYNTAX_TYPE,
-    SYNTAX_SYMBOL
+    SYNTAX_SYMBOL,
+    SYNTAX_SEARCH
 } SyntaxColor;
 
 typedef struct {

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -49,6 +49,7 @@ static const Option options[] = {
     {"String color", OPT_COLOR, offsetof(AppConfig, string_color), NULL},
     {"Type color", OPT_COLOR, offsetof(AppConfig, type_color), NULL},
     {"Symbol color", OPT_COLOR, offsetof(AppConfig, symbol_color), NULL},
+    {"Search color", OPT_COLOR, offsetof(AppConfig, search_color), NULL},
 };
 
 #define FIELD_COUNT ((int)(sizeof(options) / sizeof(options[0])))
@@ -64,11 +65,11 @@ static void render_theme_sample(const AppConfig *cfg, WINDOW *win, int row) {
     short st = get_color_code(cfg->string_color);
     short ty = get_color_code(cfg->type_color);
     short sy = get_color_code(cfg->symbol_color);
-
-    short base = COLOR_PAIRS - 6;
+    short se = get_color_code(cfg->search_color);
+    short base = COLOR_PAIRS - 7;
     if (base < 1)
         base = 1;
-    if (base + 5 >= COLOR_PAIRS)
+    if (base + 6 >= COLOR_PAIRS)
         return;
 
     init_pair(base, fg == -1 ? COLOR_WHITE : fg, bg);
@@ -77,6 +78,7 @@ static void render_theme_sample(const AppConfig *cfg, WINDOW *win, int row) {
     init_pair(base + 3, st, bg);
     init_pair(base + 4, ty, bg);
     init_pair(base + 5, sy, bg);
+    init_pair(base + 6, se, bg);
 
     int width = getmaxx(win) - 2;
     wattron(win, COLOR_PAIR(base));
@@ -100,16 +102,20 @@ static void render_theme_sample(const AppConfig *cfg, WINDOW *win, int row) {
     col = getcurx(win);
 
     wattron(win, COLOR_PAIR(base + 5));
-    mvwprintw(win, row, col, "symbol");
+    mvwprintw(win, row, col, "symbol ");
+    col = getcurx(win);
+
+    wattron(win, COLOR_PAIR(base + 6));
+    mvwprintw(win, row, col, "search");
 }
 
 static void clear_theme_sample_pairs(void) {
-    short base = COLOR_PAIRS - 6;
+    short base = COLOR_PAIRS - 7;
     if (base < 1)
         base = 1;
-    if (base + 5 >= COLOR_PAIRS)
+    if (base + 6 >= COLOR_PAIRS)
         return;
-    for (short i = 0; i < 6; ++i)
+    for (short i = 0; i < 7; ++i)
         init_pair(base + i, -1, -1);
 }
 

--- a/tests/test_search_highlight.c
+++ b/tests/test_search_highlight.c
@@ -18,6 +18,7 @@
 
 #include "files.h"
 #include "search.h"
+#include "syntax.h"
 #include "menu.h"
 #include "file_manager.h"
 #include "menu.h"
@@ -148,7 +149,7 @@ int main(void){
     assert(chgat_y==2);
     assert(chgat_x==1);
     assert(chgat_len==3);
-    assert(chgat_attr==A_REVERSE);
+    assert(chgat_attr==(COLOR_PAIR(SYNTAX_SEARCH)|A_BOLD));
 
     delwin(text_win);
     for(int i=0;i<fs.max_lines;i++) free(fs.text_buffer[i]);

--- a/themes/default.theme
+++ b/themes/default.theme
@@ -5,3 +5,4 @@ comment_color=GREEN
 string_color=YELLOW
 type_color=MAGENTA
 symbol_color=RED
+search_color=YELLOW


### PR DESCRIPTION
## Summary
- allow configuration of search highlight color via new `SYNTAX_SEARCH` pair
- add `search_color` to config, theme files and Settings dialog
- highlight search matches with `COLOR_PAIR(SYNTAX_SEARCH)`
- document new setting in README and man page
- update tests for new color pair

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ba733a69883248cbb3dc2b01261e9