### PR TITLE
Fix horizontal scrolling buffer sizing

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -564,14 +564,17 @@ void draw_text_buffer(FileState *fs, WINDOW *win) {
         }
         const char *line = fs->text_buffer[line_idx];
         const char *start = line + fs->scroll_x;
-        char temp[1024];
         int use_w = visible_width;
-        if (use_w >= (int)sizeof(temp))
-            use_w = (int)sizeof(temp) - 1;
+        char *temp = malloc(use_w + 1);
+        if (!temp) {
+            allocation_failed("malloc failed");
+            return;
+        }
         strncpy(temp, start, use_w);
         temp[use_w] = '\0';
         // Apply syntax highlighting to the current line of text
         apply_syntax_highlighting(fs, content, temp, i + 1);
+        free(temp);
 
         // Highlight current search match if it falls on this line
         if (fs->match_start_y == line_idx && fs->match_start_x >= 0) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -124,6 +124,11 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_horizontal_scroll.c src/input_keyboard.c -lncurses -o test_horizontal_scroll
 ./test_horizontal_scroll
 
+# build and run long horizontal scroll test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_long_horizontal_scroll.c src/input_keyboard.c -lncurses -o test_long_horizontal_scroll
+./test_long_horizontal_scroll
+
 # build and run color disable test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_color_disable.c src/globals.c -lncurses -o test_color_disable
 VENTO_THEME_DIR=./themes ./test_color_disable

--- a/tests/test_long_horizontal_scroll.c
+++ b/tests/test_long_horizontal_scroll.c
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include "files.h"
+#include "input.h"
+#include "editor.h"
+
+int COLS = 10;
+int LINES = 24;
+int show_line_numbers = 0;
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+
+void draw_text_buffer(FileState *fs, WINDOW *w) { (void)fs; (void)w; }
+int get_line_number_offset(FileState *fs) { (void)fs; return 0; }
+void mark_comment_state_dirty(FileState *fs){ (void)fs; }
+void allocation_failed(const char *msg){ (void)msg; abort(); }
+int ensure_line_capacity(FileState *fs, int n){ (void)fs; (void)n; return 0; }
+void push(Node **stack, Change ch){ (void)stack; free(ch.old_text); free(ch.new_text); }
+void ensure_line_loaded(FileState *fs, int idx){ (void)fs; (void)idx; }
+void load_all_remaining_lines(FileState *fs){ (void)fs; }
+
+int main(void) {
+    const int len = 2050; /* > 2000 */
+    FileState fs = {0};
+    fs.line_capacity = len + 10;
+    fs.max_lines = 1;
+    fs.text_buffer = calloc(1, sizeof(char*));
+    fs.text_buffer[0] = calloc(fs.line_capacity, 1);
+    memset(fs.text_buffer[0], 'a', len - 1);
+    fs.text_buffer[0][len - 1] = 'Z';
+    fs.text_buffer[0][len] = '\0';
+    fs.line_count = 1;
+    fs.cursor_x = 1;
+    fs.cursor_y = 1;
+    fs.start_line = 0;
+    fs.scroll_x = 0;
+    EditorContext ctx = {0};
+    ctx.active_file = &fs;
+    active_file = &fs;
+
+    for (int i = 0; i < len; i++)
+        handle_key_right(&ctx, &fs);
+    int visible = COLS - 2; /* no line numbers */
+    assert(fs.cursor_x == len + 1);
+    assert(fs.scroll_x == fs.cursor_x - visible);
+    assert(fs.scroll_x + visible >= len);
+
+    char *tmp = malloc(visible + 1);
+    strncpy(tmp, fs.text_buffer[0] + fs.scroll_x, visible);
+    tmp[visible] = '\0';
+    size_t tmplen = strlen(tmp);
+    assert(tmplen > 0 && tmp[tmplen - 1] == 'Z');
+    free(tmp);
+
+    for (int i = len; i > 0; i--)
+        handle_key_left(&ctx, &fs);
+    assert(fs.cursor_x == 1);
+    assert(fs.scroll_x == 0);
+
+    free(fs.text_buffer[0]);
+    free(fs.text_buffer);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allocate buffer dynamically for drawing text lines
- add regression test for scrolling lines longer than 2000 characters

## Testing
- `./tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683bde0f49b883249e527fee2a334515