### PR TITLE
Implement macro rename helper and integrate with UI

### DIFF
--- a/src/macro.c
+++ b/src/macro.c
@@ -163,3 +163,18 @@ Macro *macro_at(int index) {
         return NULL;
     return macro_list.items[index];
 }
+
+/*
+ * Rename the given macro to the provided new name. Memory for the
+ * name string is managed here, freeing the old name and duplicating
+ * the new one.
+ */
+void macro_rename(Macro *m, const char *new_name) {
+    if (!m || !new_name || new_name[0] == '\0')
+        return;
+    char *dup = strdup(new_name);
+    if (!dup)
+        return;
+    free(m->name);
+    m->name = dup;
+}

--- a/src/macro.h
+++ b/src/macro.h
@@ -27,6 +27,7 @@ void macro_record_key(Macro *macro, wint_t ch);
 void macro_play(Macro *macro, EditorContext *ctx, FileState *fs);
 int macro_count(void);
 Macro *macro_at(int index);
+void macro_rename(Macro *m, const char *new_name);
 
 typedef struct {
     bool recording;

--- a/src/ui_macros.c
+++ b/src/ui_macros.c
@@ -133,12 +133,8 @@ void show_manage_macros(EditorContext *ctx) {
                     buf[sizeof(buf) - 1] = '\0';
                     create_dialog(ctx, "Rename Macro:", buf, sizeof(buf));
                     if (buf[0]) {
-                        char *newname = strdup(buf);
-                        if (newname) {
-                            free(m->name);
-                            m->name = newname;
-                            macros_save(&app_config);
-                        }
+                        macro_rename(m, buf);
+                        macros_save(&app_config);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add `macro_rename` helper to update macro names
- expose new function in header
- call `macro_rename` from manage macros dialog and persist changes

## Testing
- `tests/run_tests.sh` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f30b8adf0832481428759beac8f4c