### PR TITLE
Add documentation for global config flags

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -1,13 +1,36 @@
+/*
+ * Default global configuration and runtime flags
+ * ----------------------------------------------
+ * This file provides weak definitions used by the editor so that other
+ * translation units may override them. These globals are updated when
+ * configuration files are loaded or command line options are processed.
+ */
+
 #include <ncurses.h>
 #include "config.h"
 #include "file_manager.h"
 
-// global application state
+/* Whether color output is enabled. Set by config_load based on the user's
+ * preferences and terminal capabilities. */
 __attribute__((weak)) int enable_color = 1;
+
+/* Whether mouse support is enabled. Updated after reading the configuration
+ * file. */
 __attribute__((weak)) int enable_mouse = 1;
+
+/* Display line numbers in the editor. Modified when configuration or UI
+ * options change. */
 __attribute__((weak)) int show_line_numbers = 0;
+
+/* Initial line to jump to when a file is opened. Reset after the jump is
+ * performed. */
 __attribute__((weak)) int start_line = 0;
 
+/*
+ * Global configuration loaded from the user's config file. The structure is
+ * populated during config_load and may be saved back to disk. Fields provide
+ * default colors, input settings and other editor options.
+ */
 __attribute__((weak)) AppConfig app_config = {
     .background_color = "BLACK",
     .text_color = "WHITE",
@@ -29,4 +52,8 @@ __attribute__((weak)) AppConfig app_config = {
     .macro_play_key = KEY_F(4)
 };
 
+/*
+ * Global file manager tracking all open buffers. Initialized in main() via
+ * fm_init and updated as files are opened or closed.
+ */
 __attribute__((weak)) FileManager file_manager;


### PR DESCRIPTION
## Summary
- explain purpose of `src/globals.c`
- document exported global variables

## Testing
- `make test` *(fails: multiple definition errors)*

------
https://chatgpt.com/codex/tasks/task_e_683e9200353483248fb45632eaa57e7b