### PR TITLE
Add macro cleanup on exit

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -125,6 +125,7 @@ void cleanup_on_exit(FileManager *fm) {
         return;
     }
     macros_save(&app_config);
+    macros_free_all();
     syntax_cleanup();
     for (int i = 0; i < fm->count; ++i) {
         FileState *fs = fm->files[i];

--- a/src/macro.c
+++ b/src/macro.c
@@ -192,3 +192,21 @@ void macro_rename(Macro *m, const char *new_name) {
     free(m->name);
     m->name = dup;
 }
+
+/*
+ * Free all macros and reset the macro list.
+ */
+void macros_free_all(void) {
+    for (int i = 0; i < macro_list.count; ++i) {
+        Macro *m = macro_list.items[i];
+        if (!m)
+            continue;
+        free(m->name);
+        free(m);
+    }
+    free(macro_list.items);
+    macro_list.items = NULL;
+    macro_list.count = 0;
+    macro_list.capacity = 0;
+    current_macro = NULL;
+}

--- a/src/macro.h
+++ b/src/macro.h
@@ -30,6 +30,7 @@ void macro_play(Macro *macro, EditorContext *ctx, FileState *fs);
 int macro_count(void);
 Macro *macro_at(int index);
 void macro_rename(Macro *m, const char *new_name);
+void macros_free_all(void);
 
 typedef struct {
     bool recording;


### PR DESCRIPTION
## Summary
- free all macros when exiting the editor
- expose `macros_free_all` in header
- release macros during application cleanup

## Testing
- `make`
- `tests/run_tests.sh` *(fails: glibc invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f43115d788324ac247199968dc601