### PR TITLE
Add regression test for menu-based file loading

### DIFF
--- a/tests/menu_load_tests.c
+++ b/tests/menu_load_tests.c
@@ -1,0 +1,65 @@
+#include "minunit.h"
+#include "editor.h"
+#include "file_manager.h"
+#include "file_ops.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <stdio.h>
+
+extern int last_status_count;
+
+int tests_run = 0;
+
+static char *test_menu_load_and_navigation() {
+    initscr();
+    fm_init(&file_manager);
+    EditorContext ctx = {0};
+
+    int res = load_file(NULL, NULL, "../README.md");
+    mu_assert("first load", res == 0);
+    sync_editor_context(&ctx);
+    update_status_bar(&ctx, active_file);
+    mu_assert("status after first", last_status_count == 1);
+    FileState *first = active_file;
+
+    res = load_file(NULL, NULL, "../LICENSE");
+    mu_assert("second load", res == 0);
+    sync_editor_context(&ctx);
+    update_status_bar(&ctx, active_file);
+    mu_assert("status after second", last_status_count == 2);
+    FileState *second = active_file;
+
+    mu_assert("two files", file_manager.count == 2);
+
+    next_file(&ctx);
+    mu_assert("next index", file_manager.active_index == 0);
+    mu_assert("next pointer", active_file == first);
+    mu_assert("status after next", last_status_count == 2);
+
+    prev_file(&ctx);
+    mu_assert("prev index", file_manager.active_index == 1);
+    mu_assert("prev pointer", active_file == second);
+    mu_assert("status after prev", last_status_count == 2);
+
+    for (int i = file_manager.count - 1; i >= 0; i--) {
+        fm_close(&file_manager, i);
+    }
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_menu_load_and_navigation);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -11,3 +11,7 @@ gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurses
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar -Wl,--wrap=confirm_switch \
     -o navigation_tests
 ./navigation_tests
+gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar -Wl,--wrap=confirm_switch \
+    -o menu_load_tests
+./menu_load_tests


### PR DESCRIPTION
## Summary
- add a new regression test `menu_load_tests.c`
- extend `run_tests.sh` to compile and run the new test

## Testing
- `./tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e4a8bf3448324a8ca344089d5173a