### PR TITLE
Sort themes alphabetically

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -19,6 +19,12 @@ int select_bool(const char *prompt, int current, WINDOW *parent);
 int select_int(EditorContext *ctx, const char *prompt, int current,
                WINDOW *parent);
 
+static int str_casecmp(const void *a, const void *b) {
+    const char *as = *(const char * const *)a;
+    const char *bs = *(const char * const *)b;
+    return strcasecmp(as, bs);
+}
+
 static void apply_mouse(AppConfig *cfg) {
     enable_mouse = cfg->enable_mouse;
     if (enable_mouse)
@@ -479,14 +485,16 @@ const char *select_theme(const char *current, WINDOW *parent) {
                 }
                 ++count;
             }
-        }
-        closedir(dir);
     }
+    closedir(dir);
+}
 
     if (count == 0) {
         free(names);
         return NULL;
     }
+
+    qsort(names, count, sizeof(char *), str_casecmp);
 
     int highlight = 0;
     if (current) {


### PR DESCRIPTION
## Summary
- alphabetically sort theme list in settings dialog

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683bdf69747083248dc0aa158b1952cb