### PR TITLE
Fix curses linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ make CFLAGS="-D_DARWIN_C_SOURCE"
 The code already guards `SIGWINCH`, but enabling additional feature macros may
 be required for full functionality.
 
-When linking on macOS, use the non-wide curses library. The Makefile and
-test script automatically select `-lncurses` instead of the wide-character
-version `-lncursesw` when `uname` reports `Darwin`.
+When building on macOS the non-wide curses library is used automatically.
+Both the Makefile and test script select `-lncurses` when `uname` reports
+`Darwin`, while other systems link with `-lncursesw`.
 
 ## Command Line Options
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -254,5 +254,5 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
 
 # build and run line buffer insert/delete test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
-    tests/test_linebuffer_insert_delete.c src/line_buffer.c -o test_linebuffer_insert_delete
+    tests/test_linebuffer_insert_delete.c src/line_buffer.c $CURSES_LIB -o test_linebuffer_insert_delete
 ./test_linebuffer_insert_delete


### PR DESCRIPTION
## Summary
- link the last test binary with CURSES_LIB
- clarify that macOS builds link with `-lncurses`

## Testing
- `make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cb733fbec83249ad0008dd11e0465