### PR TITLE
Fix unused parameter warnings

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -43,6 +43,7 @@ void delete_current_line(EditorContext *ctx, FileState *fs) {
 }
 
 void insert_new_line(EditorContext *ctx, FileState *fs) {
+    (void)ctx;
     if (ensure_line_capacity(fs, fs->line_count + 1) < 0)
         allocation_failed("ensure_line_capacity failed");
     for (int i = fs->line_count; i > fs->cursor_y + fs->start_line - 1; --i) {

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -201,6 +201,7 @@ void handle_key_page_up(EditorContext *ctx, FileState *fs) {
 }
 
 void handle_key_page_down(EditorContext *ctx, FileState *fs) {
+    (void)ctx;
     ensure_line_loaded(fs, fs->start_line + (LINES - 4));
     int max_lines = LINES - 4;
     if (fs->start_line + max_lines < fs->line_count) {

--- a/src/input_mouse.c
+++ b/src/input_mouse.c
@@ -9,6 +9,7 @@
 #endif
 
 void update_selection_mouse(EditorContext *ctx, FileState *fs, int x, int y) {
+    (void)ctx;
     fs->sel_end_x = x;
     fs->sel_end_y = y;
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -317,6 +317,7 @@ void menuSettings(EditorContext *ctx) {
 }
 
 void menuQuitEditor(EditorContext *ctx) {
+    (void)ctx;
     if (confirm_quit())
         close_editor();
 }

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -62,6 +62,7 @@ void show_help(EditorContext *ctx) {
 }
 
 void show_about(EditorContext *ctx) {
+    (void)ctx;
     int win_height = 10;
     int win_width = COLS - 20;
     WINDOW *about_win = dialog_open(win_height, win_width, "About");


### PR DESCRIPTION
## Summary
- add missing `(void)ctx;` markers for unused parameters
- silence compiler warnings by marking ctx unused in some other files

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683bda4e9b7c83249315d685e1aaac38