### PR TITLE
Draw menu/status bar before startup warning

### DIFF
--- a/src/vento.c
+++ b/src/vento.c
@@ -114,6 +114,11 @@ int main(int argc, char *argv[]) {
     editor.enable_mouse = enable_mouse;
     editor.enable_color = enable_color;
 
+    drawBar();
+    update_status_bar(&editor, editor.active_file);
+    wnoutrefresh(stdscr);
+    doupdate();
+
     // Show the warning dialog before entering the main editor loop
     if (app_config.show_startup_warning)
         show_warning_dialog(&editor);

--- a/tests/test_cli_line.c
+++ b/tests/test_cli_line.c
@@ -31,6 +31,7 @@ void cleanup_on_exit(FileManager *fm){(void)fm;}
 int endwin(void){return 0;}
 void update_status_bar(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 void apply_colors(void){}
+void drawBar(void){}
 
 static FileState dummy = {0};
 void go_to_line(EditorContext *ctx, FileState *fs, int line){(void)ctx;fs->cursor_y=line;}

--- a/tests/test_cli_theme.c
+++ b/tests/test_cli_theme.c
@@ -31,6 +31,8 @@ void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
 int endwin(void){return 0;}
 void apply_colors(void){}
+void drawBar(void){}
+void update_status_bar(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 
 #define main vento_main
 #include "../src/vento.c"

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -32,6 +32,8 @@ int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(EditorContext*ctx){(void)ctx;}
 void run_editor(EditorContext *ctx){(void)ctx;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
+void drawBar(void){}
+void update_status_bar(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 
 #define main vento_main
 #include "../src/vento.c"

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -35,6 +35,8 @@ void show_warning_dialog(EditorContext*ctx){(void)ctx;}
 void run_editor(EditorContext *ctx){(void)ctx;}
 int endwin(void){return 0;}
 void cleanup_on_exit(FileManager *fm){(void)fm;}
+void drawBar(void){}
+void update_status_bar(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 
 /* simplified file loader used by main */
 void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){


### PR DESCRIPTION
## Summary
- render menu bar and status bar before showing startup warning
- stub `drawBar` and `update_status_bar` in CLI-related tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683c9ec9bc988324af02a632ee8e2644