### PR TITLE
Handle KEY_RESIZE during menu navigation

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -172,6 +172,18 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
                        menus[*currentMenu].items[*currentItem].separator)
                     (*currentItem)++; // Skip separators
                 break;
+            case KEY_RESIZE:
+                resizeterm(0, 0);
+                drawMenuBar(menus, menuCount);
+                wnoutrefresh(stdscr);
+                doupdate();
+                if (!drawMenu(&menus[*currentMenu], *currentItem,
+                               menuPositions[*currentMenu], 1)) {
+                    inMenu = false;
+                }
+                wnoutrefresh(stdscr);
+                doupdate();
+                break;
             case KEY_MOUSE: {
                 if (!enable_mouse)
                     break;


### PR DESCRIPTION
## Summary
- keep the menu usable after terminal resizes
- redraw menu bar and active menu when `KEY_RESIZE` occurs

## Testing
- `make`
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e5c21b37083249b9ca12e38da25d7