### PR TITLE
Add ctx parameter to new_file

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -169,7 +169,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     start_line = 0;    /* only apply once */
 }
 
-void new_file(FileState *fs_unused) {
+void new_file(EditorContext *ctx, FileState *fs_unused) {
     (void)fs_unused;
     FileState *previous_active = active_file;
     int previous_index = file_manager.active_index;
@@ -210,11 +210,12 @@ void new_file(FileState *fs_unused) {
           fs->cursor_x + get_line_number_offset(fs));
     wrefresh(text_win);
 
-    EditorContext tmp_ctx = {0};
-    tmp_ctx.file_manager = file_manager;
-    tmp_ctx.active_file = active_file;
-    tmp_ctx.text_win = text_win;
-    update_status_bar(&tmp_ctx, active_file);
+    update_status_bar(ctx, active_file);
+    if (ctx) {
+        ctx->file_manager = file_manager;
+        ctx->active_file = active_file;
+        ctx->text_win = text_win;
+    }
 }
 
 void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
@@ -238,7 +239,7 @@ void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *
         active_file = fm_current(&file_manager);
         text_win = active_file->text_win;
     } else {
-        new_file(NULL);
+        new_file(ctx, NULL);
     }
 
     active_file = fm_current(&file_manager);

--- a/src/file_ops.h
+++ b/src/file_ops.h
@@ -2,13 +2,13 @@
 #define FILE_OPS_H
 
 struct FileState;
+struct EditorContext;
 #include <stdbool.h>
 void save_file(struct EditorContext *ctx, struct FileState *fs);
-struct EditorContext;
 void save_file_as(struct EditorContext *ctx, struct FileState *fs);
 void load_file(struct EditorContext *ctx, struct FileState *fs,
                const char *filename);
-void new_file(struct FileState *fs);
+void new_file(struct EditorContext *ctx, struct FileState *fs);
 void close_current_file(struct EditorContext *ctx, struct FileState *fs,
                         int *cx, int *cy);
 int set_syntax_mode(const char *filename);

--- a/src/menu.c
+++ b/src/menu.c
@@ -266,7 +266,7 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
 
 
 void menuNewFile(EditorContext *ctx) {
-    new_file(ctx->active_file);
+    new_file(ctx, ctx->active_file);
     ctx->active_file = active_file;
     ctx->text_win = text_win;
 }

--- a/src/vento.c
+++ b/src/vento.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (file_count == 0) {
-        new_file(NULL);
+        new_file(&editor, NULL);
     }
 
     active_file = fm_current(&file_manager);

--- a/tests/test_cli_line.c
+++ b/tests/test_cli_line.c
@@ -21,7 +21,7 @@ bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
-void new_file(FileState *fs){(void)fs;}
+void new_file(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return active_file;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(EditorContext*ctx){(void)ctx;}

--- a/tests/test_cli_theme.c
+++ b/tests/test_cli_theme.c
@@ -23,7 +23,7 @@ int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
 void load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
-void new_file(FileState *fs){(void)fs;}
+void new_file(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(EditorContext*ctx){(void)ctx;}

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -26,7 +26,7 @@ int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
 void load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
-void new_file(FileState *fs){(void)fs;}
+void new_file(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}
 void show_warning_dialog(EditorContext*ctx){(void)ctx;}

--- a/tests/test_confirm_quit.c
+++ b/tests/test_confirm_quit.c
@@ -46,7 +46,7 @@ void draw_text_buffer(FileState*fs,WINDOW*w){(void)fs;(void)w;}
 void update_status_bar(EditorContext *ctx, FileState*fs){(void)fs;}
 bool drawMenu(Menu*menu,int ci,int sx,int sy){(void)menu;(void)ci;(void)sx;(void)sy;return true;}
 void drawMenuBar(Menu*m,int mc){(void)m;(void)mc;}
-void new_file(FileState*fs){(void)fs;}
+void new_file(EditorContext *ctx, FileState*fs){(void)ctx;(void)fs;}
 void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -50,7 +50,8 @@ void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){
     active_file = fm_current(&file_manager);
 }
 
-void new_file(FileState *fs_unused){
+void new_file(EditorContext *ctx, FileState *fs_unused){
+    (void)ctx;
     (void)fs_unused;
     FileState *fs = calloc(1,sizeof(FileState));
     assert(fs);

--- a/tests/test_menu_no_clear.c
+++ b/tests/test_menu_no_clear.c
@@ -64,7 +64,7 @@ int curs_set(int c){(void)c;return 0;}
 int touchwin(WINDOW*w){(void)w;return 0;}
 
 /* stubs for external editor functions referenced in menu.c */
-void new_file(FileState*fs){(void)fs;}
+void new_file(EditorContext *ctx, FileState*fs){(void)ctx;(void)fs;}
 void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_menu_switch.c
+++ b/tests/test_menu_switch.c
@@ -64,7 +64,7 @@ int curs_set(int c){(void)c;return 0;}
 int touchwin(WINDOW*w){if(w==text_win)touch_calls++;return 0;}
 
 /* stubs for external editor functions referenced in menu.c */
-void new_file(FileState*fs){(void)fs;}
+void new_file(EditorContext *ctx, FileState*fs){(void)ctx;(void)fs;}
 void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}


### PR DESCRIPTION
## Summary
- update `new_file` signature to take an `EditorContext *`
- write context values back after adding a new file
- adjust callers (`menuNewFile`, `close_current_file`, `vento.c`)
- update all test stubs for new signature

## Testing
- `make test` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683db5f55e9c83248ade8cecabf42914