### PR TITLE
Fix paste_clipboard NULL free

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -148,7 +148,8 @@ void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
 
         char *new_text = strdup(dest);
         if (!new_text) {
-            free(old_text);
+            if (old_text)
+                free(old_text);
             allocation_failed("strdup failed");
         }
 
@@ -156,7 +157,8 @@ void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
             push(&fs->undo_stack, (Change){ line_idx, old_text, new_text });
         } else {
             push(&fs->undo_stack, (Change){ line_idx, NULL, new_text });
-            free(old_text); /* NULL or unused */
+            if (old_text)
+                free(old_text); /* only free if allocated */
         }
 
         line = strtok(NULL, "\n");

--- a/tests/clipboard_tests.c
+++ b/tests/clipboard_tests.c
@@ -7,6 +7,8 @@
 #include <string.h>
 
 int tests_run = 0;
+extern int strdup_fail_on;
+extern int strdup_call_count;
 
 static char *test_paste_cursor_clamped() {
     initscr();
@@ -32,8 +34,58 @@ static char *test_paste_cursor_clamped() {
     return 0;
 }
 
+static char *test_strdup_failure_old_text() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "hello");
+    strncpy(global_clipboard, "abc", sizeof(global_clipboard) - 1);
+    global_clipboard[sizeof(global_clipboard) - 1] = '\0';
+
+    int cx = 6;
+    int cy = 1;
+    strdup_call_count = 0;
+    strdup_fail_on = 1; /* fail first strdup */
+    paste_clipboard(fs, &cx, &cy);
+    mu_assert("still at line", cy == 1);
+    strdup_fail_on = 0;
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_strdup_failure_new_text() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "hello");
+    strncpy(global_clipboard, "abc", sizeof(global_clipboard) - 1);
+    global_clipboard[sizeof(global_clipboard) - 1] = '\0';
+
+    int cx = 6;
+    int cy = 1;
+    strdup_call_count = 0;
+    strdup_fail_on = 2; /* fail second strdup */
+    paste_clipboard(fs, &cx, &cy);
+    mu_assert("still at line", cy == 1);
+    strdup_fail_on = 0;
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_paste_cursor_clamped);
+    mu_run_test(test_strdup_failure_old_text);
+    mu_run_test(test_strdup_failure_new_text);
     return 0;
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -16,31 +16,31 @@ gcc -c test_stubs.c -I$SRC -o obj_test/test_stubs.o
 gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
-    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -o navigation_tests
 ./navigation_tests
 gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
-    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -o menu_load_tests
 ./menu_load_tests
 
 gcc macro_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
-    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -o macro_tests
 ./macro_tests
 gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
-    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -o editor_actions_tests
 ./editor_actions_tests
 gcc clipboard_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
-    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -o clipboard_tests
 ./clipboard_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -4,11 +4,17 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+char *__real_strdup(const char *);
 
 __attribute__((weak)) FileManager file_manager;
 
 int fm_switch_fail = 0;
 int fm_add_fail = 0;
+
+int strdup_fail_on = 0;
+int strdup_call_count = 0;
 
 
 bool __wrap_confirm_switch(void) { return true; }
@@ -47,4 +53,11 @@ int __wrap_fm_add(FileManager *fm, FileState *fs) {
     fm->capacity = fm->count + 1;
     fm->count++;
     return fm->active_index;
+}
+
+char *__wrap_strdup(const char *s) {
+    strdup_call_count++;
+    if (strdup_fail_on > 0 && strdup_call_count == strdup_fail_on)
+        return NULL;
+    return __real_strdup(s);
 }


### PR DESCRIPTION
## Summary
- avoid freeing NULL in `paste_clipboard`
- add strdup wrapper for tests and cover failure cases
- update run_tests.sh for strdup wrapper

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f86ccd3888324900bba96b2afa95d