### PR TITLE
Add macro playback repeats

### DIFF
--- a/docs/vento.1
+++ b/docs/vento.1
@@ -99,6 +99,9 @@ Start or stop recording a macro
 .B F4
 Play the last recorded macro
 .TP
+.B P (in Manage Macros)
+Play the highlighted macro one or more times after entering a repeat count
+.TP
 .B F6 , F7
 Switch between open files
 .PP

--- a/src/macro.c
+++ b/src/macro.c
@@ -136,21 +136,34 @@ void macro_record_key(Macro *macro, wint_t ch) {
 }
 
 /*
+ * Replay the macro 'count' times. This simply feeds each recorded key
+ * back through the regular input handler so playback behaves the same as
+ * if the user typed the keys manually.
+ */
+void macro_play_times(Macro *macro, EditorContext *ctx, FileState *fs, int count) {
+    if (!macro || macro->recording || count <= 0)
+        return;
+
+    macro_state.playing = true;
+    if (ctx)
+        update_status_bar(ctx, fs);
+
+    for (int n = 0; n < count; ++n) {
+        for (int i = 0; i < macro->length; ++i)
+            handle_regular_mode(ctx, fs, macro->keys[i]);
+    }
+
+    macro_state.playing = false;
+    if (ctx)
+        update_status_bar(ctx, fs);
+}
+
+/*
  * Replay all recorded keys in the macro.  The editor context and
  * file state are used so playback mimics user input.
  */
 void macro_play(Macro *macro, EditorContext *ctx, FileState *fs) {
-    if (!macro || macro->recording)
-        return;
-    macro_state.playing = true;
-    if (ctx)
-        update_status_bar(ctx, fs);
-    for (int i = 0; i < macro->length; ++i) {
-        handle_regular_mode(ctx, fs, macro->keys[i]);
-    }
-    macro_state.playing = false;
-    if (ctx)
-        update_status_bar(ctx, fs);
+    macro_play_times(macro, ctx, fs, 1);
 }
 
 /* Return the number of macros currently stored. */

--- a/src/macro.h
+++ b/src/macro.h
@@ -25,6 +25,7 @@ void macro_delete(const char *name);
 void macro_start(Macro *macro);
 void macro_stop(Macro *macro);
 void macro_record_key(Macro *macro, wint_t ch);
+void macro_play_times(Macro *m, EditorContext *ctx, FileState *fs, int count);
 void macro_play(Macro *macro, EditorContext *ctx, FileState *fs);
 int macro_count(void);
 Macro *macro_at(int index);

--- a/src/ui_macros.c
+++ b/src/ui_macros.c
@@ -77,7 +77,7 @@ void show_manage_macros(EditorContext *ctx) {
             mvwprintw(win, i + 2, 2, "%*s", win_width - 4, "");
 
         mvwprintw(win, win_height - 2, 2,
-                  "Arrows:move  Enter:select  N:new  R:rename  K:key  D:delete  ESC:close");
+                  "Arrows:move  Enter:select  N:new  R:rename  K:key  P:play  D:delete  ESC:close");
         wrefresh(win);
 
         ch = wgetch(win);
@@ -134,6 +134,16 @@ void show_manage_macros(EditorContext *ctx) {
                     int val = select_int(ctx, "Playback Key", m->play_key, win);
                     m->play_key = val;
                     macros_save(&app_config);
+                }
+            }
+        } else if (ch == 'p' || ch == 'P') {
+            if (highlight >= 0 && highlight < count) {
+                Macro *m = macro_at(highlight);
+                if (m) {
+                    int repeat = select_int(ctx, "Repeat Count", 1, win);
+                    macro_play_times(m, ctx, ctx->active_file, repeat);
+                    touchwin(win);
+                    wrefresh(win);
                 }
             }
         } else if (ch == 'r' || ch == 'R') {

--- a/tests/macro_tests.c
+++ b/tests/macro_tests.c
@@ -37,8 +37,8 @@ static char *test_simple_record_play() {
     macro_record_key(m2, L'3');
     macro_stop(m2);
 
-    macro_play(m1, &ctx, fs);
-    macro_play(m2, &ctx, fs);
+    macro_play_times(m1, &ctx, fs, 1);
+    macro_play_times(m2, &ctx, fs, 1);
 
     mu_assert("buffer contains abc123", strcmp(lb_get(&fs->buffer, 0), "abc123") == 0);
 


### PR DESCRIPTION
## Summary
- implement `macro_play_times` for repeating a macro
- update `macro_play` to call the new helper
- allow playing macros from the manage-macros dialog with a repeat count
- document macro repetition in the man page
- adjust unit tests for the new API

## Testing
- `make test` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f3392cdf48324a70142ee53b0c481