### PR TITLE
Remove unused initialize_buffer function

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -509,38 +509,6 @@ void run_editor(EditorContext *ctx) {
 
 
 
-/**
- * Initializes the text buffer by allocating memory for each line and setting initial values.
- * 
- * This function is responsible for initializing the text buffer by allocating memory for each line
- * and setting initial values such as line count and start line. It is called during the editor's
- * initialization process to ensure that the text buffer is properly set up before any editing
- * operations are performed.
- * 
- * @param None
- * @return None
- */
-void initialize_buffer() {
-    // Allocate memory for each line in the text buffer
-    for (int i = 0; i < active_file->buffer.capacity; ++i) {
-        if (active_file->buffer.lines[i] != NULL) {
-            free(active_file->buffer.lines[i]);
-            active_file->buffer.lines[i] = NULL;
-        }
-        active_file->buffer.lines[i] = (char *)calloc(active_file->line_capacity, sizeof(char));
-        if (active_file->buffer.lines[i] == NULL) {
-            allocation_failed("calloc failed in initialize_buffer");
-        }
-    }
-    
-    // Set the initial line count to 1
-    active_file->buffer.count = 1;
-    
-    // Set the initial start line to 0
-    if (active_file)
-        active_file->start_line = 0;
-
-}
 
 /**
  * Draws the text buffer on the specified window.

--- a/src/editor.h
+++ b/src/editor.h
@@ -55,7 +55,6 @@ void draw_text_buffer(struct FileState *fs, WINDOW *win);
 void close_editor(void);
 void clear_text_buffer(void);
 void run_editor(EditorContext *ctx);
-void initialize_buffer(void);
 void redraw(void);
 void delete_current_line(EditorContext *ctx, struct FileState *fs);
 void insert_new_line(EditorContext *ctx, struct FileState *fs);


### PR DESCRIPTION
## Summary
- drop `initialize_buffer` definition from `editor.c`
- remove its declaration from `editor.h`

## Testing
- `make`
- `timeout 30s make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cb99b4c488324b43004984be9a04a