### PR TITLE
Update context sync after fm_close

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -204,6 +204,7 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
         FileState *first = file_manager.files[0];
         if (first && first->filename[0] == '\0' && !first->modified) {
             fm_close(&file_manager, 0);
+            sync_editor_context(ctx);
             idx = file_manager.active_index;
         }
     }
@@ -307,6 +308,7 @@ void close_current_file(EditorContext *ctx, FileState *fs_unused, int *cx, int *
         }
     }
     fm_close(&file_manager, file_manager.active_index);
+    sync_editor_context(ctx);
 
     if (file_manager.count > 0) {
         active_file = fm_current(&file_manager);


### PR DESCRIPTION
## Summary
- call `sync_editor_context` immediately after closing files
- keep status bar updates after context synchronization

## Testing
- `tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e1e15d94c83249a1f4ec1fbb07cf1