### PR TITLE
Fix cursor clamp after replace

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -271,7 +271,12 @@ void replace_next_occurrence(FileState *fs, const char *search,
 
     *cursor_y = found_line - fs->start_line + 1;
     const char *found_line_text2 = lb_get(&fs->buffer, found_line);
-    *cursor_x = (found_position - found_line_text2) + strlen(replacement) + 1;
+    int desired_x = (found_position - found_line_text2) + strlen(replacement) + 1;
+    int line_len = strlen(found_line_text2);
+    if (desired_x > line_len + 1)
+        *cursor_x = line_len + 1;
+    else
+        *cursor_x = desired_x;
 
     mvprintw(LINES - 2, 0, "Replaced at Line: %d, Column: %d", *cursor_y + fs->start_line + 1, *cursor_x);
     clrtoeol();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -50,3 +50,9 @@ gcc theme_fd_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw 
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup -Wl,--wrap=wgetch \
     -o theme_fd_tests
 ./theme_fd_tests
+gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -o search_replace_tests
+./search_replace_tests

--- a/tests/search_replace_tests.c
+++ b/tests/search_replace_tests.c
@@ -1,0 +1,46 @@
+#include "minunit.h"
+#include "search.h"
+#include "files.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_replace_long_near_end() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 10);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abcdefgh");
+    fs->buffer.count = 1;
+
+    replace_next_occurrence(fs, "gh", "0123456789ABCDE");
+
+    int line_len = strlen(lb_get(&fs->buffer, 0));
+    mu_assert("truncated line", strcmp(lb_get(&fs->buffer, 0), "abcdef012") == 0);
+    mu_assert("cursor clamped", fs->cursor_x == line_len + 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_replace_long_near_end);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}


### PR DESCRIPTION
## Summary
- clamp cursor within line capacity when replacing text
- compile new search_replace_tests in test runner
- add regression test for replacing near line end

## Testing
- `TERM=xterm ./tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f8ece5a288324bf0abc317f053224