### PR TITLE
Handle fm_switch failure

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -103,7 +103,24 @@ CursorPos next_file(EditorContext *ctx) {
     }
     int idx = file_manager.active_index + 1;
     if (idx >= file_manager.count) idx = 0;
-    fm_switch(&file_manager, idx);
+    int res = fm_switch(&file_manager, idx);
+    if (res < 0) {
+        if (cur && !cur->fp && !cur->file_complete) {
+            cur->fp = fopen(cur->filename, "r");
+            if (cur->fp)
+                fseek(cur->fp, cur->file_pos, SEEK_SET);
+        }
+        active_file = cur;
+        text_win = cur ? cur->text_win : NULL;
+        if (active_file) {
+            pos.x = active_file->cursor_x;
+            pos.y = active_file->cursor_y;
+        }
+        sync_editor_context(ctx);
+        redraw();
+        update_status_bar(ctx, active_file);
+        return pos;
+    }
     active_file = fm_current(&file_manager);
     if (active_file) {
         active_file->cursor_x = active_file->saved_cursor_x;
@@ -140,7 +157,24 @@ CursorPos prev_file(EditorContext *ctx) {
     }
     int idx = file_manager.active_index - 1;
     if (idx < 0) idx = file_manager.count - 1;
-    fm_switch(&file_manager, idx);
+    int res = fm_switch(&file_manager, idx);
+    if (res < 0) {
+        if (cur && !cur->fp && !cur->file_complete) {
+            cur->fp = fopen(cur->filename, "r");
+            if (cur->fp)
+                fseek(cur->fp, cur->file_pos, SEEK_SET);
+        }
+        active_file = cur;
+        text_win = cur ? cur->text_win : NULL;
+        if (active_file) {
+            pos.x = active_file->cursor_x;
+            pos.y = active_file->cursor_y;
+        }
+        sync_editor_context(ctx);
+        redraw();
+        update_status_bar(ctx, active_file);
+        return pos;
+    }
     active_file = fm_current(&file_manager);
     if (active_file) {
         active_file->cursor_x = active_file->saved_cursor_x;

--- a/tests/minunit.h
+++ b/tests/minunit.h
@@ -1,0 +1,7 @@
+#ifndef MINUNIT_H
+#define MINUNIT_H
+#include <stdio.h>
+extern int tests_run;
+#define mu_assert(message, test) do { if (!(test)) return message; } while (0)
+#define mu_run_test(test) do { char *msg = test(); tests_run++; if (msg) return msg; } while (0)
+#endif

--- a/tests/navigation_tests.c
+++ b/tests/navigation_tests.c
@@ -1,0 +1,45 @@
+#include "minunit.h"
+#include "editor.h"
+#include "file_manager.h"
+#include <stdio.h>
+
+int tests_run = 0;
+
+int __wrap_fm_switch(FileManager *fm, int index) {
+    (void)fm; (void)index; fprintf(stderr, "fm_switch called\n"); return -1; }
+
+static char *test_next_file_switch_failure() {
+    fprintf(stderr, "test start\n");
+    fm_init(&file_manager);
+    FileState a = {0};
+    FileState b = {0};
+    a.cursor_x = 5; a.cursor_y = 6;
+    fm_add(&file_manager, &a);
+    fm_add(&file_manager, &b);
+    file_manager.active_index = 0;
+    active_file = &a;
+
+    CursorPos pos = next_file(NULL);
+    fprintf(stderr, "after next_file\n");
+    mu_assert("index unchanged", file_manager.active_index == 0);
+    mu_assert("pointer unchanged", active_file == &a);
+    mu_assert("pos.x unchanged", pos.x == a.cursor_x);
+    mu_assert("pos.y unchanged", pos.y == a.cursor_y);
+    return 0;
+}
+
+static char * all_tests() {
+    mu_run_test(test_next_file_switch_failure);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+DIR="$(dirname "$0")"
+cd "$DIR"
+mkdir -p obj_test
+SRC="../src"
+for f in $SRC/*.c; do bn=$(basename "$f"); if [ "$bn" != "vento.c" ] && [ "$bn" != "file_ops.c" ]; then gcc -c "$f" -o obj_test/$(basename "$f" .c).o -I$SRC -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra; fi; done
+ar rcs obj_test/libvento.a obj_test/*.o
+gcc -c test_stubs.c -I$SRC -o obj_test/test_stubs.o
+gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw -o navigation_tests
+./navigation_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -1,0 +1,16 @@
+#include "editor.h"
+#include "file_manager.h"
+#include <stdbool.h>
+#include <stdio.h>
+
+FileManager file_manager;
+FileState *active_file = NULL;
+WINDOW *text_win = NULL;
+
+bool confirm_switch(void) { return true; }
+void clamp_scroll_x(FileState *fs) { (void)fs; }
+void redraw(void) {}
+bool confirm_quit(void) { return true; }
+void allocation_failed(const char *msg) { fprintf(stderr, "alloc fail: %s\n", msg ? msg : ""); }
+void draw_text_buffer(FileState *fs, WINDOW *win) { (void)fs; (void)win; }
+void __wrap_update_status_bar(EditorContext *ctx, FileState *fs) { fprintf(stderr, "update_status_bar called\n"); (void)ctx; (void)fs; }


### PR DESCRIPTION
## Summary
- protect next_file and prev_file when fm_switch fails
- add simple minunit harness and failing navigation test stub
- shell script compiles and runs new tests

## Testing
- `sh tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e0d2797e083248498ac37d7195249