### PR TITLE
Implement sync_editor_context helper

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -75,4 +75,5 @@ void handle_undo_wrapper(struct FileState *fs, int *cx, int *cy);
 void allocation_failed(const char *msg);
 
 
+
 #endif // EDITOR_H

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -115,9 +115,7 @@ void next_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
         *cx = active_file->cursor_x;
         *cy = active_file->cursor_y;
     }
-    ctx->file_manager = file_manager;
-    ctx->active_file = active_file;
-    ctx->text_win = text_win;
+    sync_editor_context(ctx);
     redraw();
     update_status_bar(ctx, active_file);
 }
@@ -153,9 +151,7 @@ void prev_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
         *cx = active_file->cursor_x;
         *cy = active_file->cursor_y;
     }
-    ctx->file_manager = file_manager;
-    ctx->active_file = active_file;
-    ctx->text_win = text_win;
+    sync_editor_context(ctx);
     redraw();
     update_status_bar(ctx, active_file);
 }

--- a/src/editor_state.h
+++ b/src/editor_state.h
@@ -13,5 +13,12 @@ struct EditorContext {
     int enable_mouse;
 };
 
+static inline void sync_editor_context(struct EditorContext *ctx) {
+    if (!ctx) return;
+    ctx->file_manager = file_manager;
+    ctx->active_file = active_file;
+    ctx->text_win = text_win;
+}
+
 #endif // EDITOR_STATE_H
 

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -240,11 +240,8 @@ void new_file(EditorContext *ctx, FileState *fs_unused) {
     wrefresh(text_win);
 
     update_status_bar(ctx, active_file);
-    if (ctx) {
-        ctx->file_manager = file_manager;
-        ctx->active_file = active_file;
-        ctx->text_win = text_win;
-    }
+    if (ctx)
+        sync_editor_context(ctx);
 }
 
 void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
@@ -281,11 +278,8 @@ void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *
         *cx = active_file->cursor_x;
         *cy = active_file->cursor_y;
     }
-    if (ctx) {
-        ctx->file_manager = file_manager;
-        ctx->active_file = active_file;
-        ctx->text_win = text_win;
-    }
+    if (ctx)
+        sync_editor_context(ctx);
     redraw();
     update_status_bar(ctx, active_file);
 }

--- a/src/vento.c
+++ b/src/vento.c
@@ -98,8 +98,10 @@ int main(int argc, char *argv[]) {
         load_file(&editor, NULL, argv[i]);
         if (first_index == -1)
             first_index = file_manager.active_index;
-        else
+        else {
             fm_switch(&file_manager, first_index);
+            sync_editor_context(&editor);
+        }
 
         file_count++;
     }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -233,6 +233,11 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_main_multifile.c src/globals.c $CURSES_LIB -o test_main_multifile
 ./test_main_multifile
 
+# verify status bar counts when multiple files passed
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_status_bar_count.c src/globals.c $CURSES_LIB -o test_status_bar_count
+./test_status_bar_count
+
 # build and run select_int valid input test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_select_int_valid.c src/ui_settings.c \

--- a/tests/test_status_bar_count.c
+++ b/tests/test_status_bar_count.c
@@ -1,0 +1,60 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "files.h"
+#include "editor.h"
+#include "editor_state.h"
+#include "ui.h"
+#include "ui_common.h"
+#include "config.h"
+
+FileState *active_file = NULL;
+WINDOW *text_win = NULL;
+int COLS = 80;
+int LINES = 24;
+FileManager file_manager = {0};
+AppConfig app_config;
+int enable_mouse = 0;
+int enable_color = 0;
+int start_line = 0;
+
+void fm_init(FileManager *fm){fm->files=NULL;fm->count=0;fm->active_index=-1;}
+FileState* fm_current(FileManager *fm){if(!fm||fm->active_index<0||fm->active_index>=fm->count)return NULL;return fm->files[fm->active_index];}
+int fm_add(FileManager *fm,FileState *fs){FileState **tmp=realloc(fm->files,sizeof(FileState*)*(fm->count+1));if(!tmp)abort();fm->files=tmp;fm->files[fm->count]=fs;fm->active_index=fm->count;return fm->count++;}
+int fm_switch(FileManager *fm,int idx){if(!fm||idx<0||idx>=fm->count)return -1;fm->active_index=idx;return idx;}
+
+bool any_file_modified(FileManager *fm){(void)fm;return false;}
+int show_message(const char*msg){(void)msg;return 0;}
+void initialize(EditorContext *ctx){(void)ctx;}
+void show_warning_dialog(EditorContext*ctx){(void)ctx;}
+void run_editor(EditorContext *ctx){(void)ctx;}
+int endwin(void){return 0;}
+void cleanup_on_exit(FileManager *fm){(void)fm;}
+void drawBar(void){}
+static int s_idx=0, s_total=0;
+void update_status_bar(EditorContext *ctx, FileState *fs){(void)fs; s_idx = ctx->file_manager.active_index + 1; s_total = ctx->file_manager.count;}
+
+void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){(void)ctx;(void)fs_unused;FileState *fs=calloc(1,sizeof(FileState));assert(fs);strncpy(fs->filename,filename,sizeof(fs->filename)-1);int idx=fm_add(&file_manager,fs);fm_switch(&file_manager,idx);active_file=fm_current(&file_manager);} 
+void new_file(EditorContext *ctx, FileState *fs_unused){(void)ctx;(void)fs_unused;FileState *fs=calloc(1,sizeof(FileState));assert(fs);int idx=fm_add(&file_manager,fs);fm_switch(&file_manager,idx);active_file=fm_current(&file_manager);} 
+
+#define main vento_main
+#include "../src/vento.c"
+#undef main
+
+int main(void){
+    char t1[] = "file1XXXXXX";
+    char t2[] = "file2XXXXXX";
+    int fd1 = mkstemp(t1);
+    int fd2 = mkstemp(t2);
+    assert(fd1>=0 && fd2>=0);
+    close(fd1); close(fd2);
+    char *argv[] = {"vento", t1, t2};
+    vento_main(3, argv);
+    assert(s_idx == 1);
+    assert(s_total == 2);
+    unlink(t1); unlink(t2);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `sync_editor_context()` inline helper
- use helper after switching files
- verify editor updates via new `test_status_bar_count`

## Testing
- `gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc tests/test_status_bar_count.c src/globals.c -lncursesw -o test_status_bar_count && ./test_status_bar_count`
- `timeout 60 sh tests/run_tests.sh` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683dd5a66b6883249391829afb572679