### PR TITLE
Fix macOS mouse support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L
 
 ifeq ($(shell uname),Darwin)
     CURSES_LIB = -lncurses
-    CFLAGS += -D_XOPEN_SOURCE_EXTENDED
+    CFLAGS += -D_XOPEN_SOURCE_EXTENDED -D_DARWIN_C_SOURCE
 else
     CURSES_LIB = -lncursesw
 endif

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ sudo make install
 On macOS you may need to pass feature macros when compiling, for example:
 
 ```bash
-make CFLAGS="-D_DARWIN_C_SOURCE"
+make CFLAGS="-D_XOPEN_SOURCE_EXTENDED -D_DARWIN_C_SOURCE"
 ```
 
 The code already guards `SIGWINCH`, but enabling additional feature macros may

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ "$(uname)" = "Darwin" ]; then
     CURSES_LIB=-lncurses
-    CFLAGS="-D_XOPEN_SOURCE_EXTENDED"
+    CFLAGS="-D_XOPEN_SOURCE_EXTENDED -D_DARWIN_C_SOURCE"
 else
     CURSES_LIB=-lncursesw
     CFLAGS=""


### PR DESCRIPTION
## Summary
- extend Darwin compile flags with `_DARWIN_C_SOURCE`
- set the same flags when running the test suite
- show the full example flags for macOS builds in the README

## Testing
- `make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683cbc6dd98483248cbde080f961ed55