### PR TITLE
Add canonical path handling and duplicate file test

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -53,8 +53,7 @@ void save_file_as(EditorContext *ctx, FileState *fs) {
     char newpath[256];
     if (!show_save_file_dialog(ctx, newpath, sizeof(newpath)))
         return;    // user cancelled
-    strncpy(fs->filename, newpath, sizeof(fs->filename) - 1);
-    fs->filename[sizeof(fs->filename) - 1] = '\0';
+    canonicalize_path(newpath, fs->filename, sizeof(fs->filename));
 
     load_all_remaining_lines(fs);
 
@@ -96,8 +95,10 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     }
 
     const char *filename_canon = filename;
-    if (filename && realpath(filename, canonical))
+    if (filename) {
+        canonicalize_path(filename, canonical, sizeof(canonical));
         filename_canon = canonical;
+    }
 
     /* If the file is already open, just switch to it */
     for (int i = 0; i < file_manager.count; i++) {
@@ -125,8 +126,7 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     active_file = fs;
 
     fs->syntax_mode = set_syntax_mode(filename_canon);
-    strncpy(fs->filename, filename_canon, sizeof(fs->filename) - 1);
-    fs->filename[sizeof(fs->filename) - 1] = '\0';
+    canonicalize_path(filename_canon, fs->filename, sizeof(fs->filename));
 
 
     fs->fp = fopen(filename_canon, "r");
@@ -164,8 +164,7 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     fs->last_comment_state = false;
     fs->modified = false;
 
-    strncpy(fs->filename, filename_canon, sizeof(fs->filename) - 1);
-    fs->filename[sizeof(fs->filename) - 1] = '\0';
+    canonicalize_path(filename_canon, fs->filename, sizeof(fs->filename));
 
     refresh();
 

--- a/src/files.h
+++ b/src/files.h
@@ -4,6 +4,7 @@
 #include <ncurses.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stddef.h>
 #include "editor.h"
 #include "line_buffer.h"
 
@@ -47,5 +48,6 @@ int ensure_col_capacity(FileState *fs, int cols);
 int load_next_lines(FileState *fs, int count);
 void ensure_line_loaded(FileState *fs, int idx);
 void load_all_remaining_lines(FileState *fs);
+void canonicalize_path(const char *path, char *out, size_t out_size);
 
 #endif

--- a/tests/navigation_tests.c
+++ b/tests/navigation_tests.c
@@ -1,6 +1,8 @@
 #include "minunit.h"
 #include "editor.h"
 #include "file_manager.h"
+#include "file_ops.h"
+#include <ncurses.h>
 #include <stdio.h>
 
 int tests_run = 0;
@@ -43,9 +45,25 @@ static char *test_two_file_cycle() {
     return 0;
 }
 
+static char *test_duplicate_open_same_file() {
+    initscr();
+    fm_init(&file_manager);
+    int res = load_file(NULL, NULL, "../README.md");
+    mu_assert("first load", res == 0);
+    mu_assert("one file after first", file_manager.count == 1);
+    FileState *first = file_manager.files[0];
+    res = load_file(NULL, NULL, ".././README.md");
+    mu_assert("still one file", file_manager.count == 1);
+    mu_assert("same pointer", file_manager.files[0] == first);
+    fm_close(&file_manager, 0);
+    endwin();
+    return 0;
+}
+
 static char * all_tests() {
     mu_run_test(test_next_file_switch_failure);
     mu_run_test(test_two_file_cycle);
+    mu_run_test(test_duplicate_open_same_file);
     return 0;
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,8 +4,8 @@ DIR="$(dirname "$0")"
 cd "$DIR"
 mkdir -p obj_test
 SRC="../src"
-for f in $SRC/*.c; do bn=$(basename "$f"); if [ "$bn" != "vento.c" ] && [ "$bn" != "file_ops.c" ]; then gcc -c "$f" -o obj_test/$(basename "$f" .c).o -I$SRC -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra; fi; done
+for f in $SRC/*.c; do bn=$(basename "$f"); if [ "$bn" != "vento.c" ]; then gcc -c "$f" -o obj_test/$(basename "$f" .c).o -I$SRC -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra; fi; done
 ar rcs obj_test/libvento.a obj_test/*.o
 gcc -c test_stubs.c -I$SRC -o obj_test/test_stubs.o
-gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw -o navigation_tests
+gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw -Wl,--wrap=fm_switch -Wl,--wrap=update_status_bar -Wl,--wrap=confirm_switch -o navigation_tests
 ./navigation_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -7,7 +7,7 @@ FileManager file_manager;
 FileState *active_file = NULL;
 WINDOW *text_win = NULL;
 
-bool confirm_switch(void) { return true; }
+bool __wrap_confirm_switch(void) { return true; }
 void clamp_scroll_x(FileState *fs) { (void)fs; }
 void redraw(void) {}
 bool confirm_quit(void) { return true; }


### PR DESCRIPTION
## Summary
- canonicalize file paths via `realpath` in `FileState`
- ensure canonical paths when saving and loading files
- exercise duplicate-file handling in unit tests
- adjust test infrastructure to compile with wrappers

## Testing
- `tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e145b56648324bba91bfbdfd310c0