### PR TITLE
Add y/n hint to switch file prompt

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -445,7 +445,7 @@ bool confirm_switch(void) {
     if (!any_file_modified(&file_manager))
         return true;
 
-    int ch = show_message("Unsaved changes. Switch files?");
+    int ch = show_message("Unsaved changes. Switch files? (y/n)");
     if (ch == 'y' || ch == 'Y')
         return true;
     if (ch == 'n' || ch == 'N')


### PR DESCRIPTION
## Summary
- update confirmation prompt when switching files to include `(y/n)`

## Testing
- `make`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f5786e1188324a20e017159d80e28