### PR TITLE
Update syntax comments

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1,8 +1,28 @@
+/*
+ * syntax.c
+ * --------
+ * Dispatches to the registered syntax highlighter for the active file
+ * and provides cleanup helpers to free any compiled regular expressions
+ * when the application exits.
+ */
 #include <ncurses.h>
 #include "syntax.h"
 #include "editor.h"
 #include "files.h"
 
+/*
+ * apply_syntax_highlighting(fs, win, line, y)
+ * ------------------------------------------
+ * fs   - active FileState describing the file being rendered
+ * win  - ncurses window where output should be drawn
+ * line - contents of the line to highlight
+ * y    - vertical screen position for drawing
+ *
+ * Chooses the appropriate highlighting strategy by checking the
+ * registered SyntaxDef for the file's mode. If no definition exists
+ * but HTML mode is selected, the HTML highlighter is used; otherwise
+ * the line is printed as plain text.
+ */
 void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int y) {
     const SyntaxDef *def = syntax_get(fs->syntax_mode);
     if (def) {
@@ -14,7 +34,13 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
     }
 }
 
-/* Cleanup compiled regular expressions for all registered syntax modules */
+/*
+ * syntax_cleanup()
+ * ---------------
+ * Iterates over each registered syntax mode and frees any compiled
+ * regular expressions associated with its patterns.  This should be
+ * called during application shutdown to release regex resources.
+ */
 void syntax_cleanup(void) {
     for (int mode = 0; mode < 8; mode++) {
         const SyntaxDef *def = syntax_get(mode);


### PR DESCRIPTION
## Summary
- explain role of syntax module
- document `apply_syntax_highlighting` parameters and logic
- clarify cleanup for registered syntax highlighters

## Testing
- `make test` *(fails: multiple definition of symbols)*

------
https://chatgpt.com/codex/tasks/task_e_683f0b8d10888324a502953c6ed1108d