### PR TITLE
Fix cursor restoration in select_theme

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -511,6 +511,7 @@ const char *select_theme(const char *current, WINDOW *parent) {
                     for (size_t i = 0; i < count; ++i)
                         free(names[i]);
                     free(names);
+                    curs_set(1);
                     return NULL;
                 }
                 names = tmp;
@@ -520,6 +521,7 @@ const char *select_theme(const char *current, WINDOW *parent) {
                     for (size_t i = 0; i < count; ++i)
                         free(names[i]);
                     free(names);
+                    curs_set(1);
                     return NULL;
                 }
                 ++count;
@@ -530,6 +532,7 @@ const char *select_theme(const char *current, WINDOW *parent) {
 
     if (count == 0) {
         free(names);
+        curs_set(1);
         return NULL;
     }
 


### PR DESCRIPTION
## Summary
- ensure cursor is reset before each NULL return in `select_theme`
- add cursor restore after zero-theme case

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e5d05a4108324bdd726861fd4deaa