### PR TITLE
Fix reverse selection copying

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -62,14 +62,18 @@ void end_selection_mode(FileState *fs) {
 void copy_selection(FileState *fs) {
     int start_x = fs->sel_start_x;
     int end_x = fs->sel_end_x;
-    int start_y, end_y;
+    int start_y = fs->sel_start_y;
+    int end_y = fs->sel_end_y;
 
-    if (fs->sel_start_y < fs->sel_end_y) {
-        start_y = fs->sel_start_y;
-        end_y = fs->sel_end_y;
-    } else {
+    if (start_y > end_y) {
         start_y = fs->sel_end_y;
         end_y = fs->sel_start_y;
+        start_x = fs->sel_end_x;
+        end_x = fs->sel_start_x;
+    } else if (start_y == end_y && start_x > end_x) {
+        int tmp = start_x;
+        start_x = end_x;
+        end_x = tmp;
     }
 
     global_clipboard[0] = '\0';  // Clear clipboard

--- a/tests/clipboard_tests.c
+++ b/tests/clipboard_tests.c
@@ -82,10 +82,63 @@ static char *test_strdup_failure_new_text() {
     return 0;
 }
 
+static char *test_copy_selection_backward_multiline() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abcde");
+    strcpy(fs->buffer.lines[1], "fghij");
+    strcpy(fs->buffer.lines[2], "klmno");
+    fs->buffer.count = 3;
+
+    fs->sel_start_x = 4;
+    fs->sel_start_y = 3;
+    fs->sel_end_x = 2;
+    fs->sel_end_y = 1;
+
+    copy_selection(fs);
+
+    mu_assert("clipboard backward", strcmp(global_clipboard,
+                "bcd\nfghij\nklmno") == 0);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_copy_selection_backward_same_line() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abcdef");
+    fs->buffer.count = 1;
+
+    fs->sel_start_x = 6;
+    fs->sel_start_y = 1;
+    fs->sel_end_x = 3;
+    fs->sel_end_y = 1;
+
+    copy_selection(fs);
+
+    mu_assert("clipboard same line", strcmp(global_clipboard, "cde") == 0);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_paste_cursor_clamped);
     mu_run_test(test_strdup_failure_old_text);
     mu_run_test(test_strdup_failure_new_text);
+    mu_run_test(test_copy_selection_backward_multiline);
+    mu_run_test(test_copy_selection_backward_same_line);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- handle reversed selections in `copy_selection`
- test backward selections including same-line reverse

## Testing
- `tests/run_tests.sh` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d6169dc83248b3018403f25988d