### PR TITLE
Fix height bounds when creating centered windows

### DIFF
--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -14,6 +14,11 @@ WINDOW *create_centered_window(int height, int width, WINDOW *parent) {
     if (width < 2)
         width = 2;
 
+    if (height > LINES - 2)
+        height = LINES - 2;
+    if (height < 2)
+        height = 2;
+
     if (parent) {
         int py, px, ph, pw;
         getbegyx(parent, py, px);


### PR DESCRIPTION
## Notes
- `make test` was interrupted after several minutes and did not fully complete.
- Building with `make` fails due to missing `wget_wch` in the linked library.

## Summary
- clamp popup window height to available terminal lines


------
https://chatgpt.com/codex/tasks/task_e_683ca900232c83249a3bff233833ee42