### PR TITLE
Add context parameter to input handlers

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -46,7 +46,7 @@ extern struct FileManager file_manager;
 extern char search_text[256];
 extern volatile sig_atomic_t resize_pending;
 extern int exiting;
-void handle_regular_mode(struct FileState *fs, int ch);
+void handle_regular_mode(EditorContext *ctx, struct FileState *fs, int ch);
 void initialize(EditorContext *ctx);
 void draw_text_buffer(struct FileState *fs, WINDOW *win);
 void close_editor(void);

--- a/src/input.h
+++ b/src/input.h
@@ -4,29 +4,30 @@
 #define BOTTOM_MARGIN 4 // Define the bottom UI margin
 
 #include "files.h"
-void handle_ctrl_backtick(void);
-void handle_key_up(struct FileState *fs);
-void handle_key_down(struct FileState *fs);
-void handle_key_left(struct FileState *fs);
-void handle_key_right(struct FileState *fs);
-void handle_key_home(struct FileState *fs);
-void handle_key_end(struct FileState *fs);
-void handle_key_backspace(struct FileState *fs);
-void handle_key_delete(struct FileState *fs);
-void handle_key_enter(struct FileState *fs);
-void handle_key_page_up(struct FileState *fs);
-void handle_key_page_down(struct FileState *fs);
-void handle_ctrl_key_left(struct FileState *fs);
-void handle_ctrl_key_right(struct FileState *fs);
-void handle_ctrl_key_pgup(struct FileState *fs);
-void handle_ctrl_key_pgdn(struct FileState *fs);
-void handle_ctrl_key_up(struct FileState *fs);
-void handle_ctrl_key_down(struct FileState *fs);
-void handle_tab_key(struct FileState *fs);
-void handle_default_key(struct FileState *fs, int ch);
-void move_forward_to_next_word(struct FileState *fs);
-void move_backward_to_previous_word(struct FileState *fs);
-void handle_mouse_event(struct FileState *fs, MEVENT *ev);
-void update_selection_mouse(struct FileState *fs, int x, int y);
+#include "editor_state.h"
+void handle_ctrl_backtick(EditorContext *ctx);
+void handle_key_up(EditorContext *ctx, struct FileState *fs);
+void handle_key_down(EditorContext *ctx, struct FileState *fs);
+void handle_key_left(EditorContext *ctx, struct FileState *fs);
+void handle_key_right(EditorContext *ctx, struct FileState *fs);
+void handle_key_home(EditorContext *ctx, struct FileState *fs);
+void handle_key_end(EditorContext *ctx, struct FileState *fs);
+void handle_key_backspace(EditorContext *ctx, struct FileState *fs);
+void handle_key_delete(EditorContext *ctx, struct FileState *fs);
+void handle_key_enter(EditorContext *ctx, struct FileState *fs);
+void handle_key_page_up(EditorContext *ctx, struct FileState *fs);
+void handle_key_page_down(EditorContext *ctx, struct FileState *fs);
+void handle_ctrl_key_left(EditorContext *ctx, struct FileState *fs);
+void handle_ctrl_key_right(EditorContext *ctx, struct FileState *fs);
+void handle_ctrl_key_pgup(EditorContext *ctx, struct FileState *fs);
+void handle_ctrl_key_pgdn(EditorContext *ctx, struct FileState *fs);
+void handle_ctrl_key_up(EditorContext *ctx, struct FileState *fs);
+void handle_ctrl_key_down(EditorContext *ctx, struct FileState *fs);
+void handle_tab_key(EditorContext *ctx, struct FileState *fs);
+void handle_default_key(EditorContext *ctx, struct FileState *fs, int ch);
+void move_forward_to_next_word(EditorContext *ctx, struct FileState *fs);
+void move_backward_to_previous_word(EditorContext *ctx, struct FileState *fs);
+void handle_mouse_event(EditorContext *ctx, struct FileState *fs, MEVENT *ev);
+void update_selection_mouse(EditorContext *ctx, struct FileState *fs, int x, int y);
 
 #endif

--- a/src/input_mouse.c
+++ b/src/input_mouse.c
@@ -8,7 +8,7 @@
 #define BUTTON1_DRAGGED (BUTTON1_PRESSED | REPORT_MOUSE_POSITION)
 #endif
 
