### PR TITLE
Support VENTO_CONFIG path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The file is written in the same key order as the defaults.  When you exit the se
 dialog with changes, the updated configuration is automatically saved back to
 `~/.ventorc`.
 
+You can override the location of this file by setting the `VENTO_CONFIG`
+environment variable to an alternate path.
+
 This file is created automatically with default values if it does not exist. Unknown keys are ignored when the file is parsed. You can also change these options interactively using the **Settings** dialog. Open it from *File → Settings* (press `CTRL-T` to open the menu) and navigate with the arrow keys. The recognized keys are:
 - `background_color`
 - `text_color`

--- a/docs/vento.1
+++ b/docs/vento.1
@@ -41,6 +41,9 @@ tab_width \- number of spaces inserted when Tab is pressed
 Configuration options can also be changed interactively using the \fBFile\fP \-> \fBSettings\fP dialog which writes updates back to \fI~/.ventorc\fP.
 .SH ENVIRONMENT
 .TP
+.B VENTO_CONFIG
+Path to the configuration file. Overrides \fI~/.ventorc\fP.
+.TP
 .B VENTO_THEME_DIR
 Directory to search for \fI.theme\fP files. Overrides \fBTHEME_DIR\fP, which defaults to \fBthemes\fP.
 .SH KEYBOARD SHORTCUTS

--- a/src/config.c
+++ b/src/config.c
@@ -25,6 +25,13 @@ short get_color_code(const char *color_name) {
 }
 
 static void get_config_path(char *buf, size_t size) {
+    const char *cfg = getenv("VENTO_CONFIG");
+    if (cfg && *cfg) {
+        strncpy(buf, cfg, size - 1);
+        buf[size - 1] = '\0';
+        return;
+    }
+
     struct passwd *pw = getpwuid(getuid());
     const char *homedir = pw ? pw->pw_dir : getenv("HOME");
     if (!homedir || homedir[0] == '\0')


### PR DESCRIPTION
## Summary
- check `VENTO_CONFIG` first when determining config path
- document the new variable in README and man page

## Testing
- `make test > /tmp/test.log 2>&1 && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_683be09c9f548324814bc2abdae820f4