### PR TITLE
Add F10 menu shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Vento currently supports the following features:
 - **Adjustable Tab Width**: Choose how many spaces the Tab key inserts.
 - **Help Screen**: Press `CTRL-H` for a guide to Vento's features.
 - **About Box**: Press `CTRL-A` to view product information, version, and GPL message.
- - **Menu System**: Intuitive menu navigation for editor features.
+ - **Menu System**: Intuitive menu navigation for editor features. Press `CTRL-T` or `F10` to open the menu.
 - **Mouse Support**: Click to move the cursor, drag to select text, scroll with the wheel, and click the menu bar and its items.
 - **Resizes Without Truncation**: When the terminal window is resized, Vento preserves all text so nothing gets cut off.
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -116,6 +116,7 @@ int key_next_file = KEY_F(6);  // Key code for switching to the next file
 int key_prev_file = KEY_F(7);  // Key code for switching to the previous file
 int key_replace = 18;  // Key code for replacing text (CTRL-R)
 int key_goto_line = 7;  // Key code for go to line (CTRL-G)
+int key_menu_open = KEY_F(10);  // Key code for opening the menu (F10)
 
 static void handle_key_up_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cx;
@@ -406,6 +407,7 @@ void initialize_key_mappings(void) {
     key_mappings[key_mapping_count++] = (KeyMapping){key_next_file, handle_next_file_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){key_prev_file, handle_prev_file_wrapper};
     key_mappings[key_mapping_count++] = (KeyMapping){KEY_CTRL_T, NULL}; /* placeholder for menu key, handled elsewhere */
+    key_mappings[key_mapping_count++] = (KeyMapping){key_menu_open, NULL}; /* placeholder for F10 menu key */
 
     key_mappings[key_mapping_count++] = (KeyMapping){0, NULL}; /* terminator */
 }
@@ -477,7 +479,7 @@ void run_editor(EditorContext *ctx) {
         
         if (ctx->active_file->selection_mode) {
             handle_selection_mode(ctx->active_file, ch, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
-        } else if (ch == KEY_CTRL_T) { // CTRL-T
+        } else if (ch == KEY_CTRL_T || ch == key_menu_open) { // CTRL-T or F10
             doupdate();
             handleMenuNavigation(menus, menuCount, &currentMenu, &currentItem);
             // Redraw the editor screen after closing the menu


### PR DESCRIPTION
## Summary
- add key_menu_open to trigger menus with F10
- react to F10 alongside CTRL-T
- add mapping entry for F10 in keymap
- document the new shortcut in the README

## Testing
- `make test` *(fails to run to completion in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_683cbc8512d88324982a8f85ad9b4628