### PR TITLE
Add documentation for UI dialog helpers

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -1,3 +1,8 @@
+/*
+ * Utility helpers for generic dialogs used by the editor.
+ * These routines implement small find/replace and goto prompts
+ * on top of the primitives defined in dialog.c.
+ */
 #include <ncurses.h>
 #include <ctype.h>
 #include <string.h>
@@ -10,6 +15,18 @@
 #include "dialog.h"
 #include "editor_state.h"
 
+/*
+ * Display a generic single-input dialog box.
+ *
+ *  ctx            - editor context used for color attributes
+ *  message        - title displayed at the top of the dialog
+ *  output         - buffer receiving the user's text; may be NULL
+ *  max_input_len  - size of the output buffer
+ *
+ * The window is created using dialog_open(), gathers input via
+ * dialog_prompt() and is destroyed with dialog_close().  If the user
+ * cancels the prompt the output buffer is set to an empty string.
+ */
 void create_dialog(EditorContext *ctx, const char *message, char *output,
                    int max_input_len) {
     int win_width = (int)strlen(message) + 30;
@@ -36,6 +53,19 @@ void create_dialog(EditorContext *ctx, const char *message, char *output,
     dialog_close(dialog_win);
 }
 
+/*
+ * Prompt the user for search text.
+ *
+ *  ctx            - editor context for color management
+ *  output         - buffer receiving the search string
+ *  max_input_len  - size of output buffer
+ *  preset         - optional initial text to pre-fill the prompt
+ *
+ * Returns 1 if the user confirms, 0 if cancelled.  Internally this
+ * creates a small dialog window with dialog_open(), uses dialog_prompt()
+ * for input and closes it via dialog_close().  When cancelled the output
+ * buffer is cleared.
+ */
 int show_find_dialog(EditorContext *ctx, char *output, int max_input_len,
                      const char *preset) {
     int win_width = 40;
@@ -68,6 +98,19 @@ int show_find_dialog(EditorContext *ctx, char *output, int max_input_len,
     return ok;
 }
 
+/*
+ * Prompt the user for both a search string and its replacement.
+ *
+ *  ctx              - editor context for color attributes
+ *  search           - buffer receiving the text to search for
+ *  max_search_len   - size of search buffer
+ *  replace          - buffer receiving the replacement text
+ *  max_replace_len  - size of replace buffer
+ *
+ * Returns 1 when both prompts are confirmed, otherwise 0.  The search
+ * field is obtained via show_find_dialog() and the replacement text via
+ * create_dialog(), both using the helper routines in dialog.c.
+ */
 int show_replace_dialog(EditorContext *ctx, char *search, int max_search_len,
                         char *replace, int max_replace_len) {
     curs_set(0);
@@ -81,6 +124,16 @@ int show_replace_dialog(EditorContext *ctx, char *search, int max_search_len,
     return 1;
 }
 
+/*
+ * Ask the user for a line number and convert it to an integer.
+ *
+ *  ctx          - editor context used for the dialog appearance
+ *  line_number  - output location for the parsed number on success
+ *
+ * Returns 1 on success or 0 if the input is cancelled or invalid.
+ * The dialog itself is implemented with create_dialog() which in turn
+ * uses the dialog.c helpers to manage the popup.
+ */
 int show_goto_dialog(EditorContext *ctx, int *line_number) {
     char buf[32];
 


### PR DESCRIPTION
## Summary
- document `ui.c` dialog helper routines
- describe arguments and behaviour for user input dialogs

## Testing
- `make`
- `bash tests/run_tests.sh` *(fails: multiple definition of symbols)*

------
https://chatgpt.com/codex/tasks/task_e_683e91f284988324933c534850853a75