### PR TITLE
Fix screen refresh on redo

### DIFF
--- a/src/undo.c
+++ b/src/undo.c
@@ -161,6 +161,7 @@ void redo(FileState *fs) {
     werase(text_win);
     box(text_win, 0, 0);
     draw_text_buffer(active_file, text_win);
+    wrefresh(text_win);
     fs->modified = true;
 }
 


### PR DESCRIPTION
## Summary
- ensure redo updates text window

## Testing
- `make`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f40d29fb48324962215fa516e08bf