### PR TITLE
Synchronize context config on init

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -32,6 +32,7 @@ void initialize(EditorContext *ctx) {
     setlocale(LC_ALL, "");
     initscr();
     config_load(&app_config);
+    ctx->config = app_config;
     ctx->enable_color = enable_color;
     ctx->enable_mouse = enable_mouse;
     apply_colors();


### PR DESCRIPTION
## Summary
- sync loaded AppConfig with EditorContext when initializing

## Testing
- `make test` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_683cf0c5a9cc8324a25aa49e763c6fb7