### PR TITLE
Add EditorContext parameter to UI APIs

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -211,7 +211,7 @@ static void handle_help_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)fs;
     (void)cx;
     (void)cy;
-    show_help();
+    show_help(input_ctx);
     redraw();
 }
 
@@ -219,34 +219,34 @@ static void handle_about_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)fs;
     (void)cx;
     (void)cy;
-    show_about();
+    show_about(input_ctx);
     redraw();
 }
 
 static void handle_find_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
-    find(fs, 1);
+    find(input_ctx, fs, 1);
     redraw();
 }
 
 static void handle_find_next_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
-    find(fs, 0);
+    find(input_ctx, fs, 0);
     redraw();
 }
 
 static void handle_replace_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
-    replace(fs);
+    replace(input_ctx, fs);
     redraw();
 }
 
 static void handle_goto_line_wrapper(struct FileState *fs, int *cx, int *cy) {
     int line;
-    if (show_goto_dialog(&line)) {
+    if (show_goto_dialog(input_ctx, &line)) {
         go_to_line(fs, line);
         *cx = fs->cursor_x;
         *cy = fs->cursor_y;
@@ -280,22 +280,26 @@ static void handle_move_backward_wrapper(struct FileState *fs, int *cx, int *cy)
 static void handle_load_file_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
-    load_file(fs, NULL);
+    load_file(input_ctx, fs, NULL);
     redraw();
 }
 
 static void handle_save_as_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
-    save_file_as(fs);
+    save_file_as(input_ctx, fs);
     redraw();
 }
 
 static void handle_save_file_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
     (void)cy;
-    save_file(fs);
+    save_file(input_ctx, fs);
     redraw();
+}
+
+static void handle_close_file_wrapper(struct FileState *fs, int *cx, int *cy) {
+    close_current_file(input_ctx, fs, cx, cy);
 }
 
 static void handle_selection_mode_wrapper(struct FileState *fs, int *cx, int *cy) {
@@ -370,7 +374,7 @@ void initialize_key_mappings(void) {
     key_mappings[key_mapping_count++] = (KeyMapping){key_load_file, handle_load_file_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_save_as, handle_save_as_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_save_file, handle_save_file_wrapper};
-    key_mappings[key_mapping_count++] = (KeyMapping){key_close_file, close_current_file};
+    key_mappings[key_mapping_count++] = (KeyMapping){key_close_file, handle_close_file_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_selection_mode, handle_selection_mode_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_paste_clipboard, handle_paste_clipboard_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_copy_selection, handle_copy_selection_wrapper};

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -13,9 +13,9 @@
 
 #define INITIAL_LOAD_LINES 1024
 
-void save_file(FileState *fs) {
+void save_file(EditorContext *ctx, FileState *fs) {
     if (strlen(fs->filename) == 0) {
-        save_file_as(fs);
+        save_file_as(ctx, fs);
     } else {
         load_all_remaining_lines(fs);
         FILE *fp = fopen(fs->filename, "w");
@@ -36,9 +36,9 @@ void save_file(FileState *fs) {
     }
 }
 
-void save_file_as(FileState *fs) {
+void save_file_as(EditorContext *ctx, FileState *fs) {
     char newpath[256];
-    if (!show_save_file_dialog(newpath, sizeof(newpath)))
+    if (!show_save_file_dialog(ctx, newpath, sizeof(newpath)))
         return;    // user cancelled
     strncpy(fs->filename, newpath, sizeof(fs->filename) - 1);
     fs->filename[sizeof(fs->filename) - 1] = '\0';
@@ -63,13 +63,13 @@ void save_file_as(FileState *fs) {
     refresh();
 }
 
-void load_file(FileState *fs_unused, const char *filename) {
+void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     (void)fs_unused;
     char file_to_load[256];
     FileState *previous_active = active_file;
 
     if (filename == NULL) {
-        if (show_open_file_dialog(file_to_load, sizeof(file_to_load)) == 0) {
+        if (show_open_file_dialog(ctx, file_to_load, sizeof(file_to_load)) == 0) {
             return; // user cancelled
         }
         filename = file_to_load;
@@ -196,7 +196,7 @@ void new_file(FileState *fs_unused) {
     update_status_bar(active_file);
 }
 
-void close_current_file(FileState *fs_unused, int *cx, int *cy) {
+void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
     (void)fs_unused;
     FileState *current = fm_current(&file_manager);
     if (current) {
@@ -206,7 +206,7 @@ void close_current_file(FileState *fs_unused, int *cx, int *cy) {
     if (current && current->modified) {
         int ch = show_message("File modified. Save before closing? (y/n)");
         if (ch == 'y' || ch == 'Y') {
-            save_file(current);
+            save_file(ctx, current);
         } else if (ch != 'n' && ch != 'N') {
             return; /* cancel on other keys */
         }

--- a/src/file_ops.h
+++ b/src/file_ops.h
@@ -3,11 +3,14 @@
 
 struct FileState;
 #include <stdbool.h>
-void save_file(struct FileState *fs);
-void save_file_as(struct FileState *fs);
-void load_file(struct FileState *fs, const char *filename);
+void save_file(struct EditorContext *ctx, struct FileState *fs);
+struct EditorContext;
+void save_file_as(struct EditorContext *ctx, struct FileState *fs);
+void load_file(struct EditorContext *ctx, struct FileState *fs,
+               const char *filename);
 void new_file(struct FileState *fs);
-void close_current_file(struct FileState *fs, int *cx, int *cy);
+void close_current_file(struct EditorContext *ctx, struct FileState *fs,
+                        int *cx, int *cy);
 int set_syntax_mode(const char *filename);
 bool confirm_switch(void);
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -307,21 +307,22 @@ void menuNewFile(EditorContext *ctx) {
 }
 
 void menuLoadFile(EditorContext *ctx) {
-    load_file(ctx->active_file, NULL);
+    load_file(ctx, ctx->active_file, NULL);
     ctx->active_file = active_file;
     ctx->text_win = text_win;
 }
 
 void menuSaveFile(EditorContext *ctx) {
-    save_file(ctx->active_file);
+    save_file(ctx, ctx->active_file);
 }
 
 void menuSaveAs(EditorContext *ctx) {
-    save_file_as(ctx->active_file);
+    save_file_as(ctx, ctx->active_file);
 }
 
 void menuCloseFile(EditorContext *ctx) {
-    close_current_file(ctx->active_file, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
+    close_current_file(ctx, ctx->active_file, &ctx->active_file->cursor_x,
+                      &ctx->active_file->cursor_y);
     ctx->active_file = active_file;
     ctx->text_win = text_win;
 }
@@ -339,7 +340,7 @@ void menuPrevFile(EditorContext *ctx) {
 }
 
 void menuSettings(EditorContext *ctx) {
-    if (show_settings_dialog(&ctx->config)) {
+    if (show_settings_dialog(ctx, &ctx->config)) {
         config_save(&ctx->config);
         config_load(&ctx->config);
         ctx->enable_mouse = enable_mouse;
@@ -368,19 +369,19 @@ void menuRedo(EditorContext *ctx) {
 }
 
 void menuFind(EditorContext *ctx) {
-    find(ctx->active_file, 1);
+    find(ctx, ctx->active_file, 1);
 }
 
 void menuReplace(EditorContext *ctx) {
-    replace(ctx->active_file);
+    replace(ctx, ctx->active_file);
 }
 
 void menuAbout(EditorContext *ctx) {
-    show_about();
+    show_about(ctx);
 }
 
 void menuHelp(EditorContext *ctx) {
-    show_help();
+    show_help(ctx);
 }
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -116,13 +116,13 @@ void find_next_occurrence(FileState *fs, const char *word) {
     wrefresh(text_win);
 }
 
-void find(FileState *fs, int new_search)
+void find(EditorContext *ctx, FileState *fs, int new_search)
 {
     char output[256];
 
     if (new_search) {
         while (1) {
-            int confirmed = show_find_dialog(output, sizeof(output),
+            int confirmed = show_find_dialog(ctx, output, sizeof(output),
                                             search_text[0] ? search_text : NULL);
             if (!confirmed)
                 break; /* ESC pressed */
@@ -328,11 +328,12 @@ void replace_all_occurrences(FileState *fs, const char *search,
     wrefresh(text_win);
 }
 
-void replace(FileState *fs) {
+void replace(EditorContext *ctx, FileState *fs) {
     char search[256];
     char replacement[256];
 
-    if (!show_replace_dialog(search, sizeof(search), replacement, sizeof(replacement)))
+    if (!show_replace_dialog(ctx, search, sizeof(search), replacement,
+                             sizeof(replacement)))
         return;
 
     const char *options[] = {"Replace Next", "Replace All", "Cancel"};

--- a/src/search.h
+++ b/src/search.h
@@ -3,11 +3,12 @@
 
 #include "files.h"
 void find_next_occurrence(struct FileState *fs, const char *word);
-void find(struct FileState *fs, int new_search);
+struct EditorContext;
+void find(struct EditorContext *ctx, struct FileState *fs, int new_search);
 void replace_next_occurrence(struct FileState *fs, const char *search,
                              const char *replacement);
 void replace_all_occurrences(struct FileState *fs, const char *search,
                              const char *replacement);
-void replace(struct FileState *fs);
+void replace(struct EditorContext *ctx, struct FileState *fs);
 
 #endif

--- a/src/ui.c
+++ b/src/ui.c
@@ -9,7 +9,8 @@
 #include "dialog.h"
 #include "editor_state.h"
 
-void create_dialog(const char *message, char *output, int max_input_len) {
+void create_dialog(EditorContext *ctx, const char *message, char *output,
+                   int max_input_len) {
     int win_width = (int)strlen(message) + 30;
     WINDOW *dialog_win = dialog_open(7, win_width, message);
     if (!dialog_win) {
@@ -20,10 +21,10 @@ void create_dialog(const char *message, char *output, int max_input_len) {
 
     int input_x = 2;
     int input_y = 3;
-    if (enable_color)
+    if (ctx->enable_color)
         wattron(dialog_win, COLOR_PAIR(SYNTAX_KEYWORD));
     mvwprintw(dialog_win, input_y, input_x, "Input: ");
-    if (enable_color)
+    if (ctx->enable_color)
         wattroff(dialog_win, COLOR_PAIR(SYNTAX_KEYWORD));
     wrefresh(dialog_win);
 
@@ -34,7 +35,8 @@ void create_dialog(const char *message, char *output, int max_input_len) {
     dialog_close(dialog_win);
 }
 
-int show_find_dialog(char *output, int max_input_len, const char *preset) {
+int show_find_dialog(EditorContext *ctx, char *output, int max_input_len,
+                     const char *preset) {
     int win_width = 40;
     WINDOW *dialog_win = dialog_open(7, win_width, "Find:");
     if (!dialog_win) {
@@ -45,10 +47,10 @@ int show_find_dialog(char *output, int max_input_len, const char *preset) {
 
     int input_x = 7;
     int input_y = 3;
-    if (enable_color)
+    if (ctx->enable_color)
         wattron(dialog_win, COLOR_PAIR(SYNTAX_KEYWORD));
     mvwprintw(dialog_win, input_y, input_x, "Input: ");
-    if (enable_color)
+    if (ctx->enable_color)
         wattroff(dialog_win, COLOR_PAIR(SYNTAX_KEYWORD));
     if (preset && *preset) {
         strncpy(output, preset, max_input_len - 1);
@@ -65,23 +67,23 @@ int show_find_dialog(char *output, int max_input_len, const char *preset) {
     return ok;
 }
 
-int show_replace_dialog(char *search, int max_search_len,
+int show_replace_dialog(EditorContext *ctx, char *search, int max_search_len,
                         char *replace, int max_replace_len) {
     curs_set(0);
-    if (!show_find_dialog(search, max_search_len, NULL) || search[0] == '\0') {
+    if (!show_find_dialog(ctx, search, max_search_len, NULL) || search[0] == '\0') {
         curs_set(1);
         return 0;
     }
 
-    create_dialog("Replace:", replace, max_replace_len);
+    create_dialog(ctx, "Replace:", replace, max_replace_len);
     curs_set(1);
     return 1;
 }
 
-int show_goto_dialog(int *line_number) {
+int show_goto_dialog(EditorContext *ctx, int *line_number) {
     char buf[32];
 
-    create_dialog("Go To Line:", buf, sizeof(buf));
+    create_dialog(ctx, "Go To Line:", buf, sizeof(buf));
 
     if (buf[0] == '\0') {
         return 0;

--- a/src/ui.h
+++ b/src/ui.h
@@ -2,18 +2,21 @@
 #define UI_H
 
 #include "config.h"
+#include "editor_state.h"
 #include <ncurses.h>
 
-void show_help(void);
-void show_about(void);
-void create_dialog(const char *message, char *output, int max_input_len);
-void show_warning_dialog(void);
-int show_find_dialog(char *output, int max_input_len, const char *preset);
-int show_replace_dialog(char *search, int max_search_len,
+void show_help(EditorContext *ctx);
+void show_about(EditorContext *ctx);
+void create_dialog(EditorContext *ctx, const char *message, char *output,
+                   int max_input_len);
+void show_warning_dialog(EditorContext *ctx);
+int show_find_dialog(EditorContext *ctx, char *output, int max_input_len,
+                     const char *preset);
+int show_replace_dialog(EditorContext *ctx, char *search, int max_search_len,
                         char *replace, int max_replace_len);
-int show_goto_dialog(int *line_number);
-int show_open_file_dialog(char *path, int max_len);
-int show_save_file_dialog(char *path, int max_len);
-int show_settings_dialog(AppConfig *cfg);
+int show_goto_dialog(EditorContext *ctx, int *line_number);
+int show_open_file_dialog(EditorContext *ctx, char *path, int max_len);
+int show_save_file_dialog(EditorContext *ctx, char *path, int max_len);
+int show_settings_dialog(EditorContext *ctx, AppConfig *cfg);
 
 #endif // UI_H

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -62,7 +62,7 @@ void free_dir_contents(char **choices, int n_choices) {
     free(choices);
 }
 
-static int file_dialog_loop(char *path, int max_len,
+static int file_dialog_loop(EditorContext *ctx, char *path, int max_len,
                             int cursor_on_enter, int cursor_on_mouse) {
     curs_set(0);
     int highlight = 0;
@@ -173,7 +173,7 @@ static int file_dialog_loop(char *path, int max_len,
                     return 1;
                 }
             }
-        } else if (ch == KEY_MOUSE && enable_mouse) {
+        } else if (ch == KEY_MOUSE && ctx->enable_mouse) {
             MEVENT ev;
             if (getmouse(&ev) == OK &&
                 (ev.bstate & (BUTTON1_PRESSED | BUTTON1_CLICKED |
@@ -249,11 +249,11 @@ static int file_dialog_loop(char *path, int max_len,
     return 0;
 }
 
-int show_open_file_dialog(char *path, int max_len) {
-    return file_dialog_loop(path, max_len, 1, 0);
+int show_open_file_dialog(EditorContext *ctx, char *path, int max_len) {
+    return file_dialog_loop(ctx, path, max_len, 1, 0);
 }
 
-int show_save_file_dialog(char *path, int max_len) {
-    return file_dialog_loop(path, max_len, 0, 1);
+int show_save_file_dialog(EditorContext *ctx, char *path, int max_len) {
+    return file_dialog_loop(ctx, path, max_len, 0, 1);
 }
 

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -7,9 +7,9 @@
 #include <ncurses.h>
 #include <string.h>
 
-void show_help() {
+void show_help(EditorContext *ctx) {
     curs_set(0);
-    wbkgd(stdscr, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
+    wbkgd(stdscr, ctx->enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
 
     const char *help_lines[] = {
         "CTRL-H: Show this help",
@@ -61,7 +61,7 @@ void show_help() {
     curs_set(1);
 }
 
-void show_about() {
+void show_about(EditorContext *ctx) {
     int win_height = 10;
     int win_width = COLS - 20;
     WINDOW *about_win = dialog_open(win_height, win_width, "About");
@@ -79,7 +79,7 @@ void show_about() {
     dialog_close(about_win);
 }
 
-void show_warning_dialog() {
+void show_warning_dialog(EditorContext *ctx) {
     int win_height = 7;
     int win_width = COLS - 20;
     WINDOW *warning_win = dialog_open(win_height, win_width, "Warning");
@@ -99,10 +99,10 @@ void show_warning_dialog() {
 
     dialog_close(warning_win);
 
-    werase(text_win);
-    box(text_win, 0, 0);
-    draw_text_buffer(active_file, text_win);
-    wrefresh(text_win);
-    update_status_bar(active_file);
+    werase(ctx->text_win);
+    box(ctx->text_win, 0, 0);
+    draw_text_buffer(ctx->active_file, ctx->text_win);
+    wrefresh(ctx->text_win);
+    update_status_bar(ctx->active_file);
     wrefresh(stdscr);
 }

--- a/src/vento.c
+++ b/src/vento.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
             continue;
         }
 
-        load_file(NULL, argv[i]);
+        load_file(&editor, NULL, argv[i]);
         if (first_index == -1)
             first_index = file_manager.active_index;
         else
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
 
     // Show the warning dialog before entering the main editor loop
     if (app_config.show_startup_warning)
-        show_warning_dialog();
+        show_warning_dialog(&editor);
 
     // Finishes initializing editor window and begin accepting keyboard input.
     run_editor(&editor);

--- a/tests/stubs_file_ops.c
+++ b/tests/stubs_file_ops.c
@@ -18,8 +18,8 @@ int fm_add(FileManager *fm, FileState *fs){(void)fm;(void)fs;return 0;}
 void fm_close(FileManager *fm,int i){(void)fm;(void)i;}
 FileState *fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int i){(void)fm;(void)i;return 0;}
-int show_open_file_dialog(char *p,int m){(void)p;(void)m;return 0;}
-int show_save_file_dialog(char *p,int m){(void)p;(void)m;return 0;}
+int show_open_file_dialog(EditorContext *ctx,char *p,int m){(void)ctx;(void)p;(void)m;return 0;}
+int show_save_file_dialog(EditorContext *ctx,char *p,int m){(void)ctx;(void)p;(void)m;return 0;}
 void update_status_bar(FileState *fs){(void)fs;}
 void redraw(void){}
 int show_message(const char *msg){(void)msg;return 0;}

--- a/tests/test_cli_theme.c
+++ b/tests/test_cli_theme.c
@@ -21,11 +21,11 @@ bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
-void load_file(FileState *fs,const char*fn){(void)fs;(void)fn;}
+void load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
 void new_file(FileState *fs){(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
-void show_warning_dialog(void){}
+void show_warning_dialog(EditorContext*ctx){(void)ctx;}
 void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 int endwin(void){return 0;}

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -24,11 +24,11 @@ bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
-void load_file(FileState *fs,const char*fn){(void)fs;(void)fn;}
+void load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
 void new_file(FileState *fs){(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
-void show_warning_dialog(void){}
+void show_warning_dialog(EditorContext*ctx){(void)ctx;}
 void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 

--- a/tests/test_confirm_quit.c
+++ b/tests/test_confirm_quit.c
@@ -46,13 +46,13 @@ void update_status_bar(FileState*fs){(void)fs;}
 bool drawMenu(Menu*menu,int ci,int sx,int sy){(void)menu;(void)ci;(void)sx;(void)sy;return true;}
 void drawMenuBar(Menu*m,int mc){(void)m;(void)mc;}
 void new_file(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 void next_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
 void prev_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-int show_settings_dialog(AppConfig*cfg){(void)cfg;return 0;}
+int show_settings_dialog(EditorContext*ctx,AppConfig*cfg){(void)ctx;(void)cfg;return 0;}
 void config_save(const AppConfig*cfg){(void)cfg;}
 void config_load(AppConfig*cfg){(void)cfg;}
 void apply_colors(void){}
@@ -60,13 +60,13 @@ void redraw(void){}
 void drawBar(void){}
 void undo(FileState*fs){(void)fs;}
 void redo(FileState*fs){(void)fs;}
-void find(FileState*fs,int n){(void)fs;(void)n;}
-void replace(FileState*fs){(void)fs;}
-void show_about(void){}
-void show_help(void){}
+void find(EditorContext*ctx,FileState*fs,int n){(void)ctx;(void)fs;(void)n;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
 void allocation_failed(const char*msg){(void)msg;abort();}
 void initialize(EditorContext *ctx){(void)ctx;}
-void show_warning_dialog(void){}
+void show_warning_dialog(EditorContext*ctx){(void)ctx;}
 void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager*fm){(void)fm;}
 

--- a/tests/test_dialog_color_disable.c
+++ b/tests/test_dialog_color_disable.c
@@ -99,16 +99,20 @@ int main(void){
     assert(wattron_color_calls == 0);
     assert(wattroff_color_calls == 0);
 
+    EditorContext ctx = {0};
     printf("show_help\n");
-    show_help();
+    ctx.enable_color = enable_color;
+    show_help(&ctx);
     assert(wbkgd_attr_last == A_NORMAL);
 
     printf("show_about\n");
-    show_about();
+    ctx.enable_color = enable_color;
+    show_about(&ctx);
     assert(wbkgd_attr_last == A_NORMAL);
 
     printf("show_warning\n");
-    show_warning_dialog();
+    ctx.enable_color = enable_color;
+    show_warning_dialog(&ctx);
     assert(wbkgd_attr_last == A_NORMAL);
     
     /* color enabled */
@@ -123,15 +127,18 @@ int main(void){
     assert(wattroff_color_calls == 0);
 
     printf("show_help color\n");
-    show_help();
+    ctx.enable_color = enable_color;
+    show_help(&ctx);
     assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
 
     printf("show_about color\n");
-    show_about();
+    ctx.enable_color = enable_color;
+    show_about(&ctx);
     assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
 
     printf("show_warning color\n");
-    show_warning_dialog();
+    ctx.enable_color = enable_color;
+    show_warning_dialog(&ctx);
     assert(wbkgd_attr_last == COLOR_PAIR(SYNTAX_BG));
 
     return 0;

--- a/tests/test_info_newwin_fail.c
+++ b/tests/test_info_newwin_fail.c
@@ -60,16 +60,17 @@ int main(void){
     assert(w == NULL);
     assert(show_message_called == 1);
 
+    EditorContext ctx = {0};
     show_message_called = 0;
-    show_help();
+    show_help(&ctx);
     assert(show_message_called == 1);
 
     show_message_called = 0;
-    show_about();
+    show_about(&ctx);
     assert(show_message_called == 1);
 
     show_message_called = 0;
-    show_warning_dialog();
+    show_warning_dialog(&ctx);
     assert(show_message_called == 1);
 
     return 0;

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -30,13 +30,14 @@ int fm_switch(FileManager *fm,int idx){if(!fm||idx<0||idx>=fm->count)return -1;f
 bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
-void show_warning_dialog(void){}
+void show_warning_dialog(EditorContext*ctx){(void)ctx;}
 void run_editor(EditorContext *ctx){(void)ctx;}
 int endwin(void){return 0;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 
 /* simplified file loader used by main */
-void load_file(FileState *fs_unused,const char *filename){
+void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){
+    (void)ctx;
     (void)fs_unused;
     FileState *fs = calloc(1, sizeof(FileState));
     assert(fs);

--- a/tests/test_menu_no_clear.c
+++ b/tests/test_menu_no_clear.c
@@ -65,13 +65,13 @@ int touchwin(WINDOW*w){(void)w;return 0;}
 
 /* stubs for external editor functions referenced in menu.c */
 void new_file(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 void next_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
 void prev_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-int show_settings_dialog(AppConfig*cfg){(void)cfg;return 0;}
+int show_settings_dialog(EditorContext*ctx,AppConfig*cfg){(void)ctx;(void)cfg;return 0;}
 void config_save(const AppConfig*cfg){(void)cfg;}
 void config_load(AppConfig*cfg){(void)cfg;}
 mmask_t mousemask(mmask_t newmask, mmask_t *old){(void)newmask;if(old)*old=0;return 0;}
@@ -81,10 +81,10 @@ bool confirm_quit(void){return false;}
 void close_editor(void){}
 void undo(FileState*fs){(void)fs;}
 void redo(FileState*fs){(void)fs;}
-void find(FileState*fs,int n){(void)fs;(void)n;}
-void replace(FileState*fs){(void)fs;}
-void show_about(void){}
-void show_help(void){}
+void find(EditorContext*ctx,FileState*fs,int n){(void)ctx;(void)fs;(void)n;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
 void allocation_failed(const char*msg){(void)msg;abort();}
 
 #include "../src/menu_draw.c"

--- a/tests/test_menu_switch.c
+++ b/tests/test_menu_switch.c
@@ -7,6 +7,7 @@
 #include "menu.h"
 #include "config.h"
 #include "files.h"
+#include "editor_state.h"
 
 #undef move
 #undef clrtoeol
@@ -64,13 +65,13 @@ int touchwin(WINDOW*w){if(w==text_win)touch_calls++;return 0;}
 
 /* stubs for external editor functions referenced in menu.c */
 void new_file(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 void next_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
 void prev_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-int show_settings_dialog(AppConfig*cfg){(void)cfg;return 0;}
+int show_settings_dialog(EditorContext*ctx,AppConfig*cfg){(void)ctx;(void)cfg;return 0;}
 void config_save(const AppConfig*cfg){(void)cfg;}
 void config_load(AppConfig*cfg){(void)cfg;}
 mmask_t mousemask(mmask_t newmask, mmask_t *old){(void)newmask;if(old)*old=0;return 0;}
@@ -80,10 +81,10 @@ bool confirm_quit(void){return false;}
 void close_editor(void){}
 void undo(FileState*fs){(void)fs;}
 void redo(FileState*fs){(void)fs;}
-void find(FileState*fs,int n){(void)fs;(void)n;}
-void replace(FileState*fs){(void)fs;}
-void show_about(void){}
-void show_help(void){}
+void find(EditorContext*ctx,FileState*fs,int n){(void)ctx;(void)fs;(void)n;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
 void allocation_failed(const char*msg){(void)msg;abort();}
 
 #include "../src/menu_draw.c"

--- a/tests/test_replace_modified.c
+++ b/tests/test_replace_modified.c
@@ -31,8 +31,8 @@ int COLS = 80;
 int LINES = 24;
 char search_text[256];
 AppConfig app_config;
-int show_find_dialog(char*out,int sz,const char*def){(void)out;(void)sz;(void)def;return 0;}
-int show_replace_dialog(char*s,int ss,char*r,int rs){(void)s;(void)ss;(void)r;(void)rs;return 0;}
+int show_find_dialog(EditorContext*ctx,char*out,int sz,const char*def){(void)ctx;(void)out;(void)sz;(void)def;return 0;}
+int show_replace_dialog(EditorContext*ctx,char*s,int ss,char*r,int rs){(void)ctx;(void)s;(void)ss;(void)r;(void)rs;return 0;}
 
 void draw_text_buffer(FileState*fs, WINDOW*w){(void)fs;(void)w;}
 void push(Node **stack, Change change){(void)stack; free(change.old_text); free(change.new_text);}

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -82,16 +82,16 @@ void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)f
 void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs, WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
-void show_about(void){}
-void show_help(void){}
-void find(FileState*fs,int new_search){(void)fs;(void)new_search;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
+void find(EditorContext*ctx,FileState*fs,int new_search){(void)ctx;(void)fs;(void)new_search;}
 void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
 void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
-void replace(FileState*fs){(void)fs;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}
 void menuLoadFile(EditorContext*ctx){(void)ctx;}
@@ -108,7 +108,7 @@ void menuFind(EditorContext*ctx){(void)ctx;}
 void menuReplace(EditorContext*ctx){(void)ctx;}
 void menuAbout(EditorContext*ctx){(void)ctx;}
 void menuHelp(EditorContext*ctx){(void)ctx;}
-int show_goto_dialog(int *line){(void)line;return 0;}
+int show_goto_dialog(EditorContext*ctx,int *line){(void)ctx;(void)line;return 0;}
 void go_to_line(FileState *fs,int line){(void)fs;(void)line;}
 
 /* minimal global vars */

--- a/tests/test_resize_allocfail.c
+++ b/tests/test_resize_allocfail.c
@@ -89,16 +89,16 @@ void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)f
 void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs,WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
-void show_about(void){}
-void show_help(void){}
-void find(FileState*fs,int new_search){(void)fs;(void)new_search;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
+void find(EditorContext*ctx,FileState*fs,int new_search){(void)ctx;(void)fs;(void)new_search;}
 void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
 void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
-void replace(FileState*fs){(void)fs;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}
 void menuLoadFile(EditorContext*ctx){(void)ctx;}
@@ -115,7 +115,7 @@ void menuFind(EditorContext*ctx){(void)ctx;}
 void menuReplace(EditorContext*ctx){(void)ctx;}
 void menuAbout(EditorContext*ctx){(void)ctx;}
 void menuHelp(EditorContext*ctx){(void)ctx;}
-int show_goto_dialog(int*line){(void)line;return 0;}
+int show_goto_dialog(EditorContext*ctx,int*line){(void)ctx;(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
 void ensure_line_loaded(FileState*fs,int idx){(void)fs;(void)idx;}
 

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -78,14 +78,14 @@ void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)f
 void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs,WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
-void show_about(void){}
-void show_help(void){}
-void find(FileState*fs,int n){(void)fs;(void)n;}
-void replace(FileState*fs){(void)fs;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
+void find(EditorContext*ctx,FileState*fs,int n){(void)ctx;(void)fs;(void)n;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}
 void menuLoadFile(EditorContext*ctx){(void)ctx;}
 void menuSaveFile(EditorContext*ctx){(void)ctx;}
@@ -101,7 +101,7 @@ void menuFind(EditorContext*ctx){(void)ctx;}
 void menuReplace(EditorContext*ctx){(void)ctx;}
 void menuAbout(EditorContext*ctx){(void)ctx;}
 void menuHelp(EditorContext*ctx){(void)ctx;}
-int show_goto_dialog(int*line){(void)line;return 0;}
+int show_goto_dialog(EditorContext*ctx,int*line){(void)ctx;(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
 
 int enable_mouse=0;

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -78,16 +78,16 @@ void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)f
 void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
 void apply_syntax_highlighting(FileState*fs, WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
-void show_about(void){}
-void show_help(void){}
-void find(FileState*fs,int new_search){(void)fs;(void)new_search;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
+void find(EditorContext*ctx,FileState*fs,int new_search){(void)ctx;(void)fs;(void)new_search;}
 void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
 void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
-void replace(FileState*fs){(void)fs;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}
 void menuLoadFile(EditorContext*ctx){(void)ctx;}
@@ -104,7 +104,7 @@ void menuFind(EditorContext*ctx){(void)ctx;}
 void menuReplace(EditorContext*ctx){(void)ctx;}
 void menuAbout(EditorContext*ctx){(void)ctx;}
 void menuHelp(EditorContext*ctx){(void)ctx;}
-int show_goto_dialog(int *line){(void)line;return 0;}
+int show_goto_dialog(EditorContext*ctx,int *line){(void)ctx;(void)line;return 0;}
 void go_to_line(FileState *fs,int line){(void)fs;(void)line;}
 
 /* minimal global vars */

--- a/tests/test_search_highlight.c
+++ b/tests/test_search_highlight.c
@@ -60,8 +60,8 @@ void update_status_bar(FileState*fs){(void)fs;}
 static int drawBar_called=0;
 void drawBar(void){drawBar_called=1;}
 int ensure_col_capacity(FileState*fs,int cols){(void)fs;(void)cols;return 0;}
-int show_find_dialog(char*out,int sz,const char*def){(void)out;(void)sz;(void)def;return 0;}
-int show_replace_dialog(char*s,int ss,char*r,int rs){(void)s;(void)ss;(void)r;(void)rs;return 0;}
+int show_find_dialog(EditorContext*ctx,char*out,int sz,const char*def){(void)ctx;(void)out;(void)sz;(void)def;return 0;}
+int show_replace_dialog(EditorContext*ctx,char*s,int ss,char*r,int rs){(void)ctx;(void)s;(void)ss;(void)r;(void)rs;return 0;}
 void push(Node **stack, Change change){(void)stack;(void)change;}
 void mark_comment_state_dirty(FileState *fs){(void)fs;}
 void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
@@ -95,14 +95,14 @@ void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void show_about(void){}
-void show_help(void){}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
 void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
 void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
-void save_file(FileState*fs){(void)fs;}
-void save_file_as(FileState*fs){(void)fs;}
-void load_file(FileState*fs,const char*fn){(void)fs;(void)fn;}
-void close_current_file(FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}
 void menuLoadFile(EditorContext*ctx){(void)ctx;}
@@ -119,7 +119,7 @@ void menuFind(EditorContext*ctx){(void)ctx;}
 void menuReplace(EditorContext*ctx){(void)ctx;}
 void menuAbout(EditorContext*ctx){(void)ctx;}
 void menuHelp(EditorContext*ctx){(void)ctx;}
-int show_goto_dialog(int*line){(void)line;return 0;}
+int show_goto_dialog(EditorContext*ctx,int*line){(void)ctx;(void)line;return 0;}
 void go_to_line(FileState*fs,int line){(void)fs;(void)line;}
 int enable_mouse = 0;
 Menu *menus = NULL; int menuCount = 0;

--- a/tests/test_search_ignore_case.c
+++ b/tests/test_search_ignore_case.c
@@ -22,8 +22,8 @@ int get_line_number_offset(FileState*fs){(void)fs;return 0;}
 void draw_text_buffer(FileState*fs,WINDOW*w){(void)fs;(void)w;}
 void push(Node **stack, Change change){(void)stack; free(change.old_text); free(change.new_text);}
 void mark_comment_state_dirty(FileState*fs){(void)fs;}
-int show_find_dialog(char*out,int sz,const char*def){(void)out;(void)sz;(void)def;return 0;}
-int show_replace_dialog(char*s,int ss,char*r,int rs){(void)s;(void)ss;(void)r;(void)rs;return 0;}
+int show_find_dialog(EditorContext*ctx,char*out,int sz,const char*def){(void)ctx;(void)out;(void)sz;(void)def;return 0;}
+int show_replace_dialog(EditorContext*ctx,char*s,int ss,char*r,int rs){(void)ctx;(void)s;(void)ss;(void)r;(void)rs;return 0;}
 void allocation_failed(const char*msg){(void)msg; abort();}
 
 WINDOW *text_win=NULL;

--- a/tests/test_select_int_invalid.c
+++ b/tests/test_select_int_invalid.c
@@ -3,13 +3,15 @@
 #include <ncurses.h>
 #include "ui.h"
 #include "config.h"
-int select_int(const char *prompt, int current, WINDOW *parent);
+#include "editor_state.h"
+int select_int(EditorContext *ctx, const char *prompt, int current, WINDOW *parent);
 
 // We'll run several cases: negative, non-digit, overflow
 static const char *inputs[] = {"-1", "abc", "99999999999999999999999999"};
 static int case_index = 0;
 
-void create_dialog(const char *message, char *output, int max_input_len){
+void create_dialog(EditorContext *ctx, const char *message, char *output, int max_input_len){
+    (void)ctx;
     (void)message;
     strncpy(output, inputs[case_index], max_input_len);
     if(max_input_len>0) output[max_input_len-1]='\0';
@@ -17,7 +19,8 @@ void create_dialog(const char *message, char *output, int max_input_len){
 
 int main(void){
     for(case_index=0; case_index<3; ++case_index){
-        int result = select_int("Num", 5, NULL);
+        EditorContext ctx = {0};
+        int result = select_int(&ctx, "Num", 5, NULL);
         assert(result == 5); // should return current
     }
     return 0;

--- a/tests/test_select_int_valid.c
+++ b/tests/test_select_int_valid.c
@@ -3,17 +3,20 @@
 #include <ncurses.h>
 #include "ui.h"
 #include "config.h"
-int select_int(const char *prompt, int current, WINDOW *parent);
+#include "editor_state.h"
+int select_int(EditorContext *ctx, const char *prompt, int current, WINDOW *parent);
 
 // stub create_dialog to provide valid numeric input
-void create_dialog(const char *message, char *output, int max_input_len){
+void create_dialog(EditorContext *ctx, const char *message, char *output, int max_input_len){
+    (void)ctx;
     (void)message;
     strncpy(output, "42", max_input_len);
     if(max_input_len>0) output[max_input_len-1]='\0';
 }
 
 int main(void){
-    int result = select_int("Num", 7, NULL);
+    EditorContext ctx = {0};
+    int result = select_int(&ctx, "Num", 7, NULL);
     assert(result == 42);
     return 0;
 }


### PR DESCRIPTION
## Summary
- update UI public APIs to take `EditorContext *`
- propagate context usage through UI modules
- adjust callers across source and tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683bcb5ecd2c8324be7327ed7395f5f3