### PR TITLE
Fix EditorContext typedef

### DIFF
--- a/src/editor_state.h
+++ b/src/editor_state.h
@@ -4,14 +4,14 @@
 #include "file_manager.h"
 #include "config.h"
 
-typedef struct EditorContext {
+struct EditorContext {
     FileManager file_manager;
     AppConfig   config;
     FileState  *active_file;
     WINDOW     *text_win;
     int enable_color;
     int enable_mouse;
-} EditorContext;
+};
 
 #endif // EDITOR_STATE_H
 

--- a/src/input.h
+++ b/src/input.h
@@ -4,6 +4,7 @@
 #define BOTTOM_MARGIN 4 // Define the bottom UI margin
 
 #include "files.h"
+#include "editor.h"
 #include "editor_state.h"
 void handle_ctrl_backtick(EditorContext *ctx);
 void handle_key_up(EditorContext *ctx, struct FileState *fs);

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,6 +1,7 @@
 #ifndef MENU_H
 #define MENU_H
 #include <stdbool.h>
+#include "editor.h"
 #include "editor_state.h"
 typedef struct MenuItem {
     const char *label;

--- a/src/ui.c
+++ b/src/ui.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "config.h"
+#include "editor.h"
 #include "ui.h"
 #include "syntax.h"
 #include "ui_common.h"

--- a/src/ui.h
+++ b/src/ui.h
@@ -2,6 +2,7 @@
 #define UI_H
 
 #include "config.h"
+#include "editor.h"
 #include "editor_state.h"
 #include <ncurses.h>
 

--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -8,6 +8,7 @@
 #include <ncurses.h>
 #include <stdio.h>
 #include "config.h"
+#include "editor.h"
 #include "editor_state.h"
 
 void get_dir_contents(const char *dir_path, char ***choices, int *n_choices) {

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -1,6 +1,7 @@
 #include "ui_common.h"
 #include "ui.h"
 #include "config.h"
+#include "editor.h"
 #include "editor_state.h"
 #include <ncurses.h>
 #include <stdio.h>


### PR DESCRIPTION
## Summary
- define `EditorContext` struct in `editor_state.h` without typedef
- keep the typedef in `editor.h`
- include `editor.h` where the typedef is required

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683bd91e21d88324b4e3d517087c749f