### PR TITLE
Support byte input on systems without wide curses

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ sudo apt update
 sudo apt install build-essential libncurses5-dev libncursesw5-dev
 ```
 
+Vento prefers the wide-character version of ncurses for full Unicode input
+support. On systems where only the non-wide libraries are available, the
+editor will fall back to reading input in byte mode.
+
 ## Supported Platforms
 
 Vento has been tested on modern Linux distributions and macOS. Building the

--- a/src/editor.c
+++ b/src/editor.c
@@ -5,6 +5,13 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <signal.h>
+
+#if defined(NCURSES_WIDECHAR) || defined(_XOPEN_SOURCE_EXTENDED)
+#define USE_WIDE_INPUT 1
+#else
+#define USE_WIDE_INPUT 0
+#endif
+
 #include "editor.h"
 #include "input.h"
 #include "ui.h"
@@ -435,7 +442,14 @@ void run_editor(EditorContext *ctx) {
     doupdate();
 
     while (exiting == 0) {
-        int rc = wget_wch(ctx->text_win, &ch);
+        int rc;
+#if USE_WIDE_INPUT
+        rc = wget_wch(ctx->text_win, &ch);
+#else
+        int ch_tmp = wgetch(ctx->text_win);
+        rc = (ch_tmp == ERR) ? ERR : OK;
+        ch = ch_tmp;
+#endif
         if (resize_pending || ch == KEY_RESIZE) {
             perform_resize();
             resize_pending = 0;


### PR DESCRIPTION
## Summary
- add a compile-time check for wide curses support
- read keystrokes with `wgetch` when wide-character input isn't available
- note the fallback behaviour in the README

## Testing
- `make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cac9df64083249d72c8367df98b81