### PR TITLE
Fix terminal resize key handling

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -434,6 +434,8 @@ void run_editor(EditorContext *ctx) {
         if (resize_pending || ch == KEY_RESIZE) {
             perform_resize();
             resize_pending = 0;
+            if (ch == KEY_RESIZE)
+                continue;              /* skip further processing */
         }
 
         if (ch == ERR) {


### PR DESCRIPTION
## Summary
- ignore KEY_RESIZE after performing resize to avoid stray characters

## Testing
- `make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683c9c3eea8483248f93407da85f2998