### PR TITLE
Improve undo stack documentation

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -6,15 +6,30 @@
 #include <string.h>
 #include <wchar.h>
 typedef struct EditorContext EditorContext;
+
+/*
+ * Undo/Redo Stack
+ * ---------------
+ * Each file maintains an undo and redo history implemented as a singly linked
+ * list.  A `Node` represents one entry in these stacks and contains a `Change`
+ * describing the modification to a single line.
+ *
+ * A `Change` stores the line index along with the previous and new contents of
+ * that line.  When `old_text` is NULL the change represents an insertion and
+ * when `new_text` is NULL it represents a deletion.  Both strings are
+ * dynamically allocated and ownership is transferred to the stack when the
+ * change is pushed.  They are freed when the entry is popped or when the entire
+ * stack is destroyed.
+ */
 typedef struct Change {
-    int line;
-    char *old_text;
-    char *new_text;
+    int line;        /* Affected line index */
+    char *old_text;  /* Text before the change or NULL */
+    char *new_text;  /* Text after the change or NULL */
 } Change;
 
 typedef struct Node {
-    Change change;
-    struct Node *next;
+    Change change;   /* Stored modification */
+    struct Node *next; /* Next node in the stack */
 } Node;
 
 

--- a/src/undo.h
+++ b/src/undo.h
@@ -4,12 +4,42 @@
 #include "editor.h"
 #include "files.h"
 
+/**
+ * Pushes a change onto the given stack.
+ *
+ * Ownership of any strings inside the Change is transferred to the stack. The
+ * function allocates a new Node and places it at the head of the list.
+ */
 void push(Node **stack, Change change);
+
+/**
+ * Pops the most recent change from the stack.
+ *
+ * If the stack is empty an empty Change with NULL strings is returned. The
+ * caller becomes responsible for freeing the returned Change contents.
+ */
 Change pop(Node **stack);
+
+/** Check whether the stack contains no entries. */
 int is_empty(Node *stack);
+
+/**
+ * Frees all nodes in the stack and any text they own.
+ */
 void free_stack(Node *stack);
+
 struct FileState;
+
+/**
+ * Reverses the most recent action recorded in `fs->undo_stack` and moves that
+ * entry to `fs->redo_stack`.
+ */
 void undo(FileState *fs);
+
+/**
+ * Reapplies the most recently undone action from `fs->redo_stack` and moves it
+ * back to `fs->undo_stack`.
+ */
 void redo(FileState *fs);
 
 #endif


### PR DESCRIPTION
## Summary
- document `Change` and `Node` structures
- clarify how undo stack functions work

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_683e87d685e083248126f68bca710319