### PR TITLE
Add configurable macro hotkeys

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -183,7 +183,9 @@ void config_save(const AppConfig *cfg) {
         "show_startup_warning",
         "search_ignore_case",
         "tab_width",
-        "macros_file"
+        "macros_file",
+        "macro_record_key",
+        "macro_play_key"
     };
 
     char path[PATH_MAX];
@@ -207,6 +209,8 @@ void config_save(const AppConfig *cfg) {
     fprintf(f, "%s=%s\n", keys[13], cfg->search_ignore_case ? "true" : "false");
     fprintf(f, "%s=%d\n", keys[14], cfg->tab_width);
     fprintf(f, "%s=%s\n", keys[15], cfg->macros_file);
+    fprintf(f, "%s=%d\n", keys[16], cfg->macro_record_key);
+    fprintf(f, "%s=%d\n", keys[17], cfg->macro_play_key);
     fclose(f);
 }
 
@@ -316,6 +320,10 @@ void config_load(AppConfig *cfg) {
         } else if (strcmp(key, "macros_file") == 0) {
             strncpy(tmp.macros_file, value, sizeof(tmp.macros_file) - 1);
             tmp.macros_file[sizeof(tmp.macros_file) - 1] = '\0';
+        } else if (strcmp(key, "macro_record_key") == 0) {
+            tmp.macro_record_key = atoi(value);
+        } else if (strcmp(key, "macro_play_key") == 0) {
+            tmp.macro_play_key = atoi(value);
         } else {
             // Unknown key, ignore
             continue;
@@ -327,6 +335,8 @@ void config_load(AppConfig *cfg) {
     enable_color = cfg->enable_color;
     enable_mouse = cfg->enable_mouse;
     show_line_numbers = cfg->show_line_numbers;
+    key_macro_record = cfg->macro_record_key;
+    key_macro_play = cfg->macro_play_key;
 
     if (enable_color) {
         if (!has_colors()) {

--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,8 @@ typedef struct {
     int search_ignore_case;
     int tab_width;
     char macros_file[PATH_MAX];
+    int macro_record_key;
+    int macro_play_key;
 } AppConfig;
 
 extern AppConfig app_config;

--- a/src/editor.h
+++ b/src/editor.h
@@ -66,6 +66,8 @@ extern volatile sig_atomic_t resize_pending;
 extern int exiting;
 extern EditorContext editor;
 extern int start_line;
+extern int key_macro_record;
+extern int key_macro_play;
 void handle_regular_mode(EditorContext *ctx, struct FileState *fs, wint_t ch);
 void initialize(EditorContext *ctx);
 void draw_text_buffer(struct FileState *fs, WINDOW *win);

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,3 +1,4 @@
+#include <ncurses.h>
 #include "config.h"
 #include "file_manager.h"
 
@@ -23,7 +24,9 @@ __attribute__((weak)) AppConfig app_config = {
     .show_startup_warning = 1,
     .search_ignore_case = 0,
     .tab_width = 4,
-    .macros_file = ""
+    .macros_file = "",
+    .macro_record_key = KEY_F(2),
+    .macro_play_key = KEY_F(4)
 };
 
 __attribute__((weak)) FileManager file_manager;

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -14,7 +14,11 @@
 #include "syntax.h"
 #include "files.h"
 
-__attribute__((weak)) AppConfig app_config = { .tab_width = 4 };
+__attribute__((weak)) AppConfig app_config = {
+    .tab_width = 4,
+    .macro_record_key = KEY_F(2),
+    .macro_play_key = KEY_F(4)
+};
 
 static void update_scroll_x(EditorContext *ctx, FileState *fs) {
     int offset = get_line_number_offset(fs);

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -61,6 +61,8 @@ static const Option options[] = {
     {"Type color", OPT_COLOR, offsetof(AppConfig, type_color), NULL},
     {"Symbol color", OPT_COLOR, offsetof(AppConfig, symbol_color), NULL},
     {"Search color", OPT_COLOR, offsetof(AppConfig, search_color), NULL},
+    {"Macro record key", OPT_INT, offsetof(AppConfig, macro_record_key), NULL},
+    {"Macro play key", OPT_INT, offsetof(AppConfig, macro_play_key), NULL},
 };
 
 #define FIELD_COUNT ((int)(sizeof(options) / sizeof(options[0])))


### PR DESCRIPTION
## Summary
- expose key bindings for macro recording and playback via `AppConfig`
- save and load these bindings in the config file
- display macro key options in the Settings dialog

## Testing
- `make test` *(fails: Segmentation fault)*
- `make`

------
https://chatgpt.com/codex/tasks/task_e_683e8de33af08324adcfbb342aca3ff3