### PR TITLE
Add toggle for startup warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This file is created automatically with default values if it does not exist. Unk
 - `enable_color`
 - `enable_mouse`
 - `show_line_numbers`
+- `show_startup_warning`
 - `tab_width`
 
 `tab_width` controls how many spaces are inserted when you press the Tab key.

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -32,6 +32,8 @@ enable_mouse \- toggle mouse input
 .IP \[bu] 2
 show_line_numbers \- display line numbers in the editor
 .IP \[bu] 2
+show_startup_warning \- show the startup warning dialog
+.IP \[bu] 2
 tab_width \- number of spaces inserted when Tab is pressed
 .PP
 Configuration options can also be changed interactively using the \fBFile\fP \-> \fBSettings\fP dialog which writes updates back to \fI~/.ventorc\fP.

--- a/src/config.c
+++ b/src/config.c
@@ -28,6 +28,7 @@ AppConfig app_config = {
     .enable_color = 1,
     .enable_mouse = 1,
     .show_line_numbers = 0,
+    .show_startup_warning = 1,
     .tab_width = 4
 };
 
@@ -167,6 +168,7 @@ void config_save(const AppConfig *cfg) {
         "enable_color",
         "enable_mouse",
         "show_line_numbers",
+        "show_startup_warning",
         "tab_width"
     };
 
@@ -187,7 +189,8 @@ void config_save(const AppConfig *cfg) {
     fprintf(f, "%s=%s\n", keys[9], cfg->enable_color ? "true" : "false");
     fprintf(f, "%s=%s\n", keys[10], cfg->enable_mouse ? "true" : "false");
     fprintf(f, "%s=%s\n", keys[11], cfg->show_line_numbers ? "true" : "false");
-    fprintf(f, "%s=%d\n", keys[12], cfg->tab_width);
+    fprintf(f, "%s=%s\n", keys[12], cfg->show_startup_warning ? "true" : "false");
+    fprintf(f, "%s=%d\n", keys[13], cfg->tab_width);
     fclose(f);
 }
 
@@ -284,6 +287,8 @@ void config_load(AppConfig *cfg) {
             tmp.enable_mouse = (strcmp(value, "true") == 0 || strcmp(value, "1") == 0);
         } else if (strcmp(key, "show_line_numbers") == 0) {
             tmp.show_line_numbers = (strcmp(value, "true") == 0 || strcmp(value, "1") == 0);
+        } else if (strcmp(key, "show_startup_warning") == 0) {
+            tmp.show_startup_warning = (strcmp(value, "true") == 0 || strcmp(value, "1") == 0);
         } else if (strcmp(key, "tab_width") == 0) {
             tmp.tab_width = atoi(value);
             if (tmp.tab_width <= 0)

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,7 @@ typedef struct {
     int enable_color;
     int enable_mouse;
     int show_line_numbers;
+    int show_startup_warning;
     int tab_width;
 } AppConfig;
 

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -40,6 +40,7 @@ static const Option options[] = {
     {"Enable color", OPT_BOOL, offsetof(AppConfig, enable_color), NULL},
     {"Enable mouse", OPT_BOOL, offsetof(AppConfig, enable_mouse), apply_mouse},
     {"Show line numbers", OPT_BOOL, offsetof(AppConfig, show_line_numbers), NULL},
+    {"Show startup warning", OPT_BOOL, offsetof(AppConfig, show_startup_warning), NULL},
     {"Tab width", OPT_INT, offsetof(AppConfig, tab_width), NULL},
     {"Theme", OPT_THEME, offsetof(AppConfig, theme), NULL},
     {"Background color", OPT_COLOR, offsetof(AppConfig, background_color), NULL},

--- a/src/vento.c
+++ b/src/vento.c
@@ -97,7 +97,8 @@ int main(int argc, char *argv[]) {
     active_file = fm_current(&file_manager);
 
     // Show the warning dialog before entering the main editor loop
-    show_warning_dialog();
+    if (app_config.show_startup_warning)
+        show_warning_dialog();
 
     // Finishes initializing editor window and begin accepting keyboard input.
     run_editor();


### PR DESCRIPTION
## Summary
- add `show_startup_warning` option to `AppConfig`
- persist this new option in `.ventorc`
- expose toggle in the settings dialog
- only display the warning dialog when enabled
- document the new setting

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683bacbf88788324bca7dff4e8a84058