### PR TITLE
Add LineBuffer documentation

### DIFF
--- a/src/line_buffer.c
+++ b/src/line_buffer.c
@@ -1,9 +1,25 @@
+/*
+ * line_buffer.c
+ * -------------
+ * Implementation of the LineBuffer structure, a dynamic array of strings
+ * used to hold the text contents of a file. Each entry in the array
+ * represents one line. The helpers here manage allocation, resizing and
+ * basic editing operations on that array.
+ */
+
 #include "line_buffer.h"
 #include <stdlib.h>
 #include <string.h>
 
 #define INITIAL_CAPACITY 16
 
+/**
+ * Ensure the line buffer has at least MIN_CAPACITY slots.
+ *
+ * The function reallocates the internal array when needed and initialises
+ * any newly created entries to NULL. On success the buffer's capacity is
+ * updated. Returns 0 on success or -1 if memory allocation fails.
+ */
 static int lb_grow(LineBuffer *lb, int min_capacity) {
     int new_cap = lb->capacity ? lb->capacity * 2 : INITIAL_CAPACITY;
     if (new_cap < min_capacity)
@@ -18,6 +34,13 @@ static int lb_grow(LineBuffer *lb, int min_capacity) {
     return 0;
 }
 
+/**
+ * Allocate and initialise a new LineBuffer.
+ *
+ * If INITIAL_CAPACITY is non-positive a default value is used. The returned
+ * buffer owns its internal memory and should be released with lb_free().
+ * Returns NULL on allocation failure.
+ */
 LineBuffer *lb_create(int initial_capacity) {
     LineBuffer *lb = malloc(sizeof(LineBuffer));
     if (!lb)
@@ -30,6 +53,13 @@ LineBuffer *lb_create(int initial_capacity) {
     return lb;
 }
 
+/**
+ * Initialise an existing LineBuffer structure.
+ *
+ * Memory for the line array is allocated using calloc so all slots start as
+ * NULL. The count is reset to zero and capacity reflects the number of
+ * allocated slots. A non-positive INITIAL_CAPACITY falls back to the default.
+ */
 void lb_init(LineBuffer *lb, int initial_capacity) {
     if (!lb)
         return;
@@ -45,6 +75,13 @@ void lb_init(LineBuffer *lb, int initial_capacity) {
     lb->capacity = initial_capacity;
 }
 
+/**
+ * Release all memory owned by LB.
+ *
+ * Each stored line is freed and the underlying array is released. The
+ * structure's count and capacity fields are reset to zero so the buffer can
+ * be safely reused or discarded.
+ */
 void lb_free(LineBuffer *lb) {
     if (!lb)
         return;
@@ -56,12 +93,26 @@ void lb_free(LineBuffer *lb) {
     lb->capacity = 0;
 }
 
+/**
+ * Retrieve the string at INDEX from the buffer.
+ *
+ * Returns NULL if INDEX is out of range or if LB is NULL. The returned
+ * pointer remains owned by the buffer.
+ */
 const char *lb_get(LineBuffer *lb, int index) {
     if (!lb || index < 0 || index >= lb->count)
         return NULL;
     return lb->lines[index];
 }
 
+/**
+ * Insert LINE at the given INDEX within the buffer.
+ *
+ * The buffer grows if necessary and newly created slots are initialised
+ * to NULL. When inserting past the current end, missing lines are created
+ * and count is updated to index + 1. Returns 0 on success or -1 on memory
+ * allocation failure.
+ */
 int lb_insert(LineBuffer *lb, int index, const char *line) {
     if (!lb || !line)
         return -1;
@@ -97,6 +148,12 @@ int lb_insert(LineBuffer *lb, int index, const char *line) {
     return 0;
 }
 
+/**
+ * Remove the line at INDEX from the buffer.
+ *
+ * The stored string is freed and subsequent lines are shifted up to fill the
+ * gap. The count field is decremented; capacity is left unchanged.
+ */
 void lb_delete(LineBuffer *lb, int index) {
     if (!lb || index < 0 || index >= lb->count)
         return;

--- a/src/line_buffer.h
+++ b/src/line_buffer.h
@@ -3,10 +3,19 @@
 
 #include <stddef.h>
 
+/*
+ * LineBuffer
+ * ----------
+ * A lightweight dynamic array of strings used by the editor to store
+ * the contents of files. Each entry corresponds to a single line and
+ * the structure tracks how many lines are in use as well as the
+ * currently allocated capacity.
+ */
+
 typedef struct LineBuffer {
-    char **lines;
-    int count;
-    int capacity;
+    char **lines;   /* array of allocated strings */
+    int count;      /* number of valid lines stored */
+    int capacity;   /* total slots allocated in lines */
 } LineBuffer;
 
 LineBuffer *lb_create(int initial_capacity);


### PR DESCRIPTION
## Summary
- document line_buffer.c and line_buffer.h
- add file-level overview for LineBuffer
- explain memory management for dynamic line array

## Testing
- `make test` *(fails: multiple definition errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f08ed1f588324989e02040abf33e0