### PR TITLE
Add EditorContext header

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include "editor.h"
 #include "config.h"
+#include "editor_state.h"
 #include "syntax.h"
 
 int enable_color = 1; // global flag used throughout the editor

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -2,6 +2,7 @@
 #include "ui_common.h"
 #include "syntax.h"
 #include "config.h"
+#include "editor_state.h"
 #include <string.h>
 #include <ctype.h>
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -16,6 +16,7 @@
 #include "file_ops.h"
 #include "search.h"
 #include "file_manager.h"
+#include "editor_state.h"
 
 __attribute__((weak)) void copy_selection_keyboard(FileState *fs) {
     (void)fs;

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -6,6 +6,7 @@
 #include "syntax.h"
 #include "files.h"
 #include "file_manager.h"
+#include "editor_state.h"
 #include "undo.h"
 #include "file_ops.h"
 

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -10,6 +10,7 @@
 #include "undo.h"
 #include "files.h"
 #include "syntax.h"
+#include "editor_state.h"
 
 void disable_ctrl_c_z() {
     signal(SIGINT, SIG_IGN);

--- a/src/editor_state.h
+++ b/src/editor_state.h
@@ -1,0 +1,17 @@
+#ifndef EDITOR_STATE_H
+#define EDITOR_STATE_H
+
+#include "file_manager.h"
+#include "config.h"
+
+typedef struct EditorContext {
+    FileManager file_manager;
+    AppConfig   config;
+    FileState  *active_file;
+    WINDOW     *text_win;
+    int enable_color;
+    int enable_mouse;
+} EditorContext;
+
+#endif // EDITOR_STATE_H
+

--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "file_manager.h"
+#include "editor_state.h"
 
 FileManager file_manager;
 

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -9,6 +9,7 @@
 #include "files.h"
 #include "file_manager.h"
 #include "ui_common.h"
+#include "editor_state.h"
 
 #define INITIAL_LOAD_LINES 1024
 

--- a/src/files.c
+++ b/src/files.c
@@ -4,6 +4,7 @@
 #include "editor.h"
 #include "syntax.h"
 #include "config.h"
+#include "editor_state.h"
 #include <limits.h>
 
 // Function to initialize a new FileState for a given filename

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include "config.h"
+#include "editor_state.h"
 #include "input.h"
 #include "clipboard.h"
 #include "syntax.h"

--- a/src/input_mouse.c
+++ b/src/input_mouse.c
@@ -2,6 +2,7 @@
 #include <ncurses.h>
 #include "input.h"
 #include "clipboard.h"
+#include "editor_state.h"
 
 #ifndef BUTTON1_DRAGGED
 #define BUTTON1_DRAGGED (BUTTON1_PRESSED | REPORT_MOUSE_POSITION)

--- a/src/menu.c
+++ b/src/menu.c
@@ -8,6 +8,7 @@
 #include "ui.h"
 #include "undo.h"
 #include "config.h"
+#include "editor_state.h"
 
 /* confirm_quit implemented in vento.c */
 bool confirm_quit(void);

--- a/src/menu_draw.c
+++ b/src/menu_draw.c
@@ -4,6 +4,7 @@
 #include "menu.h"
 #include "config.h"
 #include "syntax.h"
+#include "editor_state.h"
 
 /* Draws the top menu bar using the global menu list */
 void drawMenuBar(Menu *menus, int menuCount) {

--- a/src/search.c
+++ b/src/search.c
@@ -11,6 +11,7 @@
 #include "undo.h"
 #include "syntax.h"
 #include "config.h"
+#include "editor_state.h"
 
 extern char search_text[256];
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -7,6 +7,7 @@
 #include "syntax.h"
 #include "ui_common.h"
 #include "dialog.h"
+#include "editor_state.h"
 
 void create_dialog(const char *message, char *output, int max_input_len) {
     int win_width = (int)strlen(message) + 30;

--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -1,5 +1,6 @@
 #include "ui_common.h"
 #include "config.h"
+#include "editor_state.h"
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -8,6 +8,7 @@
 #include <ncurses.h>
 #include <stdio.h>
 #include "config.h"
+#include "editor_state.h"
 
 void get_dir_contents(const char *dir_path, char ***choices, int *n_choices) {
     DIR *dir;

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -1,5 +1,6 @@
 #include "editor.h"
 #include "config.h"
+#include "editor_state.h"
 #include "ui_common.h"
 #include "syntax.h"
 #include "dialog.h"

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -1,6 +1,7 @@
 #include "ui_common.h"
 #include "ui.h"
 #include "config.h"
+#include "editor_state.h"
 #include <ncurses.h>
 #include <stdio.h>
 #include <errno.h>

--- a/src/undo.c
+++ b/src/undo.c
@@ -4,6 +4,7 @@
 #include "editor.h"
 #include "undo.h"
 #include "files.h"
+#include "editor_state.h"
 
 void push(Node **stack, Change change) {
     Node *new_node = (Node *)malloc(sizeof(Node));

--- a/src/vento.c
+++ b/src/vento.c
@@ -10,6 +10,7 @@
 #include "file_manager.h"
 #include "ui_common.h"
 #include "config.h"
+#include "editor_state.h"
 #include <stdbool.h>
 
 extern void load_theme(const char *name, AppConfig *cfg) __attribute__((weak));


### PR DESCRIPTION
## Summary
- introduce `src/editor_state.h` defining `EditorContext`
- include this header across source files where the previous global variables were referenced

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683bb8ab01f88324a6e992356889ae72