### PR TITLE
Fix first-file line jump

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -160,6 +160,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     extern int start_line;
     if (start_line > 0 && go_to_line)
         go_to_line(ctx, active_file, start_line);
+    start_line = 0;    /* only apply once */
 }
 
 void new_file(FileState *fs_unused) {


### PR DESCRIPTION
## Summary
- reset start_line after first file load so subsequent files open normally

## Testing
- `make` *(fails: undefined reference to `wget_wch`)*
- `make test` *(fails to complete due to build errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ca60709d8832491332ea08b88607a