### PR TITLE
Fix lb_free leak and add regression test

### DIFF
--- a/src/line_buffer.c
+++ b/src/line_buffer.c
@@ -48,7 +48,7 @@ void lb_init(LineBuffer *lb, int initial_capacity) {
 void lb_free(LineBuffer *lb) {
     if (!lb)
         return;
-    for (int i = 0; i < lb->count; ++i)
+    for (int i = 0; i < lb->capacity; ++i)
         free(lb->lines[i]);
     free(lb->lines);
     lb->lines = NULL;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -285,3 +285,8 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -DNCURSES_NOMACROS -Isrc
 gcc -Wall -Wextra -std=c99 -g -fsanitize=address -fsanitize=leak -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_free_file_leak.c src/files.c src/line_buffer.c src/file_manager.c $CURSES_LIB -o test_free_file_leak
 ASAN_OPTIONS=detect_leaks=1 ./test_free_file_leak
+
+# build and run immediate close leak regression test
+gcc -Wall -Wextra -std=c99 -g -fsanitize=address -fsanitize=leak -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_close_immediate_leak.c src/files.c src/line_buffer.c src/file_manager.c $CURSES_LIB -o test_close_immediate_leak
+ASAN_OPTIONS=detect_leaks=1 ./test_close_immediate_leak

--- a/tests/test_close_immediate_leak.c
+++ b/tests/test_close_immediate_leak.c
@@ -1,0 +1,39 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include "files.h"
+#include "file_manager.h"
+
+int LINES = 24;
+int COLS = 80;
+
+/* allocate window memory so leaks are detected */
+WINDOW *newwin(int nlines, int ncols, int y, int x){
+    (void)nlines; (void)ncols; (void)y; (void)x;
+    return malloc(1);
+}
+int delwin(WINDOW *w){ free(w); return 0; }
+int keypad(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+int meta(WINDOW *w, bool b){ (void)w; (void)b; return 0; }
+int wbkgd(WINDOW *w, chtype ch){ (void)w; (void)ch; return 0; }
+
+/* enable_color and helpers */
+#include "editor.h"
+int enable_color = 1;
+void wtimeout(WINDOW *w, int t){ (void)w; (void)t; }
+void free_stack(Node *stack){ while (stack){ Node *n=stack->next; free(stack->change.old_text); free(stack->change.new_text); free(stack); stack=n; } }
+
+int main(void){
+    FileManager fm;
+    fm_init(&fm);
+
+    FileState *fs = initialize_file_state("dummy", 5, 10);
+    assert(fs);
+
+    fm_add(&fm, fs);
+    fm_close(&fm, 0);
+
+    assert(fm.count == 0);
+    assert(fm.files == NULL);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure `lb_free()` releases all allocated lines by iterating over `capacity`
- add regression test verifying closing a file immediately after creation doesn't leak
- run new regression test from `run_tests.sh`

## Testing
- `./tests/run_tests.sh > /tmp/test.log 2>&1`
- `gcc -Wall -Wextra -std=c99 -g -fsanitize=address -fsanitize=leak -D_POSIX_C_SOURCE=200809L -Isrc tests/test_close_immediate_leak.c src/files.c src/line_buffer.c src/file_manager.c -o test_close_immediate_leak && ASAN_OPTIONS=detect_leaks=1 ./test_close_immediate_leak`


------
https://chatgpt.com/codex/tasks/task_e_683dc3340bf88324a57e6ee5cb225f1c