### PR TITLE
Add flushinp after resize and test

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -726,6 +726,7 @@ void perform_resize(void) {
     /* Redraw the menu bar after all windows have been updated */
     drawBar();
     doupdate();
+    flushinp();
 }
 
 /**

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -41,6 +41,12 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     obj_test/stub_enable_color.o -lncurses -o test_resize_signal
 ./test_resize_signal
 
+# build and run resize flush input test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_resize_flushinp.c obj_test/files.o obj_test/line_buffer.o obj_test/file_manager.o obj_test/globals.o \
+    obj_test/stub_enable_color.o -lncurses -o test_resize_flushinp
+./test_resize_flushinp
+
 # build and run identifier overflow test with AddressSanitizer
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -Isrc -c src/syntax_common.c -o obj_test/syntax_common.o
 gcc -Wall -Wextra -std=c99 -g -Isrc -c src/syntax_regex.c -o obj_test/syntax_regex.o

--- a/tests/test_resize_flushinp.c
+++ b/tests/test_resize_flushinp.c
@@ -1,0 +1,154 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#undef refresh
+#undef clear
+#undef box
+#include "files.h"
+#include "file_manager.h"
+#include "editor.h"
+#include "menu.h"
+
+/* stub ncurses globals */
+int COLS = 80;
+int LINES = 24;
+
+/* simple WINDOW implementation */
+typedef struct { int h,w,y,x; } SIMPLE_WIN;
+
+WINDOW *newwin(int nlines, int ncols, int y, int x){
+    SIMPLE_WIN *w = calloc(1,sizeof(SIMPLE_WIN));
+    w->h=nlines; w->w=ncols; w->y=y; w->x=x;
+    return (WINDOW*)w;
+}
+int delwin(WINDOW*w){free(w);return 0;}
+int wresize(WINDOW*w,int h,int c){((SIMPLE_WIN*)w)->h=h; ((SIMPLE_WIN*)w)->w=c; return 0;}
+int mvwin(WINDOW*w,int y,int x){((SIMPLE_WIN*)w)->y=y; ((SIMPLE_WIN*)w)->x=x; return 0;}
+int werase(WINDOW*w){(void)w;return 0;}
+int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int wmove(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int endwin(void){return 0;}
+int refresh(void){return 0;}
+int clear(void){return 0;}
+int resizeterm(int r,int c){(void)r;(void)c;return 0;}
+int wnoutrefresh(WINDOW*w){(void)w;return 0;}
+int doupdate(void){return 0;}
+
+/* track flushinp calls */
+static int flushed = 0;
+int flushinp(void){flushed = 1; return 0;}
+
+/* simulate KEY_RESIZE followed by junk */
+static int get_calls = 0;
+int wgetch(WINDOW*w){
+    (void)w;
+    get_calls++;
+    if(get_calls==1) return KEY_RESIZE;
+    if(get_calls==2){
+        if(flushed){
+            exiting = 1;
+            return ERR;
+        }
+        return 'Z';
+    }
+    exiting = 1;
+    return ERR;
+}
+
+/* stubs for editor dependencies */
+void update_status_bar(EditorContext *ctx, FileState *fs){(void)fs;(void)ctx;}
+void drawBar(void){}
+void handle_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_backspace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_delete(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_enter(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_page_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_left(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_right(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgup(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_pgdn(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_up(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_ctrl_key_down(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_home(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_key_end(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void handle_default_key(EditorContext*ctx,FileState*fs,int ch){(void)ctx; fs->buffer.lines[0][0]=ch;}
+void handle_mouse_event(EditorContext*ctx,FileState*fs, MEVENT *ev){(void)ctx;(void)fs;(void)ev;}
+void start_selection_mode(FileState*fs,int x,int y){(void)fs;(void)x;(void)y;}
+void update_selection_mouse(EditorContext*ctx,FileState*fs,int x,int y){(void)ctx;(void)fs;(void)x;(void)y;}
+void end_selection_mode(FileState*fs){(void)fs;}
+void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;(void)ctx;}
+void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;(void)ctx;}
+void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)ctx;(void)fs;(void)x;(void)y;}
+void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)ctx;(void)fs;(void)x;(void)y;}
+void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void move_backward_to_previous_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void sync_multiline_comment(FileState*fs,int line){(void)fs;(void)line;}
+void apply_syntax_highlighting(FileState*fs, WINDOW*win,const char*line,int y){(void)fs;(void)win;(void)line;(void)y;}
+void show_about(EditorContext*ctx){(void)ctx;}
+void show_help(EditorContext*ctx){(void)ctx;}
+void find(EditorContext*ctx,FileState*fs,int new_search){(void)ctx;(void)fs;(void)new_search;}
+void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm;(void)ci;}
+void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
+void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
+void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
+int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
+void menuNewFile(EditorContext*ctx){(void)ctx;}
+void menuLoadFile(EditorContext*ctx){(void)ctx;}
+void menuSaveFile(EditorContext*ctx){(void)ctx;}
+void menuSaveAs(EditorContext*ctx){(void)ctx;}
+void menuCloseFile(EditorContext*ctx){(void)ctx;}
+void menuNextFile(EditorContext*ctx){(void)ctx;}
+void menuPrevFile(EditorContext*ctx){(void)ctx;}
+void menuSettings(EditorContext*ctx){(void)ctx;}
+void menuQuitEditor(EditorContext*ctx){(void)ctx;}
+void menuUndo(EditorContext*ctx){(void)ctx;}
+void menuRedo(EditorContext*ctx){(void)ctx;}
+void menuFind(EditorContext*ctx){(void)ctx;}
+void menuReplace(EditorContext*ctx){(void)ctx;}
+void menuAbout(EditorContext*ctx){(void)ctx;}
+void menuHelp(EditorContext*ctx){(void)ctx;}
+int show_goto_dialog(EditorContext*ctx,int *line){(void)ctx;(void)line;return 0;}
+void go_to_line(EditorContext *ctx, FileState *fs,int line){(void)ctx;(void)fs;(void)line;}
+
+/* minimal globals */
+int enable_mouse = 0;
+Menu *menus = NULL; int menuCount = 0;
+WINDOW *stdscr = NULL;
+
+/* include editor implementation */
+#include "../src/editor.c"
+
+int main(void){
+    fm_init(&file_manager);
+    FileState *fs = initialize_file_state("x",2,COLS);
+    assert(fs);
+    fm_add(&file_manager,fs);
+    active_file = fs;
+
+    fs->buffer.lines[0][0] = 'A';
+    fs->buffer.lines[0][1] = '\0';
+
+    EditorContext ctx = {0};
+    ctx.active_file = fs;
+    ctx.text_win = fs->text_win;
+
+    run_editor(&ctx);
+
+    assert(flushed);
+    assert(fs->buffer.lines[0][0] == 'A');
+
+    free_file_state(fs);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- flush partial input sequences when resizing
- test that KEY_RESIZE discards trailing bytes

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683c9f21f61083249fcb028906a9a055