### PR TITLE
Fix replace cursor bounds

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -271,7 +271,13 @@ void replace_next_occurrence(FileState *fs, const char *search,
 
     *cursor_y = found_line - fs->start_line + 1;
     const char *found_line_text2 = lb_get(&fs->buffer, found_line);
-    *cursor_x = (found_position - found_line_text2) + strlen(replacement) + 1;
+    int calculated_position = (found_position - found_line_text2) +
+                              strlen(replacement) + 1;
+    int line_len = strlen(lb_get(&fs->buffer, found_line));
+    *cursor_x = calculated_position < line_len + 1 ?
+                    calculated_position : line_len + 1;
+    if (*cursor_x >= fs->line_capacity)
+        *cursor_x = fs->line_capacity - 1;
 
     mvprintw(LINES - 2, 0, "Replaced at Line: %d, Column: %d", *cursor_y + fs->start_line + 1, *cursor_x);
     clrtoeol();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -38,3 +38,9 @@ gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
     -o editor_actions_tests
 ./editor_actions_tests
+gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -o search_replace_tests
+./search_replace_tests

--- a/tests/search_replace_tests.c
+++ b/tests/search_replace_tests.c
@@ -1,0 +1,66 @@
+#include "minunit.h"
+#include "files.h"
+#include "editor.h"
+#include "search.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_replace_next_long() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 16);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abc");
+    fs->buffer.count = 1;
+    fs->cursor_x = 1;
+    fs->cursor_y = 1;
+
+    replace_next_occurrence(fs, "a", "12345678901234567890");
+
+    mu_assert("line truncated", strlen(fs->buffer.lines[0]) == fs->line_capacity - 1);
+    mu_assert("cursor capped", fs->cursor_x == fs->line_capacity - 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_replace_all_long() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 16);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "aa");
+    fs->buffer.count = 1;
+
+    replace_all_occurrences(fs, "a", "12345678901234567890");
+
+    mu_assert("line truncated all", strlen(fs->buffer.lines[0]) == fs->line_capacity - 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_replace_next_long);
+    mu_run_test(test_replace_all_long);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}


### PR DESCRIPTION
## Summary
- clamp cursor position after replace operations
- add test cases for long replacements
- run search/replace tests in the test script

## Testing
- `make test` *(fails: glibc invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f8533b0508324b1491d63ff07055f