### PR TITLE
Fix single-file navigation prompt

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -86,7 +86,7 @@ void handle_undo_wrapper(FileState *fs, int *cx, int *cy) {
 
 void next_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
     (void)fs_unused;
-    if (file_manager.count == 0) {
+    if (file_manager.count <= 1) {
         return;
     }
     if (!confirm_switch())
@@ -124,7 +124,7 @@ void next_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
 
 void prev_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
     (void)fs_unused;
-    if (file_manager.count == 0) {
+    if (file_manager.count <= 1) {
         return;
     }
     if (!confirm_switch())

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -207,6 +207,12 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     obj_test/line_buffer.o $CURSES_LIB -o test_confirm_switch_input
 ./test_confirm_switch_input
 
+# build and run single file switch no prompt test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_single_file_no_prompt.c src/editor_actions.c src/file_manager.c src/globals.c \
+    obj_test/line_buffer.o $CURSES_LIB -o test_single_file_no_prompt
+./test_single_file_no_prompt
+
 # build and run menu overlay clear regression test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_menu_no_clear.c $CURSES_LIB -o test_menu_no_clear

--- a/tests/test_single_file_no_prompt.c
+++ b/tests/test_single_file_no_prompt.c
@@ -1,0 +1,57 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <ncurses.h>
+#include <string.h>
+#include "file_manager.h"
+#include "editor.h"
+#include "editor_state.h"
+#include "file_ops.h"
+
+int COLS = 80;
+int LINES = 24;
+WINDOW *text_win = NULL;
+WINDOW *stdscr = NULL;
+FileState *active_file = NULL;
+
+/* stubs required by editor_actions.c and file_manager.c */
+void allocation_failed(const char *msg){ (void)msg; abort(); }
+void draw_text_buffer(FileState *fs, WINDOW *w){ (void)fs; (void)w; }
+void mark_comment_state_dirty(FileState *fs){ (void)fs; }
+int ensure_line_capacity(FileState *fs, int n){ (void)fs; (void)n; return 0; }
+void push(Node **stack, Change ch){ (void)stack; free(ch.old_text); free(ch.new_text); }
+void redo(FileState *fs){ (void)fs; }
+void undo(FileState *fs){ (void)fs; }
+void redraw(void){}
+void clamp_scroll_x(FileState *fs){ (void)fs; }
+void free_file_state(FileState *fs){ (void)fs; }
+
+static int confirm_calls = 0;
+bool confirm_switch(void){ confirm_calls++; return false; }
+
+int main(void){
+    fm_init(&file_manager);
+    FileState fs1 = {0};
+    file_manager.files = malloc(sizeof(FileState*));
+    file_manager.files[0] = &fs1;
+    file_manager.count = 1;
+    file_manager.active_index = 0;
+    active_file = &fs1;
+    fs1.modified = true;
+
+    EditorContext ctx = {0};
+    ctx.file_manager = file_manager;
+    ctx.active_file = active_file;
+    ctx.text_win = text_win;
+
+    int cx = 0, cy = 0;
+    next_file(&ctx, active_file, &cx, &cy);
+    prev_file(&ctx, active_file, &cx, &cy);
+    active_file = ctx.active_file;
+
+    assert(confirm_calls == 0);
+    assert(file_manager.active_index == 0);
+    assert(active_file == &fs1);
+
+    free(file_manager.files);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prevent next_file/prev_file from prompting when only one file
- add regression test covering single-file navigation

## Testing
- `tests/run_tests.sh` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683dd3995c5c832497adc41a10cb6d6a