### PR TITLE
Fix includes for ncurses

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -1,4 +1,4 @@
-#include <ncursesw/curses.h>
+#include <ncurses.h>
 #include <wchar.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -1,5 +1,5 @@
 #include "editor.h"
-#include <ncursesw/curses.h>
+#include <ncurses.h>
 #include <wchar.h>
 #include <wctype.h>
 #include "undo.h"


### PR DESCRIPTION
## Summary
- replace `<ncursesw/curses.h>` with `<ncurses.h>` in editor.c
- use same header in input_keyboard.c
- ran `make` to verify the missing-header error is gone (linker fails due to wget_wch symbol)

## Testing
- `make` *(fails: undefined reference to `wget_wch`)*

------
https://chatgpt.com/codex/tasks/task_e_683ca9ed5e2c83249c77360bfed1a549