### PR TITLE
Add CLI theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ vento [options] [file...]
 
 - `-h`, `--help` &mdash; show a short help message and exit.
 - `-v`, `--version` &mdash; print the current version number and exit.
+- `-t <name>`, `--theme=<name>` &mdash; load the specified color theme before opening files.
 
 Any additional arguments are treated as files to load on startup.
 

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -16,6 +16,9 @@ Display the help screen and exit.
 .TP
 .BR \-v , \-\-version
 Print the program version and exit.
+.TP
+.BR \-t , \-\-theme=\fIname\fP
+Load the specified color theme before opening files.
 .SH CONFIGURATION
 User preferences are stored in \fI~/.ventorc\fP.  The file is created automatically if it does not exist.  Recognized keys include:
 .IP \[bu] 2

--- a/src/vento.c
+++ b/src/vento.c
@@ -9,7 +9,11 @@
 #include "files.h"
 #include "file_manager.h"
 #include "ui_common.h"
+#include "config.h"
 #include <stdbool.h>
+
+extern void load_theme(const char *name, AppConfig *cfg) __attribute__((weak));
+extern void apply_colors(void) __attribute__((weak));
 
 bool confirm_quit(void) {
     if (!any_file_modified(&file_manager))
@@ -33,20 +37,34 @@ bool confirm_quit(void) {
  */
 int main(int argc, char *argv[]) {
     int file_count = 0;
+    const char *theme_name = NULL;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             printf("Usage: %s [options] [file...]\n", argv[0]);
             printf("  -h, --help     Show this help and exit\n");
             printf("  -v, --version  Print version information and exit\n");
+            printf("  -t, --theme    Load a color theme before opening files\n");
             return 0;
         } else if (strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
             printf("%s\n", VERSION);
             return 0;
+        } else if (strncmp(argv[i], "--theme=", 8) == 0) {
+            theme_name = argv[i] + 8;
+        } else if ((strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--theme") == 0) && i + 1 < argc) {
+            theme_name = argv[++i];
         }
     }
 
     initialize();
+
+    if (theme_name && *theme_name && load_theme) {
+        load_theme(theme_name, &app_config);
+        strncpy(app_config.theme, theme_name, sizeof(app_config.theme) - 1);
+        app_config.theme[sizeof(app_config.theme) - 1] = '\0';
+        if (apply_colors)
+            apply_colors();
+    }
 
     fm_init(&file_manager);
 
@@ -55,6 +73,11 @@ int main(int argc, char *argv[]) {
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0 ||
             strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
+            continue;
+        }
+        if (strncmp(argv[i], "--theme=", 8) == 0 || strcmp(argv[i], "--theme") == 0 || strcmp(argv[i], "-t") == 0) {
+            if ((strcmp(argv[i], "--theme") == 0 || strcmp(argv[i], "-t") == 0) && i + 1 < argc)
+                i++;
             continue;
         }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -200,3 +200,8 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_select_int_invalid.c src/ui_settings.c \
     obj_test/stub_ui_settings_deps.o -lncurses -o test_select_int_invalid
 ./test_select_int_invalid
+
+# build and run theme option test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_cli_theme.c src/config.c -lncurses -o test_cli_theme
+VENTO_THEME_DIR=./themes ./test_cli_theme

--- a/tests/test_cli_theme.c
+++ b/tests/test_cli_theme.c
@@ -1,5 +1,4 @@
 #include <assert.h>
-#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <ncurses.h>
@@ -15,7 +14,6 @@ FileState *active_file = NULL;
 WINDOW *text_win = NULL;
 int COLS = 80;
 int LINES = 24;
-AppConfig app_config;
 
 bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
@@ -28,27 +26,19 @@ int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(void){}
 void run_editor(void){}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
+int endwin(void){return 0;}
+void apply_colors(void){}
 
 #define main vento_main
 #include "../src/vento.c"
 #undef main
 
 int main(void){
-    char *argv[] = {"vento", "--version"};
-    FILE *tmp = tmpfile();
-    assert(tmp);
-    int fd = fileno(tmp);
-    int saved = dup(1);
-    dup2(fd,1);
+    setenv("VENTO_THEME_DIR","./themes",1);
+    char *argv[] = {"vento", "--theme=default"};
     vento_main(2, argv);
-    fflush(stdout);
-    dup2(saved,1);
-    lseek(fd,0,SEEK_SET);
-    char buf[64];
-    size_t n = fread(buf,1,sizeof(buf)-1,tmp);
-    buf[n] = '\0';
-    assert(strstr(buf, VERSION) != NULL);
-    fclose(tmp);
-    close(saved);
+    assert(strcmp(app_config.theme, "default") == 0);
+    assert(strcmp(app_config.keyword_color, "CYAN") == 0);
+    assert(strcmp(app_config.comment_color, "GREEN") == 0);
     return 0;
 }

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -16,6 +16,7 @@ WINDOW *text_win = NULL;
 int COLS = 80;
 int LINES = 24;
 FileManager file_manager = {0};
+AppConfig app_config;
 
 void fm_init(FileManager *fm){fm->files=NULL;fm->count=0;fm->active_index=-1;}
 FileState* fm_current(FileManager *fm){if(!fm||fm->active_index<0||fm->active_index>=fm->count)return NULL;return fm->files[fm->active_index];}


### PR DESCRIPTION
## Summary
- add --theme/-t argument handling in `vento.c`
- document new option in README and man page
- provide weak references for optional functions
- add regression test for theme option

## Testing
- `tests/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ba846135c832496756de8f62bb7e1