### PR TITLE
Implement file switch confirmation and regression test

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -7,6 +7,7 @@
 #include "files.h"
 #include "file_manager.h"
 #include "undo.h"
+#include "file_ops.h"
 
 void delete_current_line(FileState *fs) {
     if (fs->line_count == 0) {
@@ -88,6 +89,8 @@ void next_file(FileState *fs_unused, int *cx, int *cy) {
     if (file_manager.count == 0) {
         return;
     }
+    if (!confirm_switch())
+        return;
     int idx = file_manager.active_index + 1;
     if (idx >= file_manager.count) idx = 0;
     fm_switch(&file_manager, idx);
@@ -105,6 +108,8 @@ void prev_file(FileState *fs_unused, int *cx, int *cy) {
     if (file_manager.count == 0) {
         return;
     }
+    if (!confirm_switch())
+        return;
     int idx = file_manager.active_index - 1;
     if (idx < 0) idx = file_manager.count - 1;
     fm_switch(&file_manager, idx);

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -218,6 +218,16 @@ void close_current_file(FileState *fs_unused, int *cx, int *cy) {
     update_status_bar(active_file);
 }
 
+bool confirm_switch(void) {
+    if (!any_file_modified(&file_manager))
+        return true;
+
+    int ch = show_message("Unsaved changes. Switch files?");
+    if (ch == 'n' || ch == 'N')
+        return false;
+    return true;
+}
+
 int set_syntax_mode(const char *filename) {
     const char *ext = strrchr(filename, '.');
     if (ext && ext[1] != '\0') {

--- a/src/file_ops.h
+++ b/src/file_ops.h
@@ -2,11 +2,13 @@
 #define FILE_OPS_H
 
 struct FileState;
+#include <stdbool.h>
 void save_file(struct FileState *fs);
 void save_file_as(struct FileState *fs);
 void load_file(struct FileState *fs, const char *filename);
 void new_file(struct FileState *fs);
 void close_current_file(struct FileState *fs, int *cx, int *cy);
 int set_syntax_mode(const char *filename);
+bool confirm_switch(void);
 
 #endif // FILE_OPS_H

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -174,6 +174,12 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_confirm
     obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_confirm_quit
 ./test_confirm_quit
 
+# build and run confirm switch regression test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_confirm_switch.c src/editor_actions.c src/file_manager.c \
+    -lncurses -o test_confirm_switch
+./test_confirm_switch
+
 # build and run menu overlay clear regression test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_menu_no_clear.c -lncurses -o test_menu_no_clear

--- a/tests/stubs_file_ops.c
+++ b/tests/stubs_file_ops.c
@@ -23,3 +23,4 @@ int show_save_file_dialog(char *p,int m){(void)p;(void)m;return 0;}
 void update_status_bar(FileState *fs){(void)fs;}
 void redraw(void){}
 int show_message(const char *msg){(void)msg;return 0;}
+bool any_file_modified(FileManager *fm){(void)fm;return false;}

--- a/tests/test_confirm_switch.c
+++ b/tests/test_confirm_switch.c
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include <string.h>
+#include "file_manager.h"
+#include "editor.h"
+#include "file_ops.h"
+
+int COLS = 80;
+int LINES = 24;
+WINDOW *text_win = NULL;
+WINDOW *stdscr = NULL;
+FileState *active_file = NULL;
+
+/* stubs required by editor_actions.c and file_manager.c */
+void allocation_failed(const char *msg){ (void)msg; abort(); }
+void draw_text_buffer(FileState *fs, WINDOW *w){ (void)fs; (void)w; }
+void mark_comment_state_dirty(FileState *fs){ (void)fs; }
+int ensure_line_capacity(FileState *fs, int n){ (void)fs; (void)n; return 0; }
+void push(Node **stack, Change ch){ (void)stack; free(ch.old_text); free(ch.new_text); }
+void redo(FileState *fs){ (void)fs; }
+void undo(FileState *fs){ (void)fs; }
+void redraw(void){}
+void clamp_scroll_x(FileState *fs){ (void)fs; }
+void free_file_state(FileState *fs){ (void)fs; }
+
+static int confirm_calls = 0;
+bool confirm_switch(void){ confirm_calls++; return false; }
+
+int main(void){
+    fm_init(&file_manager);
+    FileState fs1 = {0};
+    FileState fs2 = {0};
+    file_manager.files = malloc(2 * sizeof(FileState*));
+    file_manager.files[0] = &fs1;
+    file_manager.files[1] = &fs2;
+    file_manager.count = 2;
+    file_manager.active_index = 0;
+    active_file = &fs1;
+    fs1.modified = true;
+
+    int cx = 0, cy = 0;
+    next_file(active_file, &cx, &cy);
+
+    assert(confirm_calls == 1);
+    assert(file_manager.active_index == 0);
+    assert(active_file == &fs1);
+
+    free(file_manager.files);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prompt before switching files when unsaved changes exist
- integrate `confirm_switch()` in file navigation
- provide stub of `any_file_modified` for tests
- add regression test for cancelling file switch

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683bb0014f5083248ac6c40d463f13fa