-void update_selection_mouse(FileState *fs, int x, int y) {
+void update_selection_mouse(EditorContext *ctx, FileState *fs, int x, int y) {
     fs->sel_end_x = x;
     fs->sel_end_y = y;
 
@@ -20,7 +20,7 @@ void update_selection_mouse(FileState *fs, int x, int y) {
     wrefresh(text_win);
 }
 
-void handle_mouse_event(FileState *fs, MEVENT *ev) {
+void handle_mouse_event(EditorContext *ctx, FileState *fs, MEVENT *ev) {
     fs->match_start_x = fs->match_end_x = -1;
     fs->match_start_y = fs->match_end_y = -1;
     int mx = ev->x;
@@ -41,20 +41,20 @@ void handle_mouse_event(FileState *fs, MEVENT *ev) {
     }
 
     if (ev->bstate & BUTTON1_DRAGGED) {
-        update_selection_mouse(fs, fs->cursor_x, fs->cursor_y);
+        update_selection_mouse(ctx, fs, fs->cursor_x, fs->cursor_y);
     }
 
 #ifdef BUTTON4_PRESSED
     /* Some systems may not define BUTTON4_PRESSED */
     if (ev->bstate & BUTTON4_PRESSED) {
-        handle_key_up(fs);
+        handle_key_up(ctx, fs);
     }
 #endif
 
 #ifdef BUTTON5_PRESSED
     /* Some systems may not define BUTTON5_PRESSED */
     if (ev->bstate & BUTTON5_PRESSED) {
-        handle_key_down(fs);
+        handle_key_down(ctx, fs);
     }
 #endif
 }

--- a/tests/test_horizontal_scroll.c
+++ b/tests/test_horizontal_scroll.c
@@ -33,16 +33,18 @@ int main(void) {
     fs.cursor_y = 1;
     fs.start_line = 0;
     fs.scroll_x = 0;
+    EditorContext ctx = {0};
+    ctx.active_file = &fs;
     active_file = &fs;
 
     for (int i = 0; i < 15; i++)
-        handle_key_right(&fs);
+        handle_key_right(&ctx, &fs);
     int visible = COLS - 2; /* no line numbers */
     assert(fs.cursor_x == 16);
     assert(fs.scroll_x == fs.cursor_x - visible);
 
     for (int i = 15; i > 0; i--)
-        handle_key_left(&fs);
+        handle_key_left(&ctx, &fs);
     assert(fs.cursor_x == 1);
     assert(fs.scroll_x == 0);
 

--- a/tests/test_long_indent.c
+++ b/tests/test_long_indent.c
@@ -34,8 +34,10 @@ int main(void){
     fs.start_line = 0;
 
     active_file = &fs;
+    EditorContext ctx = {0};
+    ctx.active_file = &fs;
 
-    handle_key_enter(&fs);
+    handle_key_enter(&ctx, &fs);
 
     assert(fs.line_count == 2);
     assert(strlen(fs.text_buffer[0]) == 1100);

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -49,27 +49,27 @@ static int drawBar_called = 0;
 void drawBar(void){drawBar_called=1;}
 
 /* stubs for unused functions referenced in editor.o */
-void handle_key_up(FileState*fs){(void)fs;}
-void handle_key_down(FileState*fs){(void)fs;}
-void handle_key_left(FileState*fs){(void)fs;}
-void handle_key_right(FileState*fs){(void)fs;}
-void handle_key_backspace(FileState*fs){(void)fs;}
-void handle_key_delete(FileState*fs){(void)fs;}
-void handle_key_enter(FileState*fs){(void)fs;}
-void handle_key_page_up(FileState*fs){(void)fs;}
-void handle_key_page_down(FileState*fs){(void)fs;}
-void handle_ctrl_key_left(FileState*fs){(void)fs;}
-void handle_ctrl_key_right(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
-void handle_ctrl_key_up(FileState*fs){(void)fs;}
-void handle_ctrl_key_down(FileState*fs){(void)fs;}
-void handle_key_home(FileState*fs){(void)fs;}
-void handle_key_end(FileState*fs){(void)fs;}
-void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
-void handle_mouse_event(FileState*fs, MEVENT *ev){(void)fs;(void)ev;}
+void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_backspace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_delete(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_enter(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgup(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgdn(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_home(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_end(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_default_key(EditorContext*ctx,FileState*fs,int ch){(void)ctx;(void)fs;(void)ch;}
+void handle_mouse_event(EditorContext*ctx,FileState*fs, MEVENT *ev){(void)ctx;(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
-void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(EditorContext*ctx,FileState*fs,int x,int y){(void)ctx;(void)fs;(void)x;(void)y;}
 void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(FileState*fs){(void)fs;}
@@ -78,8 +78,8 @@ void next_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void prev_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void move_forward_to_next_word(FileState*fs){(void)fs;}
-void move_backward_to_previous_word(FileState*fs){(void)fs;}
+void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs, WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
 void show_about(void){}

--- a/tests/test_resize_allocfail.c
+++ b/tests/test_resize_allocfail.c
@@ -56,27 +56,27 @@ int mvwchgat(WINDOW*w,int y,int x,int n,attr_t attr,short c,const void*opts){(vo
 /* editor dependency stubs */
 void update_status_bar(FileState*fs){(void)fs;}
 void drawBar(void){}
-void handle_key_up(FileState*fs){(void)fs;}
-void handle_key_down(FileState*fs){(void)fs;}
-void handle_key_left(FileState*fs){(void)fs;}
-void handle_key_right(FileState*fs){(void)fs;}
-void handle_key_backspace(FileState*fs){(void)fs;}
-void handle_key_delete(FileState*fs){(void)fs;}
-void handle_key_enter(FileState*fs){(void)fs;}
-void handle_key_page_up(FileState*fs){(void)fs;}
-void handle_key_page_down(FileState*fs){(void)fs;}
-void handle_ctrl_key_left(FileState*fs){(void)fs;}
-void handle_ctrl_key_right(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
-void handle_ctrl_key_up(FileState*fs){(void)fs;}
-void handle_ctrl_key_down(FileState*fs){(void)fs;}
-void handle_key_home(FileState*fs){(void)fs;}
-void handle_key_end(FileState*fs){(void)fs;}
-void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
-void handle_mouse_event(FileState*fs,MEVENT*ev){(void)fs;(void)ev;}
+void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_backspace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_delete(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_enter(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgup(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgdn(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_home(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_end(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_default_key(EditorContext*ctx,FileState*fs,int ch){(void)ctx;(void)fs;(void)ch;}
+void handle_mouse_event(EditorContext*ctx,FileState*fs,MEVENT*ev){(void)ctx;(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
-void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(EditorContext*ctx,FileState*fs,int x,int y){(void)ctx;(void)fs;(void)x;(void)y;}
 void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(FileState*fs){(void)fs;}
@@ -85,8 +85,8 @@ void next_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void prev_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void move_forward_to_next_word(FileState*fs){(void)fs;}
-void move_backward_to_previous_word(FileState*fs){(void)fs;}
+void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs,WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
 void show_about(void){}

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -42,31 +42,31 @@ int wgetch(WINDOW*w){(void)w;gcalls++; if(gcalls==2) exiting=1; return ERR;}
 
 void update_status_bar(FileState*fs){(void)fs;}
 void drawBar(void){}
-void handle_key_up(FileState*fs){(void)fs;}
-void handle_key_down(FileState*fs){(void)fs;}
-void handle_key_left(FileState*fs){(void)fs;}
-void handle_key_right(FileState*fs){(void)fs;}
-void handle_key_backspace(FileState*fs){(void)fs;}
-void handle_key_delete(FileState*fs){(void)fs;}
-void handle_key_enter(FileState*fs){(void)fs;}
-void handle_key_page_up(FileState*fs){(void)fs;}
-void handle_key_page_down(FileState*fs){(void)fs;}
-void handle_ctrl_key_left(FileState*fs){(void)fs;}
-void handle_ctrl_key_right(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
-void handle_ctrl_key_up(FileState*fs){(void)fs;}
-void handle_ctrl_key_down(FileState*fs){(void)fs;}
-void handle_key_home(FileState*fs){(void)fs;}
-void handle_key_end(FileState*fs){(void)fs;}
-void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
+void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_backspace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_delete(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_enter(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgup(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgdn(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_home(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_end(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_default_key(EditorContext*ctx,FileState*fs,int ch){(void)ctx;(void)fs;(void)ch;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
-void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(EditorContext*ctx,FileState*fs,int x,int y){(void)ctx;(void)fs;(void)x;(void)y;}
 void end_selection_mode(FileState*fs){(void)fs;}
 void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
 void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
 int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
-void handle_mouse_event(FileState*fs,MEVENT*ev){(void)fs;(void)ev;}
+void handle_mouse_event(EditorContext*ctx,FileState*fs,MEVENT*ev){(void)ctx;(void)fs;(void)ev;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(FileState*fs){(void)fs;}
 void insert_new_line(FileState*fs){(void)fs;}
@@ -74,8 +74,8 @@ void next_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void prev_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void move_forward_to_next_word(FileState*fs){(void)fs;}
-void move_backward_to_previous_word(FileState*fs){(void)fs;}
+void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs,WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
 void show_about(void){}

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -45,27 +45,27 @@ static int drawBar_called = 0;
 void drawBar(void){drawBar_called=1;}
 
 /* stubs for unused functions referenced in editor.o */
-void handle_key_up(FileState*fs){(void)fs;}
-void handle_key_down(FileState*fs){(void)fs;}
-void handle_key_left(FileState*fs){(void)fs;}
-void handle_key_right(FileState*fs){(void)fs;}
-void handle_key_backspace(FileState*fs){(void)fs;}
-void handle_key_delete(FileState*fs){(void)fs;}
-void handle_key_enter(FileState*fs){(void)fs;}
-void handle_key_page_up(FileState*fs){(void)fs;}
-void handle_key_page_down(FileState*fs){(void)fs;}
-void handle_ctrl_key_left(FileState*fs){(void)fs;}
-void handle_ctrl_key_right(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
-void handle_ctrl_key_up(FileState*fs){(void)fs;}
-void handle_ctrl_key_down(FileState*fs){(void)fs;}
-void handle_key_home(FileState*fs){(void)fs;}
-void handle_key_end(FileState*fs){(void)fs;}
-void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
-void handle_mouse_event(FileState*fs, MEVENT *ev){(void)fs;(void)ev;}
+void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_backspace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_delete(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_enter(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgup(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgdn(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_home(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_end(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_default_key(EditorContext*ctx,FileState*fs,int ch){(void)ctx;(void)fs;(void)ch;}
+void handle_mouse_event(EditorContext*ctx,FileState*fs, MEVENT *ev){(void)ctx;(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
-void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(EditorContext*ctx,FileState*fs,int x,int y){(void)ctx;(void)fs;(void)x;(void)y;}
 void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(FileState*fs){(void)fs;}
@@ -74,8 +74,8 @@ void next_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void prev_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void move_forward_to_next_word(FileState*fs){(void)fs;}
-void move_backward_to_previous_word(FileState*fs){(void)fs;}
+void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs, WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
 void show_about(void){}

--- a/tests/test_search_highlight.c
+++ b/tests/test_search_highlight.c
@@ -64,27 +64,27 @@ int show_find_dialog(char*out,int sz,const char*def){(void)out;(void)sz;(void)de
 int show_replace_dialog(char*s,int ss,char*r,int rs){(void)s;(void)ss;(void)r;(void)rs;return 0;}
 void push(Node **stack, Change change){(void)stack;(void)change;}
 void mark_comment_state_dirty(FileState *fs){(void)fs;}
-void handle_key_up(FileState*fs){(void)fs;}
-void handle_key_down(FileState*fs){(void)fs;}
-void handle_key_left(FileState*fs){(void)fs;}
-void handle_key_right(FileState*fs){(void)fs;}
-void handle_key_backspace(FileState*fs){(void)fs;}
-void handle_key_delete(FileState*fs){(void)fs;}
-void handle_key_enter(FileState*fs){(void)fs;}
-void handle_key_page_up(FileState*fs){(void)fs;}
-void handle_key_page_down(FileState*fs){(void)fs;}
-void handle_ctrl_key_left(FileState*fs){(void)fs;}
-void handle_ctrl_key_right(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgup(FileState*fs){(void)fs;}
-void handle_ctrl_key_pgdn(FileState*fs){(void)fs;}
-void handle_ctrl_key_up(FileState*fs){(void)fs;}
-void handle_ctrl_key_down(FileState*fs){(void)fs;}
-void handle_key_home(FileState*fs){(void)fs;}
-void handle_key_end(FileState*fs){(void)fs;}
-void handle_default_key(FileState*fs,int ch){(void)fs;(void)ch;}
-void handle_mouse_event(FileState*fs,MEVENT*ev){(void)fs;(void)ev;}
+void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_backspace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_delete(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_enter(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgup(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgdn(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_home(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_end(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_default_key(EditorContext*ctx,FileState*fs,int ch){(void)ctx;(void)fs;(void)ch;}
+void handle_mouse_event(EditorContext*ctx,FileState*fs,MEVENT*ev){(void)ctx;(void)fs;(void)ev;}
 void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
-void update_selection_mouse(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(EditorContext*ctx,FileState*fs,int x,int y){(void)ctx;(void)fs;(void)x;(void)y;}
 void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(FileState*fs){(void)fs;}
@@ -93,8 +93,8 @@ void next_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void prev_file(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void move_forward_to_next_word(FileState*fs){(void)fs;}
-void move_backward_to_previous_word(FileState*fs){(void)fs;}
+void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void show_about(void){}
 void show_help(void){}
 void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}


### PR DESCRIPTION
## Summary
- pass `EditorContext` to all public input handlers
- update keyboard and mouse input implementations
- adjust editor wrappers and run loop for new signatures
- update tests for new function parameters

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683bc925c7688324a3895a77681b60f2