### PR TITLE
Fix wide-char input setup

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -1,7 +1,5 @@
-#ifdef __APPLE__
-#  ifndef _XOPEN_SOURCE_EXTENDED
-#    define _XOPEN_SOURCE_EXTENDED
-#  endif
+#ifndef _XOPEN_SOURCE_EXTENDED
+#define _XOPEN_SOURCE_EXTENDED
 #endif
 #include <ncurses.h>
 #include <wchar.h>


### PR DESCRIPTION
## Summary
- define `_XOPEN_SOURCE_EXTENDED` before including `<ncurses.h>` in `editor.c`

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e701e617c8324829e88ecc2310e23