### PR TITLE
Add macro keys to help text and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Vento currently supports the following features:
 - **Scroll Bar**: Indicates your position within the document.
 - **Optional Line Numbers**: Toggle line numbers in the settings dialog.
 - **Adjustable Tab Width**: Choose how many spaces the Tab key inserts.
+- **Keyboard Macros**: Press `F2` to record a macro and `F4` to play it back.
 - **Help Screen**: Press `CTRL-H` for a guide to Vento's features.
 - **About Box**: Press `CTRL-A` to view product information, version, and GPL message.
  - **Menu System**: Intuitive menu navigation for editor features. Press `CTRL-T` or `F10` to open the menu.
@@ -111,7 +112,6 @@ The following features are planned for future releases:
 - **Theme Support**: Multiple built in themes for easy visual customization.
 - **Spell Checker Support**: Automatically detect and correct typos.
 - **Git Integration**: Integrate with Git for version control.
-- **Macro Support**: Configurable keyboard macros for repetitive tasks.
 - **Extensions API**: Plugin support to extend editor capabilities.
 
 ## Known Issues

--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -14,6 +14,7 @@ void show_help(EditorContext *ctx) {
 
     const char *help_lines[] = {
         "CTRL-H or F1: Show this help",
+        "F2: Start/Stop macro recording",
         "CTRL-A: About",
         "CTRL-N: New file",
         "CTRL-L: Load a new file (browse files)",
@@ -29,6 +30,7 @@ void show_help(EditorContext *ctx) {
         "CTRL-Y: Redo",
         "CTRL-F: Search for text string",
         "F3: Find next occurrence",
+        "F4: Play last macro",
         "CTRL-R: Replace",
         "CTRL-G: Go to line",
         "CTRL-W: Move forward to next word",


### PR DESCRIPTION
## Summary
- document new keyboard macro keys in `src/ui_info.c`
- mention macro recording/playback in `README.md`
- remove macro bullet from Planned Features

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e6dc3b37883248b113b5a066f258e