### PR TITLE
Fix theme path building

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -80,7 +80,7 @@ void load_theme(const char *name, AppConfig *cfg) {
                 continue;
             size_t len = dot - ent->d_name;
             if (len == strlen(name) && strncasecmp(ent->d_name, name, len) == 0) {
-                snprintf(path, sizeof(path), "%s/%.*s", dirs[i], (int)len, ent->d_name);
+                snprintf(path, sizeof(path), "%s/%s", dirs[i], ent->d_name);
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- fix theme path construction to include `.theme` when loading

## Testing
- `./tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e4f354a6083248b5cdd126f2d047e