### PR TITLE
Add macro recording framework

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -30,6 +30,7 @@
 #include "search.h"
 #include "file_manager.h"
 #include "editor_state.h"
+#include "macro.h"
 
 __attribute__((weak)) void copy_selection_keyboard(FileState *fs) {
     (void)fs;
@@ -62,6 +63,7 @@ char search_text[256] = "";
 
 volatile sig_atomic_t resize_pending = 0;
 static EditorContext *input_ctx = NULL;
+Macro macro_state;
 
 void clamp_scroll_x(FileState *fs) {
     int offset = get_line_number_offset(fs);
@@ -472,6 +474,11 @@ void run_editor(EditorContext *ctx) {
 
         if (rc == ERR) {
             continue; // Handle any errors or no input case
+        }
+
+        if (macro_state.recording &&
+            ch != KEY_CTRL_BACKTICK && ch != KEY_CTRL_Q) {
+            macro_record_key(&macro_state, ch);
         }
 
         if (exiting == 1) {

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -11,6 +11,7 @@
 #include "files.h"
 #include "syntax.h"
 #include "editor_state.h"
+#include "macro.h"
 
 void disable_ctrl_c_z() {
     signal(SIGINT, SIG_IGN);
@@ -36,6 +37,8 @@ void initialize(EditorContext *ctx) {
     ctx->enable_color = enable_color;
     ctx->enable_mouse = enable_mouse;
     apply_colors();
+    macro_state.length = 0;
+    macro_state.recording = false;
     cbreak();
     noecho();
     keypad(stdscr, TRUE);

--- a/src/macro.h
+++ b/src/macro.h
@@ -19,4 +19,6 @@ void macro_stop(Macro *macro);
 void macro_record_key(Macro *macro, wint_t ch);
 void macro_play(Macro *macro, EditorContext *ctx, FileState *fs);
 
+extern Macro macro_state;
+
 #endif /* MACRO_H */


### PR DESCRIPTION
## Summary
- declare a global `Macro macro_state`
- reset `macro_state` in `initialize`
- record pressed keys during editor loop
- expose `macro_state` via `macro.h`

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e66e57ee88324b6ee9b70ceb8f6f1