### PR TITLE
Fix insert_new_line behavior

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -101,11 +101,6 @@ void insert_new_line(EditorContext *ctx, FileState *fs) {
         fs->cursor_y++;
     }
     redraw();
-    if (fs->cursor_y > 1) {
-        fs->cursor_y--;
-    } else if (fs->start_line > 0) {
-        fs->start_line--;
-    }
 }
 
 void handle_redo_wrapper(FileState *fs, int *cx, int *cy) {

--- a/tests/editor_actions_tests.c
+++ b/tests/editor_actions_tests.c
@@ -1,0 +1,45 @@
+#include "minunit.h"
+#include "files.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_insert_new_line_cursor_stays() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    EditorContext ctx = {0};
+    sync_editor_context(&ctx);
+
+    insert_new_line(&ctx, fs);
+
+    mu_assert("cursor on new line", fs->cursor_y == 2);
+    mu_assert("start_line unchanged", fs->start_line == 0);
+    mu_assert("new line empty", strcmp(lb_get(&fs->buffer, 1), "") == 0);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_insert_new_line_cursor_stays);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -32,3 +32,9 @@ gcc macro_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
     -o macro_tests
 ./macro_tests
+gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -o editor_actions_tests
+./editor_actions_tests


### PR DESCRIPTION
## Summary
- keep cursor on inserted blank line
- add regression test for insert_new_line
- run editor_actions_tests via test script

## Testing
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f4905f004832488c40a63dae0d6be