### PR TITLE
Fix goto line input validation

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -90,6 +90,13 @@ int show_goto_dialog(EditorContext *ctx, int *line_number) {
         return 0;
     }
 
-    *line_number = atoi(buf);
+    char *endptr;
+    long val = strtol(buf, &endptr, 10);
+
+    if (*endptr != '\0' || val < 1) {
+        return 0;
+    }
+
+    *line_number = (int)val;
     return 1;
 }


### PR DESCRIPTION
## Summary
- improve input validation in goto dialog

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e5d74e84c832499fbf7df86ca0c6a