### PR TITLE
Fix file loading error handling

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -360,11 +360,19 @@ int load_file_into_buffer(FileState *file_state) {
     file_state->file_complete = false;
     file_state->buffer.count = 0;
     int res = load_next_lines(file_state, INT_MAX);
+    if (res < 0) {
+        if (file_state->fp) {
+            fclose(file_state->fp);
+            file_state->fp = NULL;
+        }
+        file_state->file_complete = false;
+        return -1;
+    }
     file_state->last_scanned_line = 0;
     file_state->last_comment_state = false;
     file_state->in_multiline_comment = false;
     file_state->in_multiline_string = false;
     file_state->string_delim = '\0';
     file_state->nested_mode = 0;
-    return (res >= 0) ? 0 : -1;
+    return 0;
 }


### PR DESCRIPTION
## Summary
- check for errors from `load_next_lines` when loading a file
- close the file handle on failure

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f4aab19bc83249317a0226f0c235e