### PR TITLE
Fix menu context after loading files

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -275,6 +275,8 @@ void menuLoadFile(EditorContext *ctx) {
     load_file(ctx, ctx->active_file, NULL);
     ctx->active_file = active_file;
     ctx->text_win = text_win;
+    sync_editor_context(ctx);
+    update_status_bar(ctx, ctx->active_file);
 }
 
 void menuSaveFile(EditorContext *ctx) {


### PR DESCRIPTION
## Summary
- refresh menu context after loading a file

## Testing
- `tests/run_tests.sh` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e398c18e48324929f906b1ecf8a8a