### PR TITLE
Fix status bar sync when creating a new file

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -265,9 +265,9 @@ void new_file(EditorContext *ctx, FileState *fs_unused) {
           fs->cursor_x + get_line_number_offset(fs));
     wrefresh(text_win);
 
-    update_status_bar(ctx, active_file);
     if (ctx)
         sync_editor_context(ctx);
+    update_status_bar(ctx, active_file);
 }
 
 void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *cy) {


### PR DESCRIPTION
## Summary
- update context before drawing the status bar in `new_file`

## Testing
- `make`
- `make test` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e116339a08324af128798adfb5ccf