### PR TITLE
Ensure dir handles closed inside loop

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -574,8 +574,8 @@ const char *select_theme(const char *current, WINDOW *parent) {
                 }
                 ++count;
             }
+        closedir(dir);
     }
-    closedir(dir);
 }
 
     if (count == 0) {


### PR DESCRIPTION
## Summary
- fix theme directory cleanup by closing DIR* within the loop

## Testing
- `make`
- `TERM=dumb make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f851f2b208324ae30ab8e309f2b31