### PR TITLE
Fix cursor position switching

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -341,11 +341,17 @@ static void handle_cut_selection_wrapper(struct FileState *fs, int *cx, int *cy)
 }
 
 static void handle_next_file_wrapper(struct FileState *fs, int *cx, int *cy) {
-    next_file(input_ctx, fs, cx, cy);
+    (void)fs;
+    (void)cx;
+    (void)cy;
+    next_file(input_ctx);
 }
 
 static void handle_prev_file_wrapper(struct FileState *fs, int *cx, int *cy) {
-    prev_file(input_ctx, fs, cx, cy);
+    (void)fs;
+    (void)cx;
+    (void)cy;
+    prev_file(input_ctx);
 }
 
 static void handle_clear_buffer_wrapper(struct FileState *fs, int *cx, int *cy) {

--- a/src/editor.h
+++ b/src/editor.h
@@ -68,8 +68,14 @@ void clamp_scroll_x(struct FileState *fs);
 void cleanup_on_exit(struct FileManager *fm);
 void disable_ctrl_c_z(void);
 void apply_colors(void);
-void next_file(EditorContext *ctx, struct FileState *fs, int *cx, int *cy);
-void prev_file(EditorContext *ctx, struct FileState *fs, int *cx, int *cy);
+
+typedef struct {
+    int x;
+    int y;
+} CursorPos;
+
+CursorPos next_file(EditorContext *ctx);
+CursorPos prev_file(EditorContext *ctx);
 void handle_redo_wrapper(struct FileState *fs, int *cx, int *cy);
 void handle_undo_wrapper(struct FileState *fs, int *cx, int *cy);
 void allocation_failed(const char *msg);

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -84,13 +84,13 @@ void handle_undo_wrapper(FileState *fs, int *cx, int *cy) {
     undo(fs);
 }
 
-void next_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
-    (void)fs_unused;
+CursorPos next_file(EditorContext *ctx) {
+    CursorPos pos = {0, 0};
     if (file_manager.count <= 1) {
-        return;
+        return pos;
     }
     if (!confirm_switch())
-        return;
+        return pos;
     FileState *cur = fm_current(&file_manager);
     if (cur) {
         cur->saved_cursor_x = cur->cursor_x;
@@ -111,22 +111,23 @@ void next_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
     }
     text_win = active_file ? active_file->text_win : NULL;
     clamp_scroll_x(active_file);
-    if (cx && cy && active_file) {
-        *cx = active_file->cursor_x;
-        *cy = active_file->cursor_y;
+    if (active_file) {
+        pos.x = active_file->cursor_x;
+        pos.y = active_file->cursor_y;
     }
     sync_editor_context(ctx);
     redraw();
     update_status_bar(ctx, active_file);
+    return pos;
 }
 
-void prev_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
-    (void)fs_unused;
+CursorPos prev_file(EditorContext *ctx) {
+    CursorPos pos = {0, 0};
     if (file_manager.count <= 1) {
-        return;
+        return pos;
     }
     if (!confirm_switch())
-        return;
+        return pos;
     FileState *cur = fm_current(&file_manager);
     if (cur) {
         cur->saved_cursor_x = cur->cursor_x;
@@ -147,13 +148,14 @@ void prev_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {
     }
     text_win = active_file ? active_file->text_win : NULL;
     clamp_scroll_x(active_file);
-    if (cx && cy && active_file) {
-        *cx = active_file->cursor_x;
-        *cy = active_file->cursor_y;
+    if (active_file) {
+        pos.x = active_file->cursor_x;
+        pos.y = active_file->cursor_y;
     }
     sync_editor_context(ctx);
     redraw();
     update_status_bar(ctx, active_file);
+    return pos;
 }
 
 void update_status_bar(EditorContext *ctx, FileState *fs) {

--- a/src/menu.c
+++ b/src/menu.c
@@ -298,11 +298,11 @@ void menuCloseFile(EditorContext *ctx) {
 }
 
 void menuNextFile(EditorContext *ctx) {
-    next_file(ctx, ctx->active_file, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
+    (void)next_file(ctx);
 }
 
 void menuPrevFile(EditorContext *ctx) {
-    prev_file(ctx, ctx->active_file, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
+    (void)prev_file(ctx);
 }
 
 void menuSettings(EditorContext *ctx) {

--- a/tests/test_close_file_update.c
+++ b/tests/test_close_file_update.c
@@ -96,7 +96,7 @@ int main(void){
 
     /* ensure further operations use updated context */
     int cx = 0, cy = 0;
-    next_file(&ctx, active_file, &cx, &cy);
+    (void)next_file(&ctx);
     assert(ctx.active_file == fs2);
     assert(ctx.text_win == fs2->text_win);
 
@@ -107,7 +107,7 @@ int main(void){
     assert(active_file == file_manager.files[file_manager.active_index]);
     assert(ctx.text_win == active_file->text_win);
 
-    next_file(&ctx, active_file, &cx, &cy);
+    (void)next_file(&ctx);
     assert(ctx.active_file == active_file);
     assert(ctx.text_win == active_file->text_win);
 

--- a/tests/test_confirm_quit.c
+++ b/tests/test_confirm_quit.c
@@ -51,8 +51,8 @@ void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
-void next_file(EditorContext *ctx, FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-void prev_file(EditorContext *ctx, FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 int show_settings_dialog(EditorContext*ctx,AppConfig*cfg){(void)ctx;(void)cfg;return 0;}
 void config_save(const AppConfig*cfg){(void)cfg;}
 void config_load(AppConfig*cfg){(void)cfg;}

--- a/tests/test_confirm_switch.c
+++ b/tests/test_confirm_switch.c
@@ -45,8 +45,7 @@ int main(void){
     ctx.active_file = active_file;
     ctx.text_win = text_win;
 
-    int cx = 0, cy = 0;
-    next_file(&ctx, active_file, &cx, &cy);
+    (void)next_file(&ctx);
     active_file = ctx.active_file;
 
     assert(confirm_calls == 1);

--- a/tests/test_cursor_restore.c
+++ b/tests/test_cursor_restore.c
@@ -45,20 +45,21 @@ int main(void){
     ctx.active_file = active_file;
     ctx.text_win = text_win;
 
-    int cx = 0, cy = 0;
-    next_file(&ctx, active_file, &cx, &cy);
+    CursorPos pos = next_file(&ctx);
     assert(fs1.saved_cursor_x == 5 && fs1.saved_cursor_y == 6);
     active_file = ctx.active_file;
     assert(active_file == &fs2);
-    assert(cx == 2 && cy == 3);
+    assert(pos.x == 2 && pos.y == 3);
+    assert(fs1.cursor_x == 5 && fs1.cursor_y == 6);
 
     fs2.cursor_x = 10; fs2.cursor_y = 11;
-    prev_file(&ctx, active_file, &cx, &cy);
+    pos = prev_file(&ctx);
     active_file = ctx.active_file;
     assert(fs2.saved_cursor_x == 10 && fs2.saved_cursor_y == 11);
     assert(active_file == &fs1);
-    assert(cx == 5 && cy == 6);
+    assert(pos.x == 5 && pos.y == 6);
     assert(fs1.cursor_x == 5 && fs1.cursor_y == 6);
+    assert(fs2.cursor_x == 10 && fs2.cursor_y == 11);
 
     free(file_manager.files);
     return 0;

--- a/tests/test_many_large_files.c
+++ b/tests/test_many_large_files.c
@@ -69,7 +69,6 @@ int main(void){
     ctx.text_win = NULL;
 
     char name[64];
-    int cx=0, cy=0;
     for(int i=0;i<20;i++){
         snprintf(name,sizeof(name),"big_%d.txt",i);
         FILE *fp=fopen(name,"w");
@@ -77,7 +76,7 @@ int main(void){
         fclose(fp);
         load_file(&ctx, active_file, name);
         if(i>0){
-            next_file(&ctx, active_file, &cx, &cy);
+            (void)next_file(&ctx);
         }
         assert(count_fds() < 32);
     }

--- a/tests/test_menu_close_file.c
+++ b/tests/test_menu_close_file.c
@@ -116,7 +116,7 @@ int main(void){
     assert(ctx.text_win == fs2->text_win);
 
     int cx = 0, cy = 0;
-    next_file(&ctx, active_file, &cx, &cy);
+    (void)next_file(&ctx);
     assert(ctx.active_file == fs2);
     assert(ctx.text_win == fs2->text_win);
 
@@ -126,7 +126,7 @@ int main(void){
     assert(active_file == file_manager.files[file_manager.active_index]);
     assert(ctx.text_win == active_file->text_win);
 
-    next_file(&ctx, active_file, &cx, &cy);
+    (void)next_file(&ctx);
     assert(ctx.active_file == active_file);
     assert(ctx.text_win == active_file->text_win);
 

--- a/tests/test_menu_no_clear.c
+++ b/tests/test_menu_no_clear.c
@@ -69,8 +69,8 @@ void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
-void next_file(EditorContext *ctx, FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-void prev_file(EditorContext *ctx, FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 int show_settings_dialog(EditorContext*ctx,AppConfig*cfg){(void)ctx;(void)cfg;return 0;}
 void config_save(const AppConfig*cfg){(void)cfg;}
 void config_load(AppConfig*cfg){(void)cfg;}

--- a/tests/test_menu_switch.c
+++ b/tests/test_menu_switch.c
@@ -69,8 +69,8 @@ void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
-void next_file(EditorContext *ctx, FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
-void prev_file(EditorContext *ctx, FileState*fs,int*cx,int*cy){(void)fs;(void)cx;(void)cy;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 int show_settings_dialog(EditorContext*ctx,AppConfig*cfg){(void)ctx;(void)cfg;return 0;}
 void config_save(const AppConfig*cfg){(void)cfg;}
 void config_load(AppConfig*cfg){(void)cfg;}

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -77,8 +77,8 @@ void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;}
 void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;}
-void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_resize_allocfail.c
+++ b/tests/test_resize_allocfail.c
@@ -83,8 +83,8 @@ void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;}
 void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;}
-void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_resize_flushinp.c
+++ b/tests/test_resize_flushinp.c
@@ -92,8 +92,8 @@ void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;(void)ctx;}
 void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;(void)ctx;}
-void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)ctx;(void)fs;(void)x;(void)y;}
-void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)ctx;(void)fs;(void)x;(void)y;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -73,8 +73,8 @@ void handle_mouse_event(EditorContext*ctx,FileState*fs,MEVENT*ev){(void)ctx;(voi
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;}
 void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;}
-void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -73,8 +73,8 @@ void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;}
 void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;}
-void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_search_highlight.c
+++ b/tests/test_search_highlight.c
@@ -92,8 +92,8 @@ void end_selection_mode(FileState*fs){(void)fs;}
 void paste_clipboard(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void delete_current_line(EditorContext *ctx, FileState*fs){(void)fs;}
 void insert_new_line(EditorContext *ctx, FileState*fs){(void)fs;}
-void next_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
-void prev_file(EditorContext *ctx, FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
+CursorPos next_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
+CursorPos prev_file(EditorContext *ctx){(void)ctx;return (CursorPos){0,0};}
 void handle_redo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void handle_undo_wrapper(FileState*fs,int*x,int*y){(void)fs;(void)x;(void)y;}
 void move_forward_to_next_word(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}

--- a/tests/test_single_file_no_prompt.c
+++ b/tests/test_single_file_no_prompt.c
@@ -43,9 +43,8 @@ int main(void){
     ctx.active_file = active_file;
     ctx.text_win = text_win;
 
-    int cx = 0, cy = 0;
-    next_file(&ctx, active_file, &cx, &cy);
-    prev_file(&ctx, active_file, &cx, &cy);
+    (void)next_file(&ctx);
+    (void)prev_file(&ctx);
     active_file = ctx.active_file;
 
     assert(confirm_calls == 0);


### PR DESCRIPTION
## Summary
- refactor `next_file` and `prev_file` to return a `CursorPos`
- update editor wrappers and menu callbacks for new API
- adjust tests to use `CursorPos`
- extend `cursor_restore` test to ensure old file positions remain

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683dfe29152c8324870645a82ed8c940