### PR TITLE
Enable keypad on new windows

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -141,8 +141,6 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     mvprintw(LINES - 2, 2, "                            ");
     refresh();
     text_win = fs->text_win;
-    keypad(text_win, TRUE);
-    meta(text_win, TRUE);
 
     box(text_win, 0, 0);
     wmove(text_win, 1, 1 + get_line_number_offset(fs));
@@ -198,9 +196,6 @@ void new_file(FileState *fs_unused) {
 
     active_file = fm_current(&file_manager);
     text_win = fs->text_win;
-
-    keypad(text_win, TRUE);
-    meta(text_win, TRUE);
     box(text_win, 0, 0);
     fs->cursor_x = fs->saved_cursor_x;
     fs->cursor_y = fs->saved_cursor_y;

--- a/src/files.c
+++ b/src/files.c
@@ -64,6 +64,8 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
         free(file_state);
         return NULL;
     }
+    keypad(file_state->text_win, TRUE);
+    meta(file_state->text_win, TRUE);
     wtimeout(file_state->text_win, 10);
     wbkgd(file_state->text_win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
 

--- a/tests/test_file_state.c
+++ b/tests/test_file_state.c
@@ -10,6 +10,8 @@ WINDOW *newwin(int nlines, int ncols, int y, int x) {
     return (WINDOW *)1;
 }
 int delwin(WINDOW *w) { (void)w; return 0; }
+int keypad(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+int meta(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
 
 int main(void) {
     FileManager fm;

--- a/tests/test_long_line_load.c
+++ b/tests/test_long_line_load.c
@@ -9,6 +9,8 @@
 /* minimal WINDOW stubs */
 WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)1;}
 int delwin(WINDOW*w){(void)w;return 0;}
+int keypad(WINDOW*w,bool b){(void)w;(void)b;return 0;}
+int meta(WINDOW*w,bool b){(void)w;(void)b;return 0;}
 
 int main(void){
     const char *fname = "tmp_long_line.txt";

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -36,6 +36,8 @@ int werase(WINDOW *w){(void)w; return 0;}
 int box(WINDOW *w, chtype a, chtype b){(void)w;(void)a;(void)b;return 0;}
 int wrefresh(WINDOW *w){(void)w; return 0;}
 int wmove(WINDOW *w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int keypad(WINDOW *w,bool b){(void)w;(void)b;return 0;}
+int meta(WINDOW *w,bool b){(void)w;(void)b;return 0;}
 int endwin(void){return 0;}
 int refresh(void){return 0;}
 int clear(void){return 0;}

--- a/tests/test_resize_flushinp.c
+++ b/tests/test_resize_flushinp.c
@@ -29,6 +29,8 @@ int werase(WINDOW*w){(void)w;return 0;}
 int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
 int wrefresh(WINDOW*w){(void)w;return 0;}
 int wmove(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int keypad(WINDOW*w,bool b){(void)w;(void)b;return 0;}
+int meta(WINDOW*w,bool b){(void)w;(void)b;return 0;}
 int endwin(void){return 0;}
 int refresh(void){return 0;}
 int clear(void){return 0;}

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -30,6 +30,8 @@ int werase(WINDOW*w){(void)w;return 0;}
 int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
 int wrefresh(WINDOW*w){(void)w;return 0;}
 int wmove(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int keypad(WINDOW*w,bool b){(void)w;(void)b;return 0;}
+int meta(WINDOW*w,bool b){(void)w;(void)b;return 0;}
 int endwin(void){return 0;}
 int refresh(void){return 0;}
 int clear(void){return 0;}

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -32,6 +32,8 @@ int werase(WINDOW *w){(void)w; return 0;}
 int box(WINDOW *w, chtype a, chtype b){(void)w;(void)a;(void)b;return 0;}
 int wrefresh(WINDOW *w){(void)w; return 0;}
 int wmove(WINDOW *w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int keypad(WINDOW*w,bool b){(void)w;(void)b;return 0;}
+int meta(WINDOW*w,bool b){(void)w;(void)b;return 0;}
 int endwin(void){return 0;}
 int refresh(void){return 0;}
 int clear(void){return 0;}


### PR DESCRIPTION
## Summary
- activate keypad/meta when creating FileState windows
- avoid redundant keypad/meta setup in `load_file` and `new_file`
- add stubs for keypad/meta in tests

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683ca09aaa748324995f2f045da2367d