### PR TITLE
Update replace_all to honor ignore-case

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -247,7 +247,9 @@ void replace_all_occurrences(FileState *fs, const char *search,
     bool replaced = false;
     for (int line = 0; line < fs->buffer.count; ++line) {
         char *line_text = (char *)lb_get(&fs->buffer, line);
-        char *pos = strstr(line_text, search);
+        char *pos = app_config.search_ignore_case
+                        ? strcasestr_simple(line_text, search)
+                        : strstr(line_text, search);
         if (!pos)
             continue;
 
@@ -289,7 +291,9 @@ void replace_all_occurrences(FileState *fs, const char *search,
             }
 
             cursor = pos + search_len;
-            pos = strstr(cursor, search);
+            pos = app_config.search_ignore_case ?
+                    strcasestr_simple(cursor, search) :
+                    strstr(cursor, search);
         }
         size_t tail_len = strlen(cursor);
         if (idx + tail_len >= buf_size - 1)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -235,6 +235,11 @@ gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc
     tests/test_search_ignore_case.c src/search.c src/line_buffer.c -lncursesw -o test_search_ignore_case
 ./test_search_ignore_case
 
+# build and run replace ignore case test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_replace_ignore_case.c src/search.c src/line_buffer.c -lncursesw -o test_replace_ignore_case
+./test_replace_ignore_case
+
 # build and run cursor position restore test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_cursor_restore.c src/editor_actions.c src/file_manager.c src/globals.c \

--- a/tests/test_replace_ignore_case.c
+++ b/tests/test_replace_ignore_case.c
@@ -1,0 +1,71 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#undef mvprintw
+#undef wmove
+#undef wrefresh
+#undef werase
+#undef box
+
+#include "files.h"
+#include "line_buffer.h"
+#include "search.h"
+#include "editor.h"
+#include "config.h"
+
+/* minimal WINDOW stub */
+typedef struct { int dummy; } SIMPLE_WIN;
+WINDOW *newwin(int nlines,int ncols,int y,int x){(void)nlines;(void)ncols;(void)y;(void)x;return (WINDOW*)calloc(1,sizeof(SIMPLE_WIN));}
+int delwin(WINDOW*w){free(w);return 0;}
+int werase(WINDOW*w){(void)w;return 0;}
+int box(WINDOW*w,chtype a,chtype b){(void)w;(void)a;(void)b;return 0;}
+int wmove(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;return 0;}
+int wrefresh(WINDOW*w){(void)w;return 0;}
+int mvprintw(int y,int x,const char*fmt,...){(void)y;(void)x;(void)fmt;return 0;}
+int wborder(WINDOW*w,chtype ls,chtype rs,chtype ts,chtype bs,chtype tl,chtype tr,chtype bl,chtype br){(void)w;(void)ls;(void)rs;(void)ts;(void)bs;(void)tl;(void)tr;(void)bl;(void)br;return 0;}
+
+/* required globals and stubs */
+WINDOW *text_win = NULL;
+FileState *active_file = NULL;
+int COLS = 80;
+int LINES = 24;
+char search_text[256];
+AppConfig app_config;
+int show_find_dialog(EditorContext*ctx,char*out,int sz,const char*def){(void)ctx;(void)out;(void)sz;(void)def;return 0;}
+int show_replace_dialog(EditorContext*ctx,char*s,int ss,char*r,int rs){(void)ctx;(void)s;(void)ss;(void)r;(void)rs;return 0;}
+
+void draw_text_buffer(FileState*fs, WINDOW*w){(void)fs;(void)w;}
+void push(Node **stack, Change change){(void)stack; free(change.old_text); free(change.new_text);} 
+void mark_comment_state_dirty(FileState*fs){(void)fs;}
+int get_line_number_offset(FileState*fs){(void)fs;return 0;}
+void allocation_failed(const char*msg){(void)msg; abort();}
+
+int main(void){
+    FileState fs = {0};
+    fs.line_capacity = 2048;
+    lb_init(&fs.buffer, 1);
+    lb_insert(&fs.buffer, 0, "Foo foo FOO");
+    char *tmp = realloc(fs.buffer.lines[0], fs.line_capacity);
+    if (!tmp) abort();
+    fs.buffer.lines[0] = tmp;
+    fs.cursor_x = 0; fs.cursor_y = 0;
+    fs.start_line = 0;
+
+    text_win = newwin(5,5,0,0);
+    active_file = &fs;
+
+    app_config.search_ignore_case = 1;
+    replace_all_occurrences(&fs, "foo", "bar");
+
+    assert(strcmp(fs.buffer.lines[0], "bar bar bar") == 0);
+    assert(fs.modified);
+    assert(fs.match_start_x == -1);
+    assert(fs.match_end_x == -1);
+    assert(fs.match_start_y == -1);
+    assert(fs.match_end_y == -1);
+
+    delwin(text_win);
+    lb_free(&fs.buffer);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- support case-insensitive matching in `replace_all_occurrences`
- add regression test for case-insensitive replace-all
- run the new test from `run_tests.sh`

## Testing
- `gcc -Wall -Wextra -std=c99 -g -fsanitize=address -D_POSIX_C_SOURCE=200809L -Isrc tests/test_replace_ignore_case.c src/search.c src/line_buffer.c -lncursesw -o test_replace_ignore_case && ./test_replace_ignore_case`

------
https://chatgpt.com/codex/tasks/task_e_683ca76b5d9c83248aa477603af3cfa4