### PR TITLE
Implement macro management dialog

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -498,8 +498,8 @@ static void menuMacroPlay(EditorContext *ctx) {
  * @param ctx Editor context (unused).
  */
 static void menuManageMacros(EditorContext *ctx) {
-    (void)ctx;
-    show_message("Macro management not implemented");
+    show_manage_macros(ctx);
+    update_status_bar(menu_ctx, menu_ctx->active_file);
 }
 
 /**

--- a/src/ui.h
+++ b/src/ui.h
@@ -19,5 +19,6 @@ int show_goto_dialog(EditorContext *ctx, int *line_number);
 int show_open_file_dialog(EditorContext *ctx, char *path, int max_len);
 int show_save_file_dialog(EditorContext *ctx, char *path, int max_len);
 int show_settings_dialog(EditorContext *ctx, AppConfig *cfg);
+void show_manage_macros(EditorContext *ctx);
 
 #endif // UI_H

--- a/src/ui_macros.c
+++ b/src/ui_macros.c
@@ -1,0 +1,156 @@
+#include "ui.h"
+#include "ui_common.h"
+#include "config.h"
+#include "macro.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+#include <stdlib.h>
+
+/*
+ * Manage macros dialog
+ * --------------------
+ * Presents a scrollable list of defined macros and allows the user to
+ * select the active macro, rename or delete existing entries and create
+ * new ones.
+ */
+
+void show_manage_macros(EditorContext *ctx) {
+    curs_set(0);
+    int highlight = 0;
+    int start = 0;
+    int ch;
+
+    int win_height = LINES - 4;
+    int win_width = COLS - 4;
+    if (win_width > COLS - 2)
+        win_width = COLS - 2;
+    if (win_width < 2)
+        win_width = 2;
+
+    WINDOW *win = create_popup_window(win_height, win_width, NULL);
+    if (!win) {
+        curs_set(1);
+        show_message("Unable to create window");
+        return;
+    }
+    keypad(win, TRUE);
+
+    while (1) {
+        int count = macro_count();
+        if (count == 0) {
+            highlight = -1;
+        } else {
+            if (highlight < 0)
+                highlight = 0;
+            if (highlight >= count)
+                highlight = count - 1;
+        }
+
+        werase(win);
+        box(win, 0, 0);
+        mvwprintw(win, 1, 2, "Macros:");
+
+        int max_display = win_height - 4;
+        if (highlight < start)
+            start = highlight;
+        if (highlight >= start + max_display)
+            start = highlight - max_display + 1;
+
+        for (int i = 0; i < max_display && i + start < count; ++i) {
+            int idx = i + start;
+            Macro *m = macro_at(idx);
+            if (!m)
+                continue;
+            if (idx == highlight)
+                wattron(win, A_REVERSE);
+            mvwprintw(win, i + 2, 2, "%s%s", m->name,
+                      (m == current_macro) ? " *" : "");
+            if (idx == highlight)
+                wattroff(win, A_REVERSE);
+        }
+
+        for (int i = count - start; i < max_display; ++i)
+            mvwprintw(win, i + 2, 2, "%*s", win_width - 4, "");
+
+        mvwprintw(win, win_height - 2, 2,
+                  "Arrows:move  Enter:select  N:new  R:rename  D:delete  ESC:close");
+        wrefresh(win);
+
+        ch = wgetch(win);
+        if (ch == KEY_RESIZE) {
+            resizeterm(0, 0);
+            win_height = LINES - 4;
+            win_width = COLS - 4;
+            if (win_width > COLS - 2)
+                win_width = COLS - 2;
+            if (win_width < 2)
+                win_width = 2;
+            wresize(win, win_height, win_width);
+            mvwin(win, (LINES - win_height) / 2,
+                  (COLS - win_width) / 2 < 0 ? 0 : (COLS - win_width) / 2);
+            continue;
+        } else if (ch == KEY_UP) {
+            if (highlight > 0)
+                --highlight;
+        } else if (ch == KEY_DOWN) {
+            if (highlight < count - 1)
+                ++highlight;
+        } else if (ch == '\n') {
+            if (highlight >= 0 && highlight < count)
+                current_macro = macro_at(highlight);
+            macros_save(&app_config);
+            break;
+        } else if (ch == 'n' || ch == 'N') {
+            char name[64] = "";
+            create_dialog(ctx, "New Macro:", name, sizeof(name));
+            if (name[0]) {
+                Macro *m = macro_create(name);
+                if (m)
+                    highlight = macro_count() - 1;
+                macros_save(&app_config);
+            }
+        } else if (ch == 'd' || ch == 'D') {
+            if (highlight >= 0 && highlight < count) {
+                Macro *m = macro_at(highlight);
+                if (m) {
+                    char *tmp = strdup(m->name);
+                    if (tmp) {
+                        macro_delete(tmp);
+                        free(tmp);
+                        if (highlight >= macro_count())
+                            highlight = macro_count() - 1;
+                        macros_save(&app_config);
+                    }
+                }
+            }
+        } else if (ch == 'r' || ch == 'R') {
+            if (highlight >= 0 && highlight < count) {
+                Macro *m = macro_at(highlight);
+                if (m) {
+                    char buf[64];
+                    strncpy(buf, m->name, sizeof(buf) - 1);
+                    buf[sizeof(buf) - 1] = '\0';
+                    create_dialog(ctx, "Rename Macro:", buf, sizeof(buf));
+                    if (buf[0]) {
+                        char *newname = strdup(buf);
+                        if (newname) {
+                            free(m->name);
+                            m->name = newname;
+                            macros_save(&app_config);
+                        }
+                    }
+                }
+            }
+        } else if (ch == 27) {
+            break;
+        }
+    }
+
+    werase(win);
+    wrefresh(win);
+    delwin(win);
+    wrefresh(stdscr);
+    curs_set(1);
+}
+

--- a/tests/macro_tests.c
+++ b/tests/macro_tests.c
@@ -50,8 +50,19 @@ static char *test_simple_record_play() {
     return 0;
 }
 
+static char *test_create_delete_api() {
+    int before = macro_count();
+    Macro *m = macro_create("temp");
+    mu_assert("macro created", m != NULL);
+    mu_assert("count increased", macro_count() == before + 1);
+    macro_delete("temp");
+    mu_assert("count restored", macro_count() == before);
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_simple_record_play);
+    mu_run_test(test_create_delete_api);
     return 0;
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -4,19 +4,31 @@ DIR="$(dirname "$0")"
 cd "$DIR"
 mkdir -p obj_test
 SRC="../src"
-for f in $SRC/*.c; do bn=$(basename "$f"); if [ "$bn" != "vento.c" ]; then gcc -c "$f" -o obj_test/$(basename "$f" .c).o -I$SRC -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra; fi; done
+for f in $SRC/*.c; do
+    bn=$(basename "$f")
+    if [ "$bn" != "vento.c" ]; then
+        gcc -c "$f" -o obj_test/$(basename "$f" .c).o -I$SRC \
+            -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra -fcommon
+    fi
+done
 ar rcs obj_test/libvento.a obj_test/*.o
 gcc -c test_stubs.c -I$SRC -o obj_test/test_stubs.o
 gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
-    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar -Wl,--wrap=confirm_switch \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
     -o navigation_tests
 ./navigation_tests
 gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
-    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar -Wl,--wrap=confirm_switch \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
     -o menu_load_tests
 ./menu_load_tests
 
 gcc macro_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
-    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar -Wl,--wrap=confirm_switch \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
     -o macro_tests
 ./macro_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -5,20 +5,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-FileManager file_manager;
-FileState *active_file = NULL;
-WINDOW *text_win = NULL;
+__attribute__((weak)) FileManager file_manager;
 
 int fm_switch_fail = 0;
 int fm_add_fail = 0;
 
 
 bool __wrap_confirm_switch(void) { return true; }
-void clamp_scroll_x(FileState *fs) { (void)fs; }
-void redraw(void) {}
+void __wrap_clamp_scroll_x(FileState *fs) { (void)fs; }
+void __wrap_redraw(void) {}
 bool confirm_quit(void) { return true; }
-void allocation_failed(const char *msg) { fprintf(stderr, "alloc fail: %s\n", msg ? msg : ""); }
-void draw_text_buffer(FileState *fs, WINDOW *win) { (void)fs; (void)win; }
+void __wrap_allocation_failed(const char *msg) { fprintf(stderr, "alloc fail: %s\n", msg ? msg : ""); }
+void __wrap_draw_text_buffer(FileState *fs, WINDOW *win) { (void)fs; (void)win; }
 int last_status_count = -1;
 void __wrap_update_status_bar(EditorContext *ctx, FileState *fs) {
     last_status_count = ctx ? ctx->file_manager.count : -1;


### PR DESCRIPTION
## Summary
- implement a new `show_manage_macros` dialog in `ui_macros.c`
- hook up Macros->Manage in `menu.c`
- expose the dialog via `ui.h`
- extend tests for macro create/delete
- update test harness to compile with `-fcommon` and wrap more stubs

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f1500306483249b62941d15e7c5be