### PR TITLE
Support multiple named macros

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -32,6 +32,7 @@ typedef struct Node {
 #define KEY_CTRL_T          20
 
 struct FileState;
+struct Macro;
 typedef void (*KeyHandler)(struct FileState *, int *cx, int *cy);
 
 typedef struct {
@@ -44,6 +45,7 @@ void initialize_key_mappings(void);
 extern WINDOW *text_win;
 extern struct FileState *active_file;
 extern struct FileManager file_manager;
+extern struct Macro *current_macro;
 extern char search_text[256];
 extern volatile sig_atomic_t resize_pending;
 extern int exiting;

--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -37,8 +37,11 @@ void initialize(EditorContext *ctx) {
     ctx->enable_color = enable_color;
     ctx->enable_mouse = enable_mouse;
     apply_colors();
-    macro_state.length = 0;
-    macro_state.recording = false;
+    current_macro = macro_create("default");
+    if (current_macro) {
+        current_macro->length = 0;
+        current_macro->recording = false;
+    }
     cbreak();
     noecho();
     keypad(stdscr, TRUE);

--- a/src/macro.c
+++ b/src/macro.c
@@ -1,4 +1,74 @@
 #include "macro.h"
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    Macro **items;
+    int count;
+    int capacity;
+} MacroList;
+
+static MacroList macro_list = {0};
+extern Macro *current_macro;
+
+static int ensure_capacity(void) {
+    if (macro_list.count >= macro_list.capacity) {
+        int newcap = macro_list.capacity ? macro_list.capacity * 2 : 4;
+        Macro **tmp = realloc(macro_list.items, sizeof(Macro*) * newcap);
+        if (!tmp)
+            return -1;
+        macro_list.items = tmp;
+        macro_list.capacity = newcap;
+    }
+    return 0;
+}
+
+Macro *macro_create(const char *name) {
+    if (!name)
+        return NULL;
+    if (ensure_capacity() != 0)
+        return NULL;
+    Macro *m = calloc(1, sizeof(Macro));
+    if (!m)
+        return NULL;
+    m->name = strdup(name);
+    if (!m->name) {
+        free(m);
+        return NULL;
+    }
+    macro_list.items[macro_list.count++] = m;
+    if (!current_macro)
+        current_macro = m;
+    return m;
+}
+
+Macro *macro_get(const char *name) {
+    if (!name)
+        return current_macro;
+    for (int i = 0; i < macro_list.count; ++i) {
+        if (strcmp(macro_list.items[i]->name, name) == 0)
+            return macro_list.items[i];
+    }
+    return NULL;
+}
+
+void macro_delete(const char *name) {
+    if (!name)
+        return;
+    for (int i = 0; i < macro_list.count; ++i) {
+        Macro *m = macro_list.items[i];
+        if (strcmp(m->name, name) == 0) {
+            free(m->name);
+            free(m);
+            for (int j = i; j < macro_list.count - 1; ++j)
+                macro_list.items[j] = macro_list.items[j + 1];
+            macro_list.count--;
+            if (current_macro == m)
+                current_macro = macro_list.count ? macro_list.items[0] : NULL;
+            return;
+        }
+    }
+}
 
 void macro_start(Macro *macro) {
     if (!macro)

--- a/src/macro.h
+++ b/src/macro.h
@@ -5,20 +5,23 @@
 #include <stdbool.h>
 #include "editor.h"
 #include "files.h"
+#include <stddef.h>
 
 #define MACRO_MAX_KEYS 1024
 
 typedef struct Macro {
+    char *name;
     wint_t keys[MACRO_MAX_KEYS];
     int length;
     bool recording;
 } Macro;
 
+Macro *macro_create(const char *name);
+Macro *macro_get(const char *name);
+void macro_delete(const char *name);
 void macro_start(Macro *macro);
 void macro_stop(Macro *macro);
 void macro_record_key(Macro *macro, wint_t ch);
 void macro_play(Macro *macro, EditorContext *ctx, FileState *fs);
-
-extern Macro macro_state;
 
 #endif /* MACRO_H */

--- a/src/menu.c
+++ b/src/menu.c
@@ -343,16 +343,19 @@ void menuPrevFile(EditorContext *ctx) {
 
 static void menuMacroStart(EditorContext *ctx) {
     (void)ctx;
-    macro_start(&macro_state);
+    if (current_macro)
+        macro_start(current_macro);
 }
 
 static void menuMacroStop(EditorContext *ctx) {
     (void)ctx;
-    macro_stop(&macro_state);
+    if (current_macro)
+        macro_stop(current_macro);
 }
 
 static void menuMacroPlay(EditorContext *ctx) {
-    macro_play(&macro_state, ctx, ctx->active_file);
+    if (current_macro)
+        macro_play(current_macro, ctx, ctx->active_file);
 }
 
 static void menuManageMacros(EditorContext *ctx) {

--- a/tests/macro_tests.c
+++ b/tests/macro_tests.c
@@ -21,16 +21,29 @@ static char *test_simple_record_play() {
     EditorContext ctx = {0};
     sync_editor_context(&ctx);
 
-    Macro m = {0};
-    macro_start(&m);
-    macro_record_key(&m, L'a');
-    macro_record_key(&m, L'b');
-    macro_record_key(&m, L'c');
-    macro_stop(&m);
+    Macro *m1 = macro_create("one");
+    mu_assert("m1", m1 != NULL);
+    macro_start(m1);
+    macro_record_key(m1, L'a');
+    macro_record_key(m1, L'b');
+    macro_record_key(m1, L'c');
+    macro_stop(m1);
 
-    macro_play(&m, &ctx, fs);
+    Macro *m2 = macro_create("two");
+    mu_assert("m2", m2 != NULL);
+    macro_start(m2);
+    macro_record_key(m2, L'1');
+    macro_record_key(m2, L'2');
+    macro_record_key(m2, L'3');
+    macro_stop(m2);
 
-    mu_assert("buffer contains abc", strcmp(lb_get(&fs->buffer, 0), "abc") == 0);
+    macro_play(m1, &ctx, fs);
+    macro_play(m2, &ctx, fs);
+
+    mu_assert("buffer contains abc123", strcmp(lb_get(&fs->buffer, 0), "abc123") == 0);
+
+    macro_delete("one");
+    macro_delete("two");
 
     free_file_state(fs);
     endwin();


### PR DESCRIPTION
## Summary
- use a dynamic list to store macros
- expose helpers to create/get/delete macros
- track a current macro in editor/menu
- initialise a default macro at startup
- update tests to handle multiple macros

## Testing
- `bash tests/run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e87409ca083249b40bce52c8cfd81