### PR TITLE
Fix macros_load handling of negative lengths

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -462,11 +462,14 @@ void macros_load(AppConfig *cfg) {
         if (!name || !len_s)
             continue;
         long parsed = strtol(len_s, NULL, 10);
-        int len = (int)parsed;
-        if (len < 0)
+        int len;
+        if (parsed < 0) {
             len = 0;
-        if (len > MACRO_MAX_KEYS)
-            len = MACRO_MAX_KEYS;
+        } else {
+            len = (int)parsed;
+            if (len > MACRO_MAX_KEYS)
+                len = MACRO_MAX_KEYS;
+        }
         Macro *m = macro_get(name);
         if (!m)
             m = macro_create(name);


### PR DESCRIPTION
## Summary
- ensure macros_load ignores negative length entries

## Testing
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f7a0278e88324bbe68423b41756dc