### PR TITLE
Fix macOS ncurses build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L
 
+ifeq ($(shell uname),Darwin)
+    CFLAGS += -D_XOPEN_SOURCE_EXTENDED
+endif
+
 SRC_DIR = ./src
 OBJ_DIR = ./obj
 BIN_DIR = ./bin

--- a/src/editor.c
+++ b/src/editor.c
@@ -1,3 +1,8 @@
+#ifdef __APPLE__
+#  ifndef _XOPEN_SOURCE_EXTENDED
+#    define _XOPEN_SOURCE_EXTENDED
+#  endif
+#endif
 #include <ncurses.h>
 #include <wchar.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- add `_XOPEN_SOURCE_EXTENDED` for ncurses on macOS
- apply same flag in `Makefile`

## Testing
- `make`
- `make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cb30161108324b50fddc75b42a440