### PR TITLE
Handle getcwd failure in file dialog

### DIFF
--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -135,7 +135,14 @@ static int file_dialog_loop(EditorContext *ctx, char *path, int max_len,
     }
     keypad(win, TRUE);
 
-    getcwd(cwd, sizeof(cwd));
+    if (!getcwd(cwd, sizeof(cwd))) {
+        wclear(win);
+        wrefresh(win);
+        delwin(win);
+        curs_set(1);
+        show_message("Unable to get current directory");
+        return 0;
+    }
 
     while (1) {
         werase(win);


### PR DESCRIPTION
## Summary
- add `getcwd` failure handling in `file_dialog_loop`

## Testing
- `./tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f4429af388324a1d3fe795a543b47