### PR TITLE
Refactor editor entry points to use context

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -401,7 +401,7 @@ void initialize_key_mappings(void) {
  * @param None
  * @return None
  */
-void run_editor() {
+void run_editor(EditorContext *ctx) {
     if (runeditor == 0)
         runeditor = 1;
     else
@@ -412,11 +412,11 @@ void run_editor() {
     int currentItem = 0;
     MEVENT event; // Mouse event structure
 
-    wmove(text_win, active_file->cursor_y,
-          active_file->cursor_x + get_line_number_offset(active_file));
+    wmove(ctx->text_win, ctx->active_file->cursor_y,
+          ctx->active_file->cursor_x + get_line_number_offset(ctx->active_file));
 
     while (exiting == 0) {
-        ch = wgetch(text_win);
+        ch = wgetch(ctx->text_win);
         if (resize_pending || ch == KEY_RESIZE) {
             perform_resize();
             resize_pending = 0;
@@ -432,36 +432,36 @@ void run_editor() {
 
         //mvprintw(LINES - 1, 0, "Pressed key: %d", ch); // Add this line for debugging
         drawBar();
-        update_status_bar(active_file);
+        update_status_bar(ctx->active_file);
         doupdate();
         
-        if (active_file->selection_mode) {
-            handle_selection_mode(active_file, ch, &active_file->cursor_x, &active_file->cursor_y);
+        if (ctx->active_file->selection_mode) {
+            handle_selection_mode(ctx->active_file, ch, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
         } else if (ch == KEY_CTRL_T) { // CTRL-T
             doupdate();
             handleMenuNavigation(menus, menuCount, &currentMenu, &currentItem);
             // Redraw the editor screen after closing the menu
             redraw();
-        } else if (ch == KEY_MOUSE && enable_mouse) {
+        } else if (ch == KEY_MOUSE && ctx->enable_mouse) {
             if (getmouse(&event) == OK) {
                 if (menu_click_open(event.x, event.y)) {
                     flushinp();
                     redraw();
                 } else {
-                    handle_mouse_event(active_file, &event);
+                    handle_mouse_event(ctx->active_file, &event);
                 }
             }
         } else {
-            handle_regular_mode(active_file, ch);
+            handle_regular_mode(ctx->active_file, ch);
         }
 
         if (exiting == 1)
             break;
 
-        update_status_bar(active_file);
-        wmove(text_win, active_file->cursor_y,
-              active_file->cursor_x + get_line_number_offset(active_file));  // Restore cursor position
-        wnoutrefresh(text_win);
+        update_status_bar(ctx->active_file);
+        wmove(ctx->text_win, ctx->active_file->cursor_y,
+              ctx->active_file->cursor_x + get_line_number_offset(ctx->active_file));  // Restore cursor position
+        wnoutrefresh(ctx->text_win);
         doupdate();
     }
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -4,6 +4,7 @@
 #include <ncurses.h>
 #include <signal.h>
 #include <string.h>
+typedef struct EditorContext EditorContext;
 typedef struct Change {
     int line;
     char *old_text;
@@ -46,11 +47,11 @@ extern char search_text[256];
 extern volatile sig_atomic_t resize_pending;
 extern int exiting;
 void handle_regular_mode(struct FileState *fs, int ch);
-void initialize(void);
+void initialize(EditorContext *ctx);
 void draw_text_buffer(struct FileState *fs, WINDOW *win);
 void close_editor(void);
 void clear_text_buffer(void);
-void run_editor(void);
+void run_editor(EditorContext *ctx);
 void initialize_buffer(void);
 void redraw(void);
 void delete_current_line(struct FileState *fs);

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -28,21 +28,23 @@ void apply_colors() {
     }
 }
 
-void initialize() {
+void initialize(EditorContext *ctx) {
     setlocale(LC_ALL, "");
     initscr();
     config_load(&app_config);
+    ctx->enable_color = enable_color;
+    ctx->enable_mouse = enable_mouse;
     apply_colors();
     cbreak();
     noecho();
     keypad(stdscr, TRUE);
     meta(stdscr, TRUE);
-    if (enable_mouse)
+    if (ctx->enable_mouse)
         mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
     else
         mousemask(0, NULL);
     timeout(10);
-    bkgd(enable_color ? COLOR_PAIR(1) : A_NORMAL);
+    bkgd(ctx->enable_color ? COLOR_PAIR(1) : A_NORMAL);
     refresh();
     struct sigaction sa;
     sa.sa_handler = on_sigwinch;
@@ -62,7 +64,7 @@ void initialize() {
     define_key("\024", KEY_CTRL_T);
     initialize_key_mappings();
     initializeMenus();
-    update_status_bar(active_file);
+    update_status_bar(ctx->active_file);
 }
 
 void cleanup_on_exit(FileManager *fm) {

--- a/src/vento.c
+++ b/src/vento.c
@@ -16,6 +16,8 @@
 extern void load_theme(const char *name, AppConfig *cfg) __attribute__((weak));
 extern void apply_colors(void) __attribute__((weak));
 
+static EditorContext editor;
+
 bool confirm_quit(void) {
     if (!any_file_modified(&file_manager))
         return true;
@@ -57,7 +59,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    initialize();
+    initialize(&editor);
 
     if (theme_name && *theme_name && load_theme) {
         load_theme(theme_name, &app_config);
@@ -96,13 +98,17 @@ int main(int argc, char *argv[]) {
     }
 
     active_file = fm_current(&file_manager);
+    editor.active_file = active_file;
+    editor.text_win = text_win;
+    editor.enable_mouse = enable_mouse;
+    editor.enable_color = enable_color;
 
     // Show the warning dialog before entering the main editor loop
     if (app_config.show_startup_warning)
         show_warning_dialog();
 
     // Finishes initializing editor window and begin accepting keyboard input.
-    run_editor();
+    run_editor(&editor);
     
     endwin();
 

--- a/tests/test_cli_theme.c
+++ b/tests/test_cli_theme.c
@@ -5,6 +5,7 @@
 #include "file_manager.h"
 #include "files.h"
 #include "editor.h"
+#include "editor_state.h"
 #include "ui.h"
 #include "ui_common.h"
 #include "config.h"
@@ -14,17 +15,18 @@ FileState *active_file = NULL;
 WINDOW *text_win = NULL;
 int COLS = 80;
 int LINES = 24;
+int enable_mouse = 0;
 
 bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
-void initialize(void){}
+void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
 void load_file(FileState *fs,const char*fn){(void)fs;(void)fn;}
 void new_file(FileState *fs){(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(void){}
-void run_editor(void){}
+void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 int endwin(void){return 0;}
 void apply_colors(void){}

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -6,6 +6,7 @@
 #include "file_manager.h"
 #include "files.h"
 #include "editor.h"
+#include "editor_state.h"
 #include "ui.h"
 #include "ui_common.h"
 #include "config.h"
@@ -16,17 +17,19 @@ WINDOW *text_win = NULL;
 int COLS = 80;
 int LINES = 24;
 AppConfig app_config;
+int enable_mouse = 0;
+int enable_color = 0;
 
 bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
-void initialize(void){}
+void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
 void load_file(FileState *fs,const char*fn){(void)fs;(void)fn;}
 void new_file(FileState *fs){(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(void){}
-void run_editor(void){}
+void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 
 #define main vento_main

--- a/tests/test_confirm_quit.c
+++ b/tests/test_confirm_quit.c
@@ -4,6 +4,7 @@
 #include "file_manager.h"
 #include "menu.h"
 #include "editor.h"
+#include "editor_state.h"
 #include "config.h"
 #include "ui_common.h"
 
@@ -64,9 +65,9 @@ void replace(FileState*fs){(void)fs;}
 void show_about(void){}
 void show_help(void){}
 void allocation_failed(const char*msg){(void)msg;abort();}
-void initialize(void){}
+void initialize(EditorContext *ctx){(void)ctx;}
 void show_warning_dialog(void){}
-void run_editor(void){}
+void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager*fm){(void)fm;}
 
 /* intercept close_editor */

--- a/tests/test_initialize_mouse.c
+++ b/tests/test_initialize_mouse.c
@@ -65,7 +65,10 @@ void config_load(AppConfig *cfg){ enable_mouse = cfg->enable_mouse; }
 int main(void){
     app_config.enable_mouse = 0;
     recorded_mask = (mmask_t)0xffff;
-    initialize();
+    EditorContext ctx = {0};
+    ctx.enable_mouse = 0;
+    ctx.enable_color = 0;
+    initialize(&ctx);
     assert(recorded_mask == 0);
     return 0;
 }

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -6,6 +6,7 @@
 #include "file_manager.h"
 #include "files.h"
 #include "editor.h"
+#include "editor_state.h"
 #include "ui.h"
 #include "ui_common.h"
 #include "config.h"
@@ -17,6 +18,8 @@ int COLS = 80;
 int LINES = 24;
 FileManager file_manager = {0};
 AppConfig app_config;
+int enable_mouse = 0;
+int enable_color = 0;
 
 void fm_init(FileManager *fm){fm->files=NULL;fm->count=0;fm->active_index=-1;}
 FileState* fm_current(FileManager *fm){if(!fm||fm->active_index<0||fm->active_index>=fm->count)return NULL;return fm->files[fm->active_index];}
@@ -26,9 +29,9 @@ int fm_switch(FileManager *fm,int idx){if(!fm||idx<0||idx>=fm->count)return -1;f
 /* stubs for unused functionality */
 bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
-void initialize(void){}
+void initialize(EditorContext *ctx){(void)ctx;}
 void show_warning_dialog(void){}
-void run_editor(void){}
+void run_editor(EditorContext *ctx){(void)ctx;}
 int endwin(void){return 0;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -8,6 +8,7 @@
 #include "files.h"
 #include "file_manager.h"
 #include "editor.h"
+#include "editor_state.h"
 #include "menu.h"
 
 int COLS = 80;
@@ -118,7 +119,12 @@ int main(void){
     active_file=fs;
 
     resize_pending = 1;
-    run_editor();
+    EditorContext ctx = {0};
+    ctx.active_file = fs;
+    ctx.text_win = fs->text_win;
+    ctx.enable_mouse = enable_mouse;
+    ctx.enable_color = enable_color;
+    run_editor(&ctx);
 
     assert(resized_win==fs->text_win);
 

--- a/tests/test_utf8_print.c
+++ b/tests/test_utf8_print.c
@@ -65,7 +65,10 @@ void config_load(AppConfig *cfg){ (void)cfg; }
 #include "../src/editor_init.c"
 
 int main(void){
-    initialize();
+    EditorContext ctx = {0};
+    ctx.enable_mouse = 0;
+    ctx.enable_color = 0;
+    initialize(&ctx);
     addstr("UTF-8: \xCF\x80");
     assert(printed != NULL);
     return 0;


### PR DESCRIPTION
## Summary
- add `EditorContext` instance to main program
- pass context to `initialize` and `run_editor`
- update editor initialization and loop to use context fields
- adjust unit tests for new function signatures

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683bc0b8300c8324b8f75c4750e213ea