### PR TITLE
Remove config/file_manager globals

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -11,29 +11,6 @@
 #include "editor_state.h"
 #include "syntax.h"
 
-int enable_color = 1; // global flag used throughout the editor
-int enable_mouse = 1; // global mouse flag
-int show_line_numbers = 0; // global line number flag
-
-// default application configuration
-AppConfig app_config = {
-    .background_color = "BLACK",
-    .text_color = "WHITE",
-    .keyword_color = "CYAN",
-    .comment_color = "GREEN",
-    .string_color = "YELLOW",
-    .type_color = "MAGENTA",
-    .symbol_color = "RED",
-    .search_color = "YELLOW",
-    .theme = "",
-    .enable_color = 1,
-    .enable_mouse = 1,
-    .show_line_numbers = 0,
-    .show_startup_warning = 1,
-    .search_ignore_case = 0,
-    .tab_width = 4
-};
-
 // Helper to map color name to ncurses constant
 short get_color_code(const char *color_name) {
     if (strcasecmp(color_name, "BLACK") == 0) return COLOR_BLACK;
@@ -346,6 +323,7 @@ void config_load(AppConfig *cfg) {
 }
 
 // Compatibility wrapper
-void read_config_file() {
-    config_load(&app_config);
+void read_config_file(AppConfig *cfg) {
+    if (cfg)
+        config_load(cfg);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -38,6 +38,6 @@ short get_color_code(const char *color_name);
 void load_theme(const char *name, AppConfig *cfg);
 void config_load(AppConfig *cfg);
 void config_save(const AppConfig *cfg);
-void read_config_file(void);
+void read_config_file(AppConfig *cfg);
 
 #endif // CONFIG_H

--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -3,8 +3,6 @@
 #include "file_manager.h"
 #include "editor_state.h"
 
-FileManager file_manager;
-
 void fm_init(FileManager *fm) {
     fm->files = NULL;
     fm->count = 0;

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,27 @@
+#include "config.h"
+#include "file_manager.h"
+
+// global application state
+__attribute__((weak)) int enable_color = 1;
+__attribute__((weak)) int enable_mouse = 1;
+__attribute__((weak)) int show_line_numbers = 0;
+
+__attribute__((weak)) AppConfig app_config = {
+    .background_color = "BLACK",
+    .text_color = "WHITE",
+    .keyword_color = "CYAN",
+    .comment_color = "GREEN",
+    .string_color = "YELLOW",
+    .type_color = "MAGENTA",
+    .symbol_color = "RED",
+    .search_color = "YELLOW",
+    .theme = "",
+    .enable_color = 1,
+    .enable_mouse = 1,
+    .show_line_numbers = 0,
+    .show_startup_warning = 1,
+    .search_ignore_case = 0,
+    .tab_width = 4
+};
+
+__attribute__((weak)) FileManager file_manager;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,17 +16,18 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_paste.c
 
 # compile additional source for file state test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/file_manager.c -o obj_test/file_manager.o
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc -c src/globals.c -o obj_test/globals.o
 
 # build and run file state initialization/switching test
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_file_state
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_file_state.c obj_test/files.o obj_test/file_manager.o obj_test/globals.o obj_test/stub_enable_color.o -lncurses -o test_file_state
 ./test_file_state
 
 # build and run resize handling test (provides many stubs)
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_resize
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize.c obj_test/files.o obj_test/file_manager.o obj_test/globals.o obj_test/stub_enable_color.o -lncurses -o test_resize
 ./test_resize
 
 # build and run line truncation resize test
-gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_resize_trunc
+gcc -Wall -Wextra -std=c99 -g -Isrc tests/test_resize_trunc.c obj_test/files.o obj_test/file_manager.o obj_test/globals.o obj_test/stub_enable_color.o -lncurses -o test_resize_trunc
 ./test_resize_trunc
 
 # build and run resize allocation failure test
@@ -35,7 +36,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_resize_
 
 # build and run resize signal handling test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
-    tests/test_resize_signal.c obj_test/files.o obj_test/file_manager.o \
+    tests/test_resize_signal.c obj_test/files.o obj_test/file_manager.o obj_test/globals.o \
     obj_test/stub_enable_color.o -lncurses -o test_resize_signal
 ./test_resize_signal
 
@@ -134,7 +135,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
 ./test_horizontal_scroll
 
 # build and run color disable test
-gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c -lncurses -o test_color_disable
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c src/globals.c -lncurses -o test_color_disable
 VENTO_THEME_DIR=./themes ./test_color_disable
 
 # build and run initialize mouse test
@@ -173,12 +174,12 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_utf8_pr
 
 # build and run confirm quit regression test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_confirm_quit.c \
-    obj_test/files.o obj_test/file_manager.o obj_test/stub_enable_color.o -lncurses -o test_confirm_quit
+    obj_test/files.o obj_test/file_manager.o obj_test/globals.o obj_test/stub_enable_color.o -lncurses -o test_confirm_quit
 ./test_confirm_quit
 
 # build and run confirm switch regression test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
-    tests/test_confirm_switch.c src/editor_actions.c src/file_manager.c \
+    tests/test_confirm_switch.c src/editor_actions.c src/file_manager.c src/globals.c \
     -lncurses -o test_confirm_switch
 ./test_confirm_switch
 
@@ -216,7 +217,7 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
 
 # build and run theme option test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
-    tests/test_cli_theme.c src/config.c -lncurses -o test_cli_theme
+    tests/test_cli_theme.c src/config.c src/globals.c -lncurses -o test_cli_theme
 VENTO_THEME_DIR=./themes ./test_cli_theme
 
 # build and run search ignore case test
@@ -226,6 +227,6 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc
 
 # build and run cursor position restore test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
-    tests/test_cursor_restore.c src/editor_actions.c src/file_manager.c \
+    tests/test_cursor_restore.c src/editor_actions.c src/file_manager.c src/globals.c \
     -lncurses -o test_cursor_restore
 ./test_cursor_restore


### PR DESCRIPTION
## Summary
- drop global variables from `config.c` and `file_manager.c`
- expose globals in new `globals.c`
- update `read_config_file` API
- compile new globals object in tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683bbd00816c8324b04758e77aa91814