### PR TITLE
Ignore unmapped special keys

### DIFF
--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -337,6 +337,8 @@ void handle_default_key(EditorContext *ctx, FileState *fs, int ch) {
         handle_tab_key(ctx, fs);
         return;
     }
+    if (ch >= KEY_MIN || !isprint(ch))
+        return; /* ignore non-printable or unmapped special keys */
     if (fs->cursor_x < fs->line_capacity - 1) {
         int len = strlen(fs->buffer.lines[fs->cursor_y - 1 + fs->start_line]);
         if (len > fs->line_capacity - 1)


### PR DESCRIPTION
## Summary
- ignore non-printable or unmapped ncurses keys in `handle_default_key`
- keep `<ctype.h>` include as is

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683c9de267b083248ad67b0263ee3ed3