### PR TITLE
Update mousemask after settings dialog

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -162,7 +162,6 @@ int show_settings_dialog(EditorContext *ctx, AppConfig *cfg) {
     curs_set(0);
     AppConfig original = *cfg;
 
-    mmask_t oldmask = mousemask(0, NULL);
     mousemask(ALL_MOUSE_EVENTS | REPORT_MOUSE_POSITION, NULL);
 
     int highlight = 0;
@@ -257,7 +256,7 @@ int show_settings_dialog(EditorContext *ctx, AppConfig *cfg) {
         }
     }
 
-    mousemask(oldmask, NULL);
+    apply_mouse(cfg);
 
     wclear(win);
     wrefresh(win);


### PR DESCRIPTION
## Summary
- follow config when restoring mousemask after editing options

## Testing
- `make`
- `make test` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e50666fc48324bedc11615a9c7bca