### PR TITLE
Fix help screen menu shortcut

### DIFF
--- a/src/ui_info.c
+++ b/src/ui_info.c
@@ -56,7 +56,7 @@ void show_help(EditorContext *ctx) {
         "CTRL-PgDn: Move to end of doc",
         "F6: Next file",
         "F7: Previous file",
-        "CTRL-T: Open menus",
+        "CTRL-T/F10: Open menus",
         "Left/Right: Switch menus",
         "Up/Down: Choose item",
         "Enter/Esc: Select/close menu",


### PR DESCRIPTION
## Summary
- update help text to reference CTRL-T/F10 for opening menus

## Testing
- `make`
- `strings obj/ui_info.o | grep "CTRL-T/F10"`
- `strings bin/vento | grep "CTRL-T/F10"`

------
https://chatgpt.com/codex/tasks/task_e_683f578da7cc8324a6e91659b83a37b9