### PR TITLE
Fix free_file_state memory cleanup

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -77,10 +77,6 @@ void cleanup_on_exit(FileManager *fm) {
     for (int i = 0; i < fm->count; ++i) {
         FileState *fs = fm->files[i];
         if (!fs) continue;
-        free_stack(fs->undo_stack);
-        fs->undo_stack = NULL;
-        free_stack(fs->redo_stack);
-        fs->redo_stack = NULL;
         free_file_state(fs);
     }
     freeMenus();

--- a/src/files.c
+++ b/src/files.c
@@ -6,6 +6,7 @@
 #include "config.h"
 #include "editor_state.h"
 #include "line_buffer.h"
+#include "undo.h"
 #include <limits.h>
 
 // Function to initialize a new FileState for a given filename
@@ -82,6 +83,14 @@ void free_file_state(FileState *file_state) {
     if (file_state->fp) {
         fclose(file_state->fp);
         file_state->fp = NULL;
+    }
+    if (file_state->undo_stack) {
+        free_stack(file_state->undo_stack);
+        file_state->undo_stack = NULL;
+    }
+    if (file_state->redo_stack) {
+        free_stack(file_state->redo_stack);
+        file_state->redo_stack = NULL;
     }
     file_state->last_scanned_line = 0;
     file_state->last_comment_state = false;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -280,3 +280,8 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -DNCURSES_NOMACROS -Isrc
     tests/test_close_file_update.c src/file_ops.c src/editor_actions.c src/file_manager.c \
     obj_test/line_buffer.o $CURSES_LIB -o test_close_file_update
 ./test_close_file_update
+
+# build and run file close leak test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -fsanitize=leak -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_free_file_leak.c src/files.c src/line_buffer.c src/file_manager.c $CURSES_LIB -o test_free_file_leak
+ASAN_OPTIONS=detect_leaks=1 ./test_free_file_leak

--- a/tests/stub_enable_color.c
+++ b/tests/stub_enable_color.c
@@ -1,5 +1,17 @@
 #include <ncurses.h>
+#include <stdlib.h>
+#include "editor.h"
 
 int enable_color = 1;
 
 void wtimeout(WINDOW *w, int t){ (void)w; (void)t; }
+
+void free_stack(Node *stack){
+    while (stack){
+        Node *next = stack->next;
+        free(stack->change.old_text);
+        free(stack->change.new_text);
+        free(stack);
+        stack = next;
+    }
+}

--- a/tests/test_free_file_leak.c
+++ b/tests/test_free_file_leak.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ncurses.h>
+#include "files.h"
+#include "file_manager.h"
+#include "editor.h"
+#include "undo.h"
+
+/* minimal ncurses stubs allocating memory so leaks are detectable */
+int LINES = 24;
+int COLS = 80;
+WINDOW *newwin(int nlines, int ncols, int y, int x){
+    (void)nlines; (void)ncols; (void)y; (void)x;
+    return malloc(1);
+}
+int delwin(WINDOW *w){ free(w); return 0; }
+int keypad(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+int meta(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+int wbkgd(WINDOW *w, chtype ch){ (void)w; (void)ch; return 0; }
+
+int main(void){
+    FileManager fm; 
+    fm_init(&fm);
+
+    /* manually allocate FileState with undo and redo history */
+    FileState *fs = calloc(1, sizeof(FileState));
+    assert(fs);
+    fs->text_win = newwin(1,1,0,0);
+
+    Node *u = malloc(sizeof(Node));
+    u->change.old_text = strdup("old");
+    u->change.new_text = NULL;
+    u->next = NULL;
+    fs->undo_stack = u;
+
+    Node *r = malloc(sizeof(Node));
+    r->change.old_text = NULL;
+    r->change.new_text = strdup("new");
+    r->next = NULL;
+    fs->redo_stack = r;
+
+    fm_add(&fm, fs);
+    fm_close(&fm, 0);
+
+    assert(fm.count == 0);
+    assert(fm.files == NULL);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure undo and redo stacks are freed inside `free_file_state`
- avoid double-free by simplifying `cleanup_on_exit`
- expand test stubs to provide `free_stack`
- add regression test for leak-free file closing

## Testing
- `gcc -Wall -Wextra -std=c99 -g -fsanitize=address -fsanitize=leak -D_POSIX_C_SOURCE=200809L -Isrc tests/test_free_file_leak.c tests/stub_enable_color.c src/files.c src/line_buffer.c src/file_manager.c -lncursesw -o test_free_file_leak`
- `ASAN_OPTIONS=detect_leaks=1 ./test_free_file_leak`

------
https://chatgpt.com/codex/tasks/task_e_683dc0f764e88324b19bbd902cf2bd61