### PR TITLE
Reset macros before reloading

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -445,6 +445,7 @@ void macros_load(AppConfig *cfg) {
         return;
     if (cfg->macros_file[0] == '\0')
         get_macros_path(cfg->macros_file, sizeof(cfg->macros_file));
+    macros_free_all();
     FILE *f = fopen(cfg->macros_file, "r");
     if (!f)
         return;


### PR DESCRIPTION
## Summary
- reset macro list before loading macros

## Testing
- `tests/run_tests.sh` *(fails: invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f487d74e08324bc3a472e43f551fb