### PR TITLE
Fix load_next_lines error handling

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -277,18 +277,25 @@ int load_next_lines(FileState *fs, int count) {
         (void)nread;
         if (read_line_into(fs, line) < 0) {
             free(line);
+            if (fs->fp) {
+                fclose(fs->fp);
+                fs->fp = NULL;
+            }
+            fs->file_complete = false;
             return -1;
         }
         loaded++;
+        if (fs->fp)
+            fs->file_pos = ftell(fs->fp);
     }
     if (fs->fp)
         fs->file_pos = ftell(fs->fp);
     free(line);
-    if (feof(fs->fp)) {
+    if (fs->fp && feof(fs->fp)) {
         fclose(fs->fp);
         fs->fp = NULL;
         fs->file_complete = true;
-    } else {
+    } else if (fs->fp) {
         fs->file_complete = false;
     }
     return loaded;


### PR DESCRIPTION
## Summary
- ensure `load_next_lines` closes the file and marks it incomplete when a line fails to load
- keep `file_pos` at the last successfully read position

## Testing
- `make test` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f490f8f888324a5450c36030aa056