### PR TITLE
Update ncurses linkage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MANPAGE = $(DOC_DIR)/vento.1
 
 $(BIN_DIR)/vento: $(OBJS)
 	@mkdir -p $(BIN_DIR)
-	$(CC) $(CFLAGS) -o $@ $^ -lncurses
+	$(CC) $(CFLAGS) -o $@ $^ -lncursesw
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(DEPS)
 	@mkdir -p $(OBJ_DIR)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Before you can compile Vento, make sure you have the following installed:
 
 - **GCC**: The GNU Compiler Collection for compiling the source code.
 - **Binutils**: A collection of binary tools.
-- **Ncurses Dev Libraries**: Development libraries for Ncurses (necessary for text-based user interfaces).
+- **Ncurses Dev Libraries**: Development libraries for Ncurses (necessary for text-based user interfaces). The wide-character version (`libncursesw`) is recommended.
 
 On Debian-based systems, you can install these with:
 


### PR DESCRIPTION
## Summary
- link with wide-character ncurses library
- recommend using libncursesw in README

## Testing
- `timeout 60s sh tests/run_tests.sh` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cafde8f40832496ffe1a7ca722b0d