### PR TITLE
Fix dialog position after resize

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -91,8 +91,14 @@ int dialog_prompt(WINDOW *win, int y, int x, char *buf, size_t len) {
             getmaxyx(win, h, w);
             int win_y = (LINES - h) / 2;
             int win_x = (COLS - w) / 2;
+            if (win_y < 0)
+                win_y = 0;
+            if (win_y > LINES - h)
+                win_y = LINES - h;
             if (win_x < 0)
                 win_x = 0;
+            if (win_x > COLS - w)
+                win_x = COLS - w;
             mvwin(win, win_y, win_x);
             box(win, 0, 0);
             mvwprintw(win, y, x, "%s", buf);


### PR DESCRIPTION
## Summary
- clamp dialog position within screen bounds when resizing

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f92b054ac8324955427a7f4ef104e