### PR TITLE
Adjust macOS CFLAGS

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,15 +3,15 @@ set -e
 
 if [ "$(uname)" = "Darwin" ]; then
     CURSES_LIB=-lncurses
-    EXTRA_CFLAGS="-D_XOPEN_SOURCE_EXTENDED"
+    CFLAGS="-D_XOPEN_SOURCE_EXTENDED"
 else
     CURSES_LIB=-lncursesw
-    EXTRA_CFLAGS=""
+    CFLAGS=""
 fi
 
 # Ensure all gcc invocations include any extra flags (e.g. for macOS)
 gcc() {
-    command gcc $EXTRA_CFLAGS "$@"
+    command gcc $CFLAGS "$@"
 }
 # Ensure a clean build directory
 rm -rf obj_test


### PR DESCRIPTION
## Summary
- update run_tests.sh to use `CFLAGS` variable when invoking gcc
- append `-D_XOPEN_SOURCE_EXTENDED` on macOS via this variable

## Testing
- `./tests/run_tests.sh` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cb9a9c4408324a8987b9d633c54b7