### PR TITLE
Add safety check in perform_resize

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -700,6 +700,9 @@ void redraw() {
  */
 void perform_resize(void) {
 
+    if (!active_file || !active_file->text_win)
+        return;
+
     endwin(); // End the curses mode
     resizeterm(0, 0); // update ncurses internal size
     clear(); // Clear the screen


### PR DESCRIPTION
## Summary
- avoid dereferencing NULL when resizing

## Testing
- `gcc ... test_resize.c ...`
- `./test_resize`
- `gcc ... test_resize_trunc.c ...`
- `./test_resize_trunc`
- `gcc ... test_resize_allocfail.c ...`
- `./test_resize_allocfail`
- `gcc ... test_resize_signal.c ...`
- `./test_resize_signal`
- `gcc ... test_resize_flushinp.c ...`
- `./test_resize_flushinp`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683cb8987020832499de9c966f1a76e3