### PR TITLE
Add status return from load_file and tests

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -81,7 +81,7 @@ void save_file_as(EditorContext *ctx, FileState *fs) {
     return;
 }
 
-void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
+int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     (void)fs_unused;
     char file_to_load[256];
     char canonical[PATH_MAX];
@@ -89,7 +89,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
 
     if (filename == NULL) {
         if (show_open_file_dialog(ctx, file_to_load, sizeof(file_to_load)) == 0) {
-            return; // user cancelled
+            return -1; // user cancelled
         }
         filename = file_to_load;
     }
@@ -111,7 +111,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
                 ctx->text_win = text_win;
             }
             update_status_bar(ctx, active_file);
-            return;
+            return 0;
         }
     }
 
@@ -138,7 +138,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         free_file_state(fs);
         active_file = previous_active;
         text_win = previous_active ? previous_active->text_win : NULL;
-        return;
+        return -1;
     }
     fs->file_complete = false;
     fs->buffer.count = 0;
@@ -151,7 +151,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         free_file_state(fs);
         active_file = previous_active;
         text_win = previous_active ? previous_active->text_win : NULL;
-        return;
+        return -1;
     }
     mvprintw(LINES - 2, 2, "File loaded: %s", filename_canon);
 
@@ -193,7 +193,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         free_file_state(fs);
         active_file = previous_active;
         text_win = previous_active ? previous_active->text_win : NULL;
-        return;
+        return -1;
     }
     fm_switch(&file_manager, idx);
     active_file = fm_current(&file_manager);
@@ -207,6 +207,7 @@ void load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     if (start_line > 0 && go_to_line)
         go_to_line(ctx, active_file, start_line);
     start_line = 0;    /* only apply once */
