### PR TITLE
Improve save feedback UX

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -30,10 +30,12 @@ void save_file(EditorContext *ctx, FileState *fs) {
         } else {
             mvprintw(LINES - 2, 2, "Error saving file!");
         }
+        clrtoeol();
         refresh();
-        getch();
-        mvprintw(LINES - 2, 2, "                            ");
+        napms(1000);      /* display for one second */
+        mvprintw(LINES - 2, 2, "%*s", COLS - 4, "");
         refresh();
+        return;
     }
 }
 
@@ -59,10 +61,12 @@ void save_file_as(EditorContext *ctx, FileState *fs) {
         mvprintw(LINES - 2, 2, "Error saving file!");
     }
 
+    clrtoeol();
     refresh();
-    getch();
-    mvprintw(LINES - 2, 2, "                            ");
+    napms(1000);      /* display for one second */
+    mvprintw(LINES - 2, 2, "%*s", COLS - 4, "");
     refresh();
+    return;
 }
 
 void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {


### PR DESCRIPTION
## Summary
- replace blocking `getch()` with timed message when saving files
- exit `save_file`/`save_file_as` after showing the one-second notice

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683bdd266d748324956fc2ec309983ac