### PR TITLE
Remember per-file cursor position

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -91,11 +91,20 @@ void next_file(FileState *fs_unused, int *cx, int *cy) {
     }
     if (!confirm_switch())
         return;
+    FileState *cur = fm_current(&file_manager);
+    if (cur) {
+        cur->saved_cursor_x = cur->cursor_x;
+        cur->saved_cursor_y = cur->cursor_y;
+    }
     int idx = file_manager.active_index + 1;
     if (idx >= file_manager.count) idx = 0;
     fm_switch(&file_manager, idx);
     active_file = fm_current(&file_manager);
-    text_win = active_file->text_win;
+    if (active_file) {
+        active_file->cursor_x = active_file->saved_cursor_x;
+        active_file->cursor_y = active_file->saved_cursor_y;
+    }
+    text_win = active_file ? active_file->text_win : NULL;
     clamp_scroll_x(active_file);
     *cx = active_file->cursor_x;
     *cy = active_file->cursor_y;
@@ -110,11 +119,20 @@ void prev_file(FileState *fs_unused, int *cx, int *cy) {
     }
     if (!confirm_switch())
         return;
+    FileState *cur = fm_current(&file_manager);
+    if (cur) {
+        cur->saved_cursor_x = cur->cursor_x;
+        cur->saved_cursor_y = cur->cursor_y;
+    }
     int idx = file_manager.active_index - 1;
     if (idx < 0) idx = file_manager.count - 1;
     fm_switch(&file_manager, idx);
     active_file = fm_current(&file_manager);
-    text_win = active_file->text_win;
+    if (active_file) {
+        active_file->cursor_x = active_file->saved_cursor_x;
+        active_file->cursor_y = active_file->saved_cursor_y;
+    }
+    text_win = active_file ? active_file->text_win : NULL;
     clamp_scroll_x(active_file);
     *cx = active_file->cursor_x;
     *cy = active_file->cursor_y;

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -135,6 +135,10 @@ void load_file(FileState *fs_unused, const char *filename) {
     wmove(text_win, 1, 1 + get_line_number_offset(fs));
 
     draw_text_buffer(fs, text_win);
+    fs->cursor_x = fs->saved_cursor_x;
+    fs->cursor_y = fs->saved_cursor_y;
+    wmove(text_win, fs->cursor_y,
+          fs->cursor_x + get_line_number_offset(fs));
     wrefresh(text_win);
 
     int idx = fm_add(&file_manager, fs);
@@ -182,6 +186,8 @@ void new_file(FileState *fs_unused) {
     keypad(text_win, TRUE);
     meta(text_win, TRUE);
     box(text_win, 0, 0);
+    fs->cursor_x = fs->saved_cursor_x;
+    fs->cursor_y = fs->saved_cursor_y;
     wmove(text_win, fs->cursor_y,
           fs->cursor_x + get_line_number_offset(fs));
     wrefresh(text_win);
@@ -192,6 +198,10 @@ void new_file(FileState *fs_unused) {
 void close_current_file(FileState *fs_unused, int *cx, int *cy) {
     (void)fs_unused;
     FileState *current = fm_current(&file_manager);
+    if (current) {
+        current->saved_cursor_x = current->cursor_x;
+        current->saved_cursor_y = current->cursor_y;
+    }
     if (current && current->modified) {
         int ch = show_message("File modified. Save before closing? (y/n)");
         if (ch == 'y' || ch == 'Y') {
@@ -210,6 +220,10 @@ void close_current_file(FileState *fs_unused, int *cx, int *cy) {
     }
 
     active_file = fm_current(&file_manager);
+    if (active_file) {
+        active_file->cursor_x = active_file->saved_cursor_x;
+        active_file->cursor_y = active_file->saved_cursor_y;
+    }
     if (cx && cy && active_file) {
         *cx = active_file->cursor_x;
         *cy = active_file->cursor_y;

--- a/src/files.c
+++ b/src/files.c
@@ -41,6 +41,8 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->scroll_x = 0;
     file_state->cursor_x = 1;
     file_state->cursor_y = 1;
+    file_state->saved_cursor_x = 1;
+    file_state->saved_cursor_y = 1;
     file_state->undo_stack = NULL; // Initialize your undo stack
     file_state->redo_stack = NULL; // Initialize your redo stack
     file_state->selection_mode = false;

--- a/src/files.h
+++ b/src/files.h
@@ -14,6 +14,7 @@ typedef struct FileState {
     int start_line;
     int scroll_x; /* leftmost visible column */
     int cursor_x, cursor_y;
+    int saved_cursor_x, saved_cursor_y;
     int line_capacity;
     Node *undo_stack;
     Node *redo_stack;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -221,3 +221,9 @@ VENTO_THEME_DIR=./themes ./test_cli_theme
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_search_ignore_case.c src/search.c -lncurses -o test_search_ignore_case
 ./test_search_ignore_case
+
+# build and run cursor position restore test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_cursor_restore.c src/editor_actions.c src/file_manager.c \
+    -lncurses -o test_cursor_restore
+./test_cursor_restore

--- a/tests/test_cursor_restore.c
+++ b/tests/test_cursor_restore.c
@@ -1,0 +1,57 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "editor.h"
+#include "file_ops.h"
+
+int COLS = 80;
+int LINES = 24;
+WINDOW *text_win = NULL;
+WINDOW *stdscr = NULL;
+FileState *active_file = NULL;
+
+/* stubs required by editor_actions.c */
+void allocation_failed(const char *msg){(void)msg; abort();}
+void draw_text_buffer(FileState *fs, WINDOW *w){(void)fs;(void)w;}
+void mark_comment_state_dirty(FileState *fs){(void)fs;}
+int ensure_line_capacity(FileState *fs, int n){(void)fs;(void)n;return 0;}
+void push(Node **stack, Change ch){(void)stack; free(ch.old_text); free(ch.new_text);}
+void redo(FileState *fs){(void)fs;}
+void undo(FileState *fs){(void)fs;}
+void redraw(void){}
+void clamp_scroll_x(FileState *fs){(void)fs;}
+void free_file_state(FileState *fs){(void)fs;}
+bool confirm_switch(void){return true;}
+
+int main(void){
+    fm_init(&file_manager);
+    FileState fs1 = {0};
+    FileState fs2 = {0};
+    fs1.cursor_x = fs1.saved_cursor_x = 5;
+    fs1.cursor_y = fs1.saved_cursor_y = 6;
+    fs2.cursor_x = fs2.saved_cursor_x = 2;
+    fs2.cursor_y = fs2.saved_cursor_y = 3;
+    file_manager.files = malloc(2 * sizeof(FileState*));
+    file_manager.files[0] = &fs1;
+    file_manager.files[1] = &fs2;
+    file_manager.count = 2;
+    file_manager.active_index = 0;
+    active_file = &fs1;
+
+    int cx = 0, cy = 0;
+    next_file(active_file, &cx, &cy);
+    assert(fs1.saved_cursor_x == 5 && fs1.saved_cursor_y == 6);
+    assert(active_file == &fs2);
+    assert(cx == 2 && cy == 3);
+
+    fs2.cursor_x = 10; fs2.cursor_y = 11;
+    prev_file(active_file, &cx, &cy);
+    assert(fs2.saved_cursor_x == 10 && fs2.saved_cursor_y == 11);
+    assert(active_file == &fs1);
+    assert(cx == 5 && cy == 6);
+    assert(fs1.cursor_x == 5 && fs1.cursor_y == 6);
+
+    free(file_manager.files);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- track saved cursor_x/cursor_y in FileState
- store cursor position when switching or closing files
- restore saved position on activation
- keep cursor fields when creating FileState
- add regression test for cursor position restore

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683bb466b3988324872e1ccc06835692