### PR TITLE
Fix macro state after clearing macros

### DIFF
--- a/src/macro.c
+++ b/src/macro.c
@@ -237,4 +237,6 @@ void macros_free_all(void) {
     macro_list.count = 0;
     macro_list.capacity = 0;
     current_macro = NULL;
+    macro_state.recording = false;
+    macro_state.playing = false;
 }


### PR DESCRIPTION
## Summary
- reset global macro flags when all macros are freed

## Testing
- `make`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f577c2ff083248c1bef4183fd17b2