### PR TITLE
Dynamic menu width

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -201,12 +201,14 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
 
         int startX = menuPositions[*currentMenu];
         int startY = 1;
-        int boxWidth = 20;
+        int boxWidth = calcMenuWidth(&menus[*currentMenu]);
         int boxHeight = menus[*currentMenu].itemCount + 2;
-        if (startX + boxWidth > COLS || startY + boxHeight > LINES) {
-            inMenu = false;
-            continue;
-        }
+        if (startX + boxWidth > COLS)
+            startX = COLS - boxWidth;
+        if (startX < 0)
+            startX = 0;
+        if (startY + boxHeight > LINES)
+            startY = LINES - boxHeight;
         if (!drawMenu(&menus[*currentMenu], *currentItem, startX, startY)) {
             inMenu = false;
             continue;
@@ -295,12 +297,14 @@ void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *cur
                     }
                     int startX = menuPositions[*currentMenu];
                     int startY = 1;
-                    int boxWidth = 20;
+                    int boxWidth = calcMenuWidth(&menus[*currentMenu]);
                     int boxHeight = menus[*currentMenu].itemCount + 2;
-                    if (startX + boxWidth > COLS || startY + boxHeight > LINES) {
-                        inMenu = false;
-                        break;
-                    }
+                    if (startX + boxWidth > COLS)
+                        startX = COLS - boxWidth;
+                    if (startX < 0)
+                        startX = 0;
+                    if (startY + boxHeight > LINES)
+                        startY = LINES - boxHeight;
 
                     if (ev.x >= startX && ev.x < startX + boxWidth &&
                         ev.y >= startY && ev.y < startY + boxHeight) {

--- a/src/menu.h
+++ b/src/menu.h
@@ -20,6 +20,7 @@ void initializeMenus(EditorContext *ctx);
 void handleMenuNavigation(Menu *menus, int menuCount, int *currentMenu, int *currentItem);
 bool drawMenu(Menu *menu, int currentItem, int startX, int startY);
 void drawMenuBar(Menu *menus, int menuCount);
+int calcMenuWidth(Menu *menu);
 void menuNewFile(EditorContext *ctx);
 void menuLoadFile(EditorContext *ctx);
 void menuSaveFile(EditorContext *ctx);

--- a/src/menu_draw.c
+++ b/src/menu_draw.c
@@ -14,6 +14,21 @@
 #include "syntax.h"
 #include "editor_state.h"
 
+int calcMenuWidth(Menu *menu) {
+    int longest = 0;
+    for (int i = 0; i < menu->itemCount; ++i) {
+        MenuItem *item = &menu->items[i];
+        if (item->separator)
+            continue;
+        int len = (int)strlen(item->label);
+        if (item->shortcut)
+            len += (int)strlen(item->shortcut);
+        if (len > longest)
+            longest = len;
+    }
+    return longest + 3; // account for padding and borders
+}
+
 /*
  * Draw the top menu bar.
  *
@@ -65,13 +80,17 @@ void drawBar(void) {
  * from the global `menuPositions` array populated by drawMenuBar().
  */
 bool drawMenu(Menu *menu, int currentItem, int startX, int startY) {
-    int boxWidth = 20;
+    int boxWidth = calcMenuWidth(menu);
     int boxHeight = menu->itemCount + 2;
 
-    if (startX < 0 || startY < 0 || startX + boxWidth > COLS ||
-        startY + boxHeight > LINES) {
-        return false;
-    }
+    if (startX + boxWidth > COLS)
+        startX = COLS - boxWidth;
+    if (startX < 0)
+        startX = 0;
+    if (startY + boxHeight > LINES)
+        startY = LINES - boxHeight;
+    if (startY < 0)
+        startY = 0;
 
     WINDOW *menuWin = newwin(boxHeight, boxWidth, startY, startX);
     if (menuWin == NULL) {


### PR DESCRIPTION
## Summary
- calculate width needed for dropdown menus
- adjust drawMenu() to shift within screen bounds
- adapt menu navigation to call the new helper

## Testing
- `make`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f39fdae548324afa4005111a7f02b