### PR TITLE
Shrink file array on close

### DIFF
--- a/src/file_manager.c
+++ b/src/file_manager.c
@@ -8,6 +8,7 @@ void fm_init(FileManager *fm) {
     fm->files = NULL;
     fm->count = 0;
     fm->active_index = -1;
+    fm->capacity = 0;
 }
 
 FileState *fm_current(FileManager *fm) {
@@ -24,6 +25,7 @@ int fm_add(FileManager *fm, FileState *fs) {
     fm->files = tmp;
     fm->files[fm->count] = fs;
     fm->active_index = fm->count;
+    fm->capacity = fm->count + 1;
     fm->count++;
     return fm->active_index;
 }
@@ -45,7 +47,12 @@ void fm_close(FileManager *fm, int index) {
         free(fm->files);
         fm->files = NULL;
         fm->active_index = -1;
+        fm->capacity = 0;
     } else {
+        FileState **tmp = realloc(fm->files, sizeof(FileState*) * fm->count);
+        if (tmp)
+            fm->files = tmp;
+        fm->capacity = fm->count;
         fm->active_index = (index <= fm->active_index && fm->active_index > 0) ? fm->active_index - 1 : fm->active_index;
         if (fm->active_index >= fm->count) fm->active_index = fm->count - 1;
     }

--- a/src/file_manager.h
+++ b/src/file_manager.h
@@ -8,6 +8,7 @@ typedef struct FileManager {
     FileState **files;
     int count;
     int active_index;
+    int capacity;
 } FileManager;
 
 extern FileManager file_manager;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -296,3 +296,8 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_many_large_files.c src/file_ops.c src/editor_actions.c src/file_manager.c \
     src/globals.c obj_test/files.o obj_test/line_buffer.o $CURSES_LIB -o test_many_large_files
 ./test_many_large_files
+
+# build and run file manager shrink test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_fm_shrink.c src/file_manager.c src/files.c src/line_buffer.c $CURSES_LIB -o test_fm_shrink
+./test_fm_shrink

--- a/tests/test_fm_shrink.c
+++ b/tests/test_fm_shrink.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "files.h"
+
+int main(void){
+    FileManager fm;
+    fm_init(&fm);
+
+    FileState *states[10];
+    for(int i=0;i<10;i++){
+        states[i] = calloc(1, sizeof(FileState));
+        assert(states[i]);
+        fm_add(&fm, states[i]);
+        assert(fm.count == i + 1);
+        assert(fm.capacity == fm.count);
+    }
+
+    for(int i=9;i>=0;i--){
+        fm_close(&fm, i);
+        assert(fm.count == i);
+        assert(fm.capacity == fm.count);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Notes
- Testing took longer than expected and was interrupted, so results are unavailable in this environment.

## Summary
- track `FileManager` capacity and shrink the array in `fm_close`
- update initialization and add new unit test for shrinking
- run the new test via the test runner

## Testing
- `./tests/run_tests.sh` *(fails: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_683dc75c6c908324a2c01a2e523d5880