### PR TITLE
Fix screen refresh after line deletion

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -58,6 +58,7 @@ void delete_current_line(EditorContext *ctx, FileState *fs) {
     werase(ctx->text_win);
     box(ctx->text_win, 0, 0);
     draw_text_buffer(fs, ctx->text_win);
+    wrefresh(ctx->text_win);
     mark_comment_state_dirty(fs);
 }
 


### PR DESCRIPTION
## Summary
- ensure `delete_current_line` refreshes text window immediately

## Testing
- `make`
- `make test` *(fails: glibc invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f4274a1408324a81972d172c2625f