### PR TITLE
Call sync_editor_context after load updates

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -117,6 +117,7 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
                 ctx->file_manager = file_manager;
                 ctx->active_file = active_file;
                 ctx->text_win = text_win;
+                sync_editor_context(ctx);
             }
             update_status_bar(ctx, active_file);
             sync_editor_context(ctx);
@@ -227,12 +228,14 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     ctx->file_manager = file_manager;
     ctx->active_file = active_file;
     ctx->text_win = text_win;
+    sync_editor_context(ctx);
 
     update_status_bar(ctx, active_file);
     extern int start_line;
     if (start_line > 0 && go_to_line)
         go_to_line(ctx, active_file, start_line);
     start_line = 0;    /* only apply once */
+    sync_editor_context(ctx);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- sync editor context whenever `ctx->file_manager` is updated in `load_file`
- ensure context synced again before returning

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e48f3f618832498cbbc660e7a0f5f