### PR TITLE
Handle fm_switch failures in navigation

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -101,10 +101,12 @@ CursorPos next_file(EditorContext *ctx) {
             cur->fp = NULL;
         }
     }
+    int prev_index = file_manager.active_index;
     int idx = file_manager.active_index + 1;
     if (idx >= file_manager.count) idx = 0;
     int res = fm_switch(&file_manager, idx);
     if (res < 0) {
+        file_manager.active_index = prev_index;
         if (cur && !cur->fp && !cur->file_complete) {
             cur->fp = fopen(cur->filename, "r");
             if (cur->fp)
@@ -155,10 +157,12 @@ CursorPos prev_file(EditorContext *ctx) {
             cur->fp = NULL;
         }
     }
+    int prev_index = file_manager.active_index;
     int idx = file_manager.active_index - 1;
     if (idx < 0) idx = file_manager.count - 1;
     int res = fm_switch(&file_manager, idx);
     if (res < 0) {
+        file_manager.active_index = prev_index;
         if (cur && !cur->fp && !cur->file_complete) {
             cur->fp = fopen(cur->filename, "r");
             if (cur->fp)

--- a/tests/navigation_tests.c
+++ b/tests/navigation_tests.c
@@ -34,6 +34,27 @@ static char *test_next_file_switch_failure() {
     return 0;
 }
 
+static char *test_prev_file_switch_failure() {
+    fm_init(&file_manager);
+    FileState a = {0};
+    FileState b = {0};
+    b.cursor_x = 3; b.cursor_y = 4;
+    fm_add(&file_manager, &a);
+    fm_add(&file_manager, &b);
+    file_manager.active_index = 1;
+    active_file = &b;
+
+    fm_switch_fail = 1;
+    CursorPos pos = prev_file(NULL);
+    fm_switch_fail = 0;
+
+    mu_assert("index unchanged", file_manager.active_index == 1);
+    mu_assert("pointer unchanged", active_file == &b);
+    mu_assert("pos.x unchanged", pos.x == b.cursor_x);
+    mu_assert("pos.y unchanged", pos.y == b.cursor_y);
+    return 0;
+}
+
 static char *test_two_file_cycle() {
     fm_init(&file_manager);
     FileState a = {0};
@@ -116,6 +137,7 @@ static char *test_new_file_switch_failure() {
 
 static char * all_tests() {
     mu_run_test(test_next_file_switch_failure);
+    mu_run_test(test_prev_file_switch_failure);
     mu_run_test(test_two_file_cycle);
     mu_run_test(test_duplicate_open_same_file);
     mu_run_test(test_new_file_add_failure);


### PR DESCRIPTION
## Summary
- handle fm_switch failure in `next_file`/`prev_file`
- test prev_file switch failure like next_file

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e1ca040c083249cdf8da96f0f5da8