### PR TITLE
Fix drawBar declaration

### DIFF
--- a/src/vento.c
+++ b/src/vento.c
@@ -8,6 +8,7 @@
 #include "ui.h"
 #include "files.h"
 #include "file_manager.h"
+#include "menu.h"
 #include "ui_common.h"
 #include "config.h"
 #include "editor_state.h"


### PR DESCRIPTION
## Summary
- include `menu.h` in `src/vento.c` to ensure drawBar is declared

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683ca06e55a08324971df691e5f0a257