### PR TITLE
Handle initial empty buffer on load

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -200,6 +200,15 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         sync_editor_context(ctx);
         return -1;
     }
+
+    if (file_manager.count > 1) {
+        FileState *first = file_manager.files[0];
+        if (first && first->filename[0] == '\0' && !first->modified) {
+            fm_close(&file_manager, 0);
+            idx = file_manager.active_index;
+        }
+    }
+
     fm_switch(&file_manager, idx);
     active_file = fm_current(&file_manager);
 

--- a/tests/navigation_tests.c
+++ b/tests/navigation_tests.c
@@ -28,8 +28,24 @@ static char *test_next_file_switch_failure() {
     return 0;
 }
 
+static char *test_two_file_cycle() {
+    fm_init(&file_manager);
+    FileState a = {0};
+    FileState b = {0};
+    fm_add(&file_manager, &a);
+    fm_add(&file_manager, &b);
+    file_manager.active_index = 0;
+    mu_assert("two files loaded", file_manager.count == 2);
+    fm_switch(&file_manager, (file_manager.active_index + 1) % file_manager.count);
+    mu_assert("switch to second", file_manager.active_index == 1);
+    fm_switch(&file_manager, (file_manager.active_index + 1) % file_manager.count);
+    mu_assert("cycle back to first", file_manager.active_index == 0);
+    return 0;
+}
+
 static char * all_tests() {
     mu_run_test(test_next_file_switch_failure);
+    mu_run_test(test_two_file_cycle);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- remove empty placeholder buffer when loading a real file
- cover navigation with a simple cycling test

## Testing
- `./tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e12c8022c8324a76a18a8322c3b92