### PR TITLE
Fix paste overflow

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -139,10 +139,11 @@ void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
             }
         }
 
-        memmove(&dest[*cursor_x - 1 + len],
-                &dest[*cursor_x - 1],
-                dest_len - (*cursor_x - 1) + 1);
-        memcpy(&dest[*cursor_x - 1], line, len);
+        if (*cursor_x > (int)dest_len + 1)
+            *cursor_x = dest_len + 1;
+        size_t idx = (size_t)(*cursor_x - 1);
+        memmove(&dest[idx + len], &dest[idx], dest_len - idx + 1);
+        memcpy(&dest[idx], line, len);
         *cursor_x += len;
 
         char *new_text = strdup(dest);

--- a/tests/clipboard_tests.c
+++ b/tests/clipboard_tests.c
@@ -1,0 +1,49 @@
+#include "minunit.h"
+#include "files.h"
+#include "clipboard.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_paste_cursor_clamped() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "hello");
+    strncpy(global_clipboard, "world", sizeof(global_clipboard) - 1);
+    global_clipboard[sizeof(global_clipboard) - 1] = '\0';
+
+    int cx = 10; /* beyond end of 'hello' */
+    int cy = 1;
+    paste_clipboard(fs, &cx, &cy);
+
+    mu_assert("pasted at end", strcmp(fs->buffer.lines[0], "helloworld") == 0);
+    mu_assert("cursor at end", cx == (int)strlen("helloworld") + 1);
+    mu_assert("y unchanged", cy == 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_paste_cursor_clamped);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -38,3 +38,9 @@ gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
     -o editor_actions_tests
 ./editor_actions_tests
+gcc clipboard_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -o clipboard_tests
+./clipboard_tests


### PR DESCRIPTION
## Summary
- avoid underflow when pasting beyond end of line
- add coverage for paste with cursor past line end
- run clipboard test with other unit tests

## Testing
- `make test` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f852950b08324a4fd2f3b8864e4c9