### PR TITLE
Update status bar context sync

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -227,6 +227,7 @@ CursorPos prev_file(EditorContext *ctx) {
 }
 
 void update_status_bar(EditorContext *ctx, FileState *fs) {
+    sync_editor_context(ctx);
     move(0, 0);
     int idx = ctx->file_manager.active_index + 1;
     int total = ctx->file_manager.count > 0 ? ctx->file_manager.count : 1;

--- a/tests/navigation_tests.c
+++ b/tests/navigation_tests.c
@@ -11,6 +11,7 @@ int tests_run = 0;
 
 extern int fm_switch_fail;
 extern int fm_add_fail;
+extern int last_status_count;
 
 static char *test_next_file_switch_failure() {
     fprintf(stderr, "test start\n");
@@ -174,6 +175,27 @@ static char *test_untitled_ignored_in_cycle() {
     return 0;
 }
 
+static char *test_status_bar_sync_on_load() {
+    initscr();
+    fm_init(&file_manager);
+    EditorContext ctx = {0};
+    sync_editor_context(&ctx);
+
+    int res = load_file(&ctx, NULL, "../README.md");
+    mu_assert("first load", res == 0);
+    mu_assert("status count after first", last_status_count == 1);
+
+    res = load_file(&ctx, NULL, "../LICENSE");
+    mu_assert("second load", res == 0);
+    mu_assert("status count after second", last_status_count == 2);
+
+    for (int i = file_manager.count - 1; i >= 0; i--) {
+        fm_close(&file_manager, i);
+    }
+    endwin();
+    return 0;
+}
+
 static char * all_tests() {
     mu_run_test(test_next_file_switch_failure);
     mu_run_test(test_prev_file_switch_failure);
@@ -182,6 +204,7 @@ static char * all_tests() {
     mu_run_test(test_new_file_add_failure);
     mu_run_test(test_new_file_switch_failure);
     mu_run_test(test_untitled_ignored_in_cycle);
+    mu_run_test(test_status_bar_sync_on_load);
     return 0;
 }
 

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -1,5 +1,6 @@
 #include "editor.h"
 #include "file_manager.h"
+#include "editor_state.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,7 +19,12 @@ void redraw(void) {}
 bool confirm_quit(void) { return true; }
 void allocation_failed(const char *msg) { fprintf(stderr, "alloc fail: %s\n", msg ? msg : ""); }
 void draw_text_buffer(FileState *fs, WINDOW *win) { (void)fs; (void)win; }
-void __wrap_update_status_bar(EditorContext *ctx, FileState *fs) { fprintf(stderr, "update_status_bar called\n"); (void)ctx; (void)fs; }
+int last_status_count = -1;
+void __wrap_update_status_bar(EditorContext *ctx, FileState *fs) {
+    last_status_count = ctx ? ctx->file_manager.count : -1;
+    fprintf(stderr, "update_status_bar called\n");
+    (void)fs;
+}
 
 int __wrap_fm_switch(FileManager *fm, int index) {
     if (fm_switch_fail)


### PR DESCRIPTION
## Summary
- sync editor context at start of `update_status_bar`
- track last status bar count in tests
- add regression test for automatic status bar updates

## Testing
- `./tests/run_tests.sh` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e253cfe9083248581e279a4216a3d