### PR TITLE
Suppress warnings in file ops functions

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -14,6 +14,7 @@
 #define INITIAL_LOAD_LINES 1024
 
 void save_file(EditorContext *ctx, FileState *fs) {
+    (void)ctx;
     if (strlen(fs->filename) == 0) {
         save_file_as(ctx, fs);
     } else {
@@ -37,6 +38,7 @@ void save_file(EditorContext *ctx, FileState *fs) {
 }
 
 void save_file_as(EditorContext *ctx, FileState *fs) {
+    (void)ctx;
     char newpath[256];
     if (!show_save_file_dialog(ctx, newpath, sizeof(newpath)))
         return;    // user cancelled


### PR DESCRIPTION
## Summary
- silence potential unused `ctx` warnings in `save_file` and `save_file_as`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683bda39afec8324be8624234df5006f