### PR TITLE
Per-macro play keys

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -474,11 +474,13 @@ void macros_load(AppConfig *cfg) {
             m->keys[m->length++] = (wint_t)strtoul(tok, NULL, 10);
         }
         char *active_s = strtok(NULL, " \t");
+        char *play_s = strtok(NULL, " \t");
         m->recording = false;
         m->active = false;
         if (active_s && atoi(active_s)) {
             loaded_active = m;
         }
+        m->play_key = play_s ? atoi(play_s) : 0;
     }
     fclose(f);
     if (loaded_active)
@@ -513,7 +515,7 @@ void macros_save(const AppConfig *cfg) {
         fprintf(f, "%s %d", m->name, m->length);
         for (int j = 0; j < m->length; ++j)
             fprintf(f, " %u", (unsigned int)m->keys[j]);
-        fprintf(f, " %d\n", m->active ? 1 : 0);
+        fprintf(f, " %d %d\n", m->active ? 1 : 0, m->play_key);
     }
     fclose(f);
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -543,10 +543,22 @@ void run_editor(EditorContext *ctx) {
             }
         } else if (ch == (wint_t)key_macro_record) {
             handle_macro_record_wrapper(ctx->active_file, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
-        } else if (ch == (wint_t)key_macro_play) {
-            handle_macro_play_wrapper(ctx->active_file, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
         } else {
-            handle_regular_mode(ctx, ctx->active_file, ch);
+            Macro *play = NULL;
+            for (int i = 0; i < macro_count(); ++i) {
+                Macro *m = macro_at(i);
+                if (m && m->play_key && m->play_key == (int)ch) {
+                    play = m;
+                    break;
+                }
+            }
+            if (play) {
+                macro_play(play, ctx, ctx->active_file);
+            } else if (ch == (wint_t)key_macro_play) {
+                handle_macro_play_wrapper(ctx->active_file, &ctx->active_file->cursor_x, &ctx->active_file->cursor_y);
+            } else {
+                handle_regular_mode(ctx, ctx->active_file, ch);
+            }
         }
 
         if (exiting == 1)

--- a/src/macro.c
+++ b/src/macro.c
@@ -47,6 +47,7 @@ Macro *macro_create(const char *name) {
         free(m);
         return NULL;
     }
+    m->play_key = 0;
     m->active = false;
     macro_list.items[macro_list.count++] = m;
     if (!current_macro) {

--- a/src/macro.h
+++ b/src/macro.h
@@ -13,6 +13,7 @@ typedef struct Macro {
     char *name;
     wint_t keys[MACRO_MAX_KEYS];
     int length;
+    int play_key;
     bool recording;
     bool active;
 } Macro;

--- a/src/ui_macros.c
+++ b/src/ui_macros.c
@@ -7,6 +7,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+int select_int(EditorContext *ctx, const char *prompt, int current, WINDOW *parent);
+
 /*
  * Manage macros dialog
  * --------------------
@@ -64,7 +66,8 @@ void show_manage_macros(EditorContext *ctx) {
                 continue;
             if (idx == highlight)
                 wattron(win, A_REVERSE);
-            mvwprintw(win, i + 2, 2, "%s%s", m->name,
+            const char *kname = m->play_key ? keyname(m->play_key) : "-";
+            mvwprintw(win, i + 2, 2, "%s (%s)%s", m->name, kname,
                       m->active ? " *" : "");
             if (idx == highlight)
                 wattroff(win, A_REVERSE);
@@ -74,7 +77,7 @@ void show_manage_macros(EditorContext *ctx) {
             mvwprintw(win, i + 2, 2, "%*s", win_width - 4, "");
 
         mvwprintw(win, win_height - 2, 2,
-                  "Arrows:move  Enter:select  N:new  R:rename  D:delete  ESC:close");
+                  "Arrows:move  Enter:select  N:new  R:rename  K:key  D:delete  ESC:close");
         wrefresh(win);
 
         ch = wgetch(win);
@@ -122,6 +125,15 @@ void show_manage_macros(EditorContext *ctx) {
                             highlight = macro_count() - 1;
                         macros_save(&app_config);
                     }
+                }
+            }
+        } else if (ch == 'k' || ch == 'K') {
+            if (highlight >= 0 && highlight < count) {
+                Macro *m = macro_at(highlight);
+                if (m) {
+                    int val = select_int(ctx, "Playback Key", m->play_key, win);
+                    m->play_key = val;
+                    macros_save(&app_config);
                 }
             }
         } else if (ch == 'r' || ch == 'R') {

--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -74,7 +74,6 @@ static const Option options[] = {
     {"Symbol color", OPT_COLOR, offsetof(AppConfig, symbol_color), NULL},
     {"Search color", OPT_COLOR, offsetof(AppConfig, search_color), NULL},
     {"Macro record key", OPT_INT, offsetof(AppConfig, macro_record_key), NULL},
-    {"Macro play key", OPT_INT, offsetof(AppConfig, macro_play_key), NULL},
 };
 
 #define FIELD_COUNT ((int)(sizeof(options) / sizeof(options[0])))


### PR DESCRIPTION
## Summary
- add `play_key` to `Macro`
- persist play keys via `macros_save`/`macros_load`
- trigger playback when hitting a macro's `play_key`
- allow editing play keys in Manage Macros dialog
- remove `Macro play key` from the settings dialog

## Testing
- `make -k test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f31ccba188324bf8eb721750bbcf0