### PR TITLE
Add XOPEN flag for mac tests

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,9 +3,16 @@ set -e
 
 if [ "$(uname)" = "Darwin" ]; then
     CURSES_LIB=-lncurses
+    EXTRA_CFLAGS="-D_XOPEN_SOURCE_EXTENDED"
 else
     CURSES_LIB=-lncursesw
+    EXTRA_CFLAGS=""
 fi
+
+# Ensure all gcc invocations include any extra flags (e.g. for macOS)
+gcc() {
+    command gcc $EXTRA_CFLAGS "$@"
+}
 # Ensure a clean build directory
 rm -rf obj_test
 mkdir obj_test


### PR DESCRIPTION
## Summary
- include `-D_XOPEN_SOURCE_EXTENDED` in test script for macOS builds

## Testing
- `make`
- `make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cb85491188324a01e80651c6f8974