+    return 0;
 }
 
 void new_file(EditorContext *ctx, FileState *fs_unused) {

--- a/src/file_ops.h
+++ b/src/file_ops.h
@@ -6,8 +6,8 @@ struct EditorContext;
 #include <stdbool.h>
 void save_file(struct EditorContext *ctx, struct FileState *fs);
 void save_file_as(struct EditorContext *ctx, struct FileState *fs);
-void load_file(struct EditorContext *ctx, struct FileState *fs,
-               const char *filename);
+int load_file(struct EditorContext *ctx, struct FileState *fs,
+              const char *filename);
 void new_file(struct EditorContext *ctx, struct FileState *fs);
 void close_current_file(struct EditorContext *ctx, struct FileState *fs,
                         int *cx, int *cy);

--- a/src/vento.c
+++ b/src/vento.c
@@ -95,21 +95,22 @@ int main(int argc, char *argv[]) {
             continue;
         }
 
-        load_file(&editor, NULL, argv[i]);
-        if (first_index == -1) {
-            first_index = file_manager.active_index;
-        } else {
-            FileState *loaded = fm_current(&file_manager);
-            if (loaded && loaded->fp && !loaded->file_complete) {
-                loaded->file_pos = ftell(loaded->fp);
-                fclose(loaded->fp);
-                loaded->fp = NULL;
+        if (load_file(&editor, NULL, argv[i]) == 0) {
+            if (first_index == -1) {
+                first_index = file_manager.active_index;
+            } else {
+                FileState *loaded = fm_current(&file_manager);
+                if (loaded && loaded->fp && !loaded->file_complete) {
+                    loaded->file_pos = ftell(loaded->fp);
+                    fclose(loaded->fp);
+                    loaded->fp = NULL;
+                }
+                fm_switch(&file_manager, first_index);
+                sync_editor_context(&editor);
             }
-            fm_switch(&file_manager, first_index);
-            sync_editor_context(&editor);
-        }
 
-        file_count++;
+            file_count++;
+        }
     }
 
     if (file_count == 0) {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -238,6 +238,12 @@ gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_status_bar_count.c src/globals.c $CURSES_LIB -o test_status_bar_count
 ./test_status_bar_count
 
+# build and run nonexistent file argument test
+gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
+    tests/test_main_nonexistent.c src/file_ops.c src/file_manager.c \
+    src/globals.c obj_test/files.o obj_test/line_buffer.o $CURSES_LIB -o test_main_nonexistent
+./test_main_nonexistent
+
 # build and run select_int valid input test
 gcc -Wall -Wextra -std=c99 -g -D_POSIX_C_SOURCE=200809L -Isrc \
     tests/test_select_int_valid.c src/ui_settings.c \

--- a/tests/test_cli_line.c
+++ b/tests/test_cli_line.c
@@ -35,7 +35,7 @@ void drawBar(void){}
 
 static FileState dummy = {0};
 void go_to_line(EditorContext *ctx, FileState *fs, int line){(void)ctx;fs->cursor_y=line;}
-void load_file(EditorContext *ctx, FileState *unused, const char *filename){
+int load_file(EditorContext *ctx, FileState *unused, const char *filename){
     (void)ctx;(void)unused;
     strncpy(dummy.filename, filename, sizeof(dummy.filename)-1);
     dummy.buffer.count = 10;
@@ -43,6 +43,7 @@ void load_file(EditorContext *ctx, FileState *unused, const char *filename){
     dummy.cursor_y = 1;
     active_file = &dummy;
     if(start_line>0) go_to_line(ctx, active_file, start_line);
+    return 0;
 }
 
 #define main vento_main

--- a/tests/test_cli_theme.c
+++ b/tests/test_cli_theme.c
@@ -22,7 +22,7 @@ bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
-void load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void new_file(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}

--- a/tests/test_cli_version.c
+++ b/tests/test_cli_version.c
@@ -25,7 +25,7 @@ bool any_file_modified(FileManager *fm){(void)fm;return false;}
 int show_message(const char*msg){(void)msg;return 0;}
 void initialize(EditorContext *ctx){(void)ctx;}
 void fm_init(FileManager *fm){(void)fm;}
-void load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext *ctx,FileState *fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void new_file(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 FileState* fm_current(FileManager *fm){(void)fm;return NULL;}
 int fm_switch(FileManager *fm,int idx){(void)fm;(void)idx;return 0;}

--- a/tests/test_confirm_quit.c
+++ b/tests/test_confirm_quit.c
@@ -47,7 +47,7 @@ void update_status_bar(EditorContext *ctx, FileState*fs){(void)fs;}
 bool drawMenu(Menu*menu,int ci,int sx,int sy){(void)menu;(void)ci;(void)sx;(void)sy;return true;}
 void drawMenuBar(Menu*m,int mc){(void)m;(void)mc;}
 void new_file(EditorContext *ctx, FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}

--- a/tests/test_main_multifile.c
+++ b/tests/test_main_multifile.c
@@ -39,7 +39,7 @@ void drawBar(void){}
 void update_status_bar(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
 
 /* simplified file loader used by main */
-void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){
+int load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){
     (void)ctx;
     (void)fs_unused;
     FileState *fs = calloc(1, sizeof(FileState));
@@ -48,6 +48,7 @@ void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){
     int idx = fm_add(&file_manager, fs);
     fm_switch(&file_manager, idx);
     active_file = fm_current(&file_manager);
+    return 0;
 }
 
 void new_file(EditorContext *ctx, FileState *fs_unused){

--- a/tests/test_main_nonexistent.c
+++ b/tests/test_main_nonexistent.c
@@ -1,0 +1,68 @@
+#include <assert.h>
+#include <string.h>
+#include <ncurses.h>
+#include "file_manager.h"
+#include "file_ops.h"
+#include "editor.h"
+#include "editor_state.h"
+#include "ui.h"
+#include "ui_common.h"
+#include "config.h"
+
+int COLS = 80;
+int LINES = 24;
+WINDOW *text_win = NULL;
+WINDOW *stdscr = NULL;
+FileState *active_file = NULL;
+FileManager file_manager;
+AppConfig app_config;
+int start_line = 0;
+int enable_mouse = 0;
+int enable_color = 0;
+
+int mvprintw(int y,int x,const char*fmt,...){(void)y;(void)x;(void)fmt;return 0;}
+int clrtoeol(void){return 0;}
+int refresh(void){return 0;}
+int getch(void){return 0;}
+void box(WINDOW*w,int a,int b){(void)w;(void)a;(void)b;}
+void wmove(WINDOW*w,int y,int x){(void)w;(void)y;(void)x;}
+void wrefresh(WINDOW*w){(void)w;}
+int timeout(int t){(void)t;return 0;}
+int werase(WINDOW*w){(void)w;return 0;}
+int wnoutrefresh(WINDOW*w){(void)w;return 0;}
+int napms(int n){(void)n;return 0;}
+void draw_text_buffer(FileState *fs, WINDOW *w){(void)fs;(void)w;}
+void redraw(void){}
+void clamp_scroll_x(FileState *fs){(void)fs;}
+void mark_comment_state_dirty(FileState *fs){(void)fs;}
+int ensure_line_capacity(FileState *fs,int n){(void)fs;(void)n;return 0;}
+void push(Node **stack, Change ch){(void)stack; free(ch.old_text); free(ch.new_text);}
+void redo(FileState *fs){(void)fs;}
+void undo(FileState *fs){(void)fs;}
+bool any_file_modified(FileManager *fm){(void)fm;return false;}
+int show_message(const char *msg){(void)msg;return 'y';}
+int show_open_file_dialog(EditorContext *ctx,char*p,int m){(void)ctx;(void)p;(void)m;return 0;}
+int show_save_file_dialog(EditorContext *ctx,char*p,int m){(void)ctx;(void)p;(void)m;return 0;}
+void update_status_bar(EditorContext *ctx, FileState *fs){(void)ctx;(void)fs;}
+int get_line_number_offset(FileState *fs){(void)fs;return 0;}
+void allocation_failed(const char *msg){(void)msg;abort();}
+void drawBar(void){}
+void show_warning_dialog(EditorContext*ctx){(void)ctx;}
+void run_editor(EditorContext *ctx){(void)ctx;}
+int endwin(void){return 0;}
+void cleanup_on_exit(FileManager *fm){(void)fm;}
+void initialize(EditorContext *ctx){(void)ctx;}
+
+#define main vento_main
+#include "../src/vento.c"
+#undef main
+
+int main(void){
+    char *argv[] = {"vento", "missing1.txt", "missing2.txt"};
+    vento_main(3, argv);
+    assert(file_manager.count == 1);
+    assert(file_manager.files[0]->filename[0] == '\0');
+    free_file_state(file_manager.files[0]);
+    free(file_manager.files);
+    return 0;
+}

--- a/tests/test_menu_no_clear.c
+++ b/tests/test_menu_no_clear.c
@@ -65,7 +65,7 @@ int touchwin(WINDOW*w){(void)w;return 0;}
 
 /* stubs for external editor functions referenced in menu.c */
 void new_file(EditorContext *ctx, FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}

--- a/tests/test_menu_switch.c
+++ b/tests/test_menu_switch.c
@@ -65,7 +65,7 @@ int touchwin(WINDOW*w){if(w==text_win)touch_calls++;return 0;}
 
 /* stubs for external editor functions referenced in menu.c */
 void new_file(EditorContext *ctx, FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}

--- a/tests/test_resize.c
+++ b/tests/test_resize.c
@@ -93,7 +93,7 @@ void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;
 void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}

--- a/tests/test_resize_allocfail.c
+++ b/tests/test_resize_allocfail.c
@@ -99,7 +99,7 @@ void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;
 void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}

--- a/tests/test_resize_flushinp.c
+++ b/tests/test_resize_flushinp.c
@@ -108,7 +108,7 @@ void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;
 void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}

--- a/tests/test_resize_signal.c
+++ b/tests/test_resize_signal.c
@@ -87,7 +87,7 @@ void find(EditorContext*ctx,FileState*fs,int n){(void)ctx;(void)fs;(void)n;}
 void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}
 void menuLoadFile(EditorContext*ctx){(void)ctx;}

--- a/tests/test_resize_trunc.c
+++ b/tests/test_resize_trunc.c
@@ -89,7 +89,7 @@ void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;
 void replace(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y; return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}

--- a/tests/test_search_highlight.c
+++ b/tests/test_search_highlight.c
@@ -104,7 +104,7 @@ void handleMenuNavigation(Menu*m,int mc,int*cm,int*ci){(void)m;(void)mc;(void)cm
 void handle_selection_mode(FileState*fs,int ch,int*cx,int*cy){(void)fs;(void)ch;(void)cx;(void)cy;}
 void save_file(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
 void save_file_as(EditorContext*ctx,FileState*fs){(void)ctx;(void)fs;}
-void load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;}
+int load_file(EditorContext*ctx,FileState*fs,const char*fn){(void)ctx;(void)fs;(void)fn;return 0;}
 void close_current_file(EditorContext*ctx,FileState*fs,int*cx,int*cy){(void)ctx;(void)fs;(void)cx;(void)cy;}
 int menu_click_open(int x,int y){(void)x;(void)y;return 0;}
 void menuNewFile(EditorContext*ctx){(void)ctx;}

--- a/tests/test_status_bar_count.c
+++ b/tests/test_status_bar_count.c
@@ -37,7 +37,7 @@ void drawBar(void){}
 static int s_idx=0, s_total=0;
 void update_status_bar(EditorContext *ctx, FileState *fs){(void)fs; s_idx = ctx->file_manager.active_index + 1; s_total = ctx->file_manager.count;}
 
-void load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){(void)ctx;(void)fs_unused;FileState *fs=calloc(1,sizeof(FileState));assert(fs);strncpy(fs->filename,filename,sizeof(fs->filename)-1);int idx=fm_add(&file_manager,fs);fm_switch(&file_manager,idx);active_file=fm_current(&file_manager);} 
+int load_file(EditorContext *ctx,FileState *fs_unused,const char *filename){(void)ctx;(void)fs_unused;FileState *fs=calloc(1,sizeof(FileState));assert(fs);strncpy(fs->filename,filename,sizeof(fs->filename)-1);int idx=fm_add(&file_manager,fs);fm_switch(&file_manager,idx);active_file=fm_current(&file_manager);return 0;}
 void new_file(EditorContext *ctx, FileState *fs_unused){(void)ctx;(void)fs_unused;FileState *fs=calloc(1,sizeof(FileState));assert(fs);int idx=fm_add(&file_manager,fs);fm_switch(&file_manager,idx);active_file=fm_current(&file_manager);} 
 
 #define main vento_main


### PR DESCRIPTION
## Summary
- return int status from `load_file`
- only count successfully loaded files in `main`
- adjust tests for new function signature
- add test for nonexistent files on the command line

## Testing
- `./tests/run_tests.sh` *(fails: ensure_col_capacity failed)*

------
https://chatgpt.com/codex/tasks/task_e_683e02846ea88324aafe9924d9261c51