### PR TITLE
Ensure menus show on startup

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -429,6 +429,10 @@ void run_editor(EditorContext *ctx) {
     wmove(ctx->text_win, ctx->active_file->cursor_y,
           ctx->active_file->cursor_x + get_line_number_offset(ctx->active_file));
 
+    drawBar();
+    update_status_bar(ctx, ctx->active_file);
+    doupdate();
+
     while (exiting == 0) {
         ch = wgetch(ctx->text_win);
         if (resize_pending || ch == KEY_RESIZE) {

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -4,6 +4,7 @@
 #include "ui_common.h"
 #include "syntax.h"
 #include "dialog.h"
+#include "menu.h"
 #include <ncurses.h>
 #include <string.h>
 
@@ -105,5 +106,7 @@ void show_warning_dialog(EditorContext *ctx) {
     draw_text_buffer(ctx->active_file, ctx->text_win);
     wrefresh(ctx->text_win);
     update_status_bar(ctx, ctx->active_file);
-    wrefresh(stdscr);
+    drawBar();
+    wnoutrefresh(stdscr);
+    doupdate();
 }

--- a/tests/test_dialog_color_disable.c
+++ b/tests/test_dialog_color_disable.c
@@ -80,11 +80,14 @@ int werase(WINDOW*w){ (void)w; return 0; }
 int wborder(WINDOW*w,chtype ls,chtype rs,chtype ts,chtype bs,chtype tl,chtype tr,chtype bl,chtype br){(void)w;(void)ls;(void)rs;(void)ts;(void)bs;(void)tl;(void)tr;(void)bl;(void)br; return 0; }
 #define getbegyx(win,y,x) do{ (void)(win); y=0; x=0; }while(0)
 #define getmaxyx(win,y,x) do{ (void)(win); y=LINES; x=COLS; }while(0)
+int wnoutrefresh(WINDOW*w){(void)w;return 0;}
+int doupdate(void){return 0;}
 
 /* stubs for other functions */
 void draw_text_buffer(FileState*fs, WINDOW*w){ (void)fs; (void)w; }
 void update_status_bar(EditorContext *ctx, FileState*fs){ (void)fs; }
 int show_message(const char*msg){ (void)msg; return 0; }
+void drawBar(void){}
 
 int main(void){
     /* color disabled */

--- a/tests/test_info_newwin_fail.c
+++ b/tests/test_info_newwin_fail.c
@@ -49,9 +49,12 @@ int curs_set(int c){(void)c;return 0;}
 int werase(WINDOW*w){(void)w;return 0;}
 #define getbegyx(win,y,x) do{ (void)(win); y=0; x=0; }while(0)
 #define getmaxyx(win,y,x) do{ (void)(win); y=LINES; x=COLS; }while(0)
+int wnoutrefresh(WINDOW*w){(void)w;return 0;}
+int doupdate(void){return 0;}
 
 void draw_text_buffer(FileState*fs, WINDOW*w){(void)fs;(void)w;}
 void update_status_bar(EditorContext *ctx, FileState*fs){(void)fs;}
+void drawBar(void){}
 
 int main(void){
     show_message_called = 0;


### PR DESCRIPTION
## Summary
- show the menu bar when entering the editor
- refresh menu bar after warning dialogs
- stub additional UI functions in tests for new calls

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683c9cd07b4c8324a91cd9ab3ea347b4