### PR TITLE
Add macro recording indicator in status bar

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -378,6 +378,8 @@ static void handle_macro_record_wrapper(struct FileState *fs, int *cx, int *cy) 
         macro_stop(current_macro);
     else
         macro_start(current_macro);
+    if (input_ctx)
+        update_status_bar(input_ctx, input_ctx->active_file);
 }
 
 static void handle_macro_play_wrapper(struct FileState *fs, int *cx, int *cy) {
@@ -385,6 +387,8 @@ static void handle_macro_play_wrapper(struct FileState *fs, int *cx, int *cy) {
     (void)cy;
     if (current_macro)
         macro_play(current_macro, input_ctx, fs);
+    if (input_ctx)
+        update_status_bar(input_ctx, input_ctx->active_file);
 }
 
 

--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -9,6 +9,7 @@
 #include "editor_state.h"
 #include "undo.h"
 #include "file_ops.h"
+#include "macro.h"
 
 // Delete the line under the cursor when the user issues the delete-line
 // command. The removed text is pushed onto the undo stack and the text window
@@ -255,6 +256,10 @@ void update_status_bar(EditorContext *ctx, FileState *fs) {
         snprintf(display, sizeof(display), "%s* [%d/%d]", name, idx, total);
     else
         snprintf(display, sizeof(display), "%s [%d/%d]", name, idx, total);
+    if (macro_state.recording)
+        strncat(display, " [REC]", sizeof(display) - strlen(display) - 1);
+    else if (macro_state.playing)
+        strncat(display, " [PLAY]", sizeof(display) - strlen(display) - 1);
     int center_position = (COLS - (int)strlen(display)) / 2;
     if (center_position < 0) center_position = 0;
     mvprintw(1, center_position, "%s", display);

--- a/src/macro.c
+++ b/src/macro.c
@@ -10,6 +10,7 @@ typedef struct {
 
 static MacroList macro_list = {0};
 extern Macro *current_macro;
+MacroState macro_state = {false, false};
 
 static int ensure_capacity(void) {
     if (macro_list.count >= macro_list.capacity) {
@@ -75,12 +76,14 @@ void macro_start(Macro *macro) {
         return;
     macro->length = 0;
     macro->recording = true;
+    macro_state.recording = true;
 }
 
 void macro_stop(Macro *macro) {
     if (!macro)
         return;
     macro->recording = false;
+    macro_state.recording = false;
 }
 
 void macro_record_key(Macro *macro, wint_t ch) {
@@ -94,9 +97,15 @@ void macro_record_key(Macro *macro, wint_t ch) {
 void macro_play(Macro *macro, EditorContext *ctx, FileState *fs) {
     if (!macro || macro->recording)
         return;
+    macro_state.playing = true;
+    if (ctx)
+        update_status_bar(ctx, fs);
     for (int i = 0; i < macro->length; ++i) {
         handle_regular_mode(ctx, fs, macro->keys[i]);
     }
+    macro_state.playing = false;
+    if (ctx)
+        update_status_bar(ctx, fs);
 }
 
 int macro_count(void) {

--- a/src/macro.h
+++ b/src/macro.h
@@ -26,4 +26,11 @@ void macro_play(Macro *macro, EditorContext *ctx, FileState *fs);
 int macro_count(void);
 Macro *macro_at(int index);
 
+typedef struct {
+    bool recording;
+    bool playing;
+} MacroState;
+
+extern MacroState macro_state;
+
 #endif /* MACRO_H */

--- a/src/menu.c
+++ b/src/menu.c
@@ -377,6 +377,7 @@ static void menuMacroStart(EditorContext *ctx) {
     (void)ctx;
     if (current_macro)
         macro_start(current_macro);
+    update_status_bar(menu_ctx, menu_ctx->active_file);
 }
 
 /* Stop recording the current macro (Macros->"Stop Recording"). */
@@ -386,12 +387,14 @@ static void menuMacroStop(EditorContext *ctx) {
         macro_stop(current_macro);
         macros_save(&app_config);
     }
+    update_status_bar(menu_ctx, menu_ctx->active_file);
 }
 
 /* Play back the last recorded macro (Macros->"Play Last Macro"). */
 static void menuMacroPlay(EditorContext *ctx) {
     if (current_macro)
         macro_play(current_macro, ctx, ctx->active_file);
+    update_status_bar(menu_ctx, menu_ctx->active_file);
 }
 
 /* Opens the macro management dialog (Macros->"Manage Macros..."). */


### PR DESCRIPTION
## Summary
- expose global `macro_state` to track recording/playback
- append `[REC]` or `[PLAY]` in `update_status_bar`
- update macros menu and hotkey handlers to refresh the status bar
- show playback status while macros execute

## Testing
- `make`
- `sh tests/run_tests.sh` *(fails: multiple definition of `allocation_failed` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683e8f3a2e888324b29303584b1998ed