### PR TITLE
Fix text_win restore on load failure

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -108,6 +108,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         refresh();
         free_file_state(fs);
         active_file = previous_active;
+        text_win = previous_active ? previous_active->text_win : NULL;
         return;
     }
     fs->file_complete = false;
@@ -120,6 +121,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         refresh();
         free_file_state(fs);
         active_file = previous_active;
+        text_win = previous_active ? previous_active->text_win : NULL;
         return;
     }
     mvprintw(LINES - 2, 2, "File loaded: %s", filename);


### PR DESCRIPTION
## Summary
- ensure `text_win` is restored if `load_file` fails to open or read

## Testing
- `timeout 60 tests/run_tests.sh` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683d1c66640c832481a11ac11c873666