### PR TITLE
Handle dialog popup creation failure

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -23,8 +23,10 @@
 WINDOW *dialog_open(int height, int width, const char *title) {
     curs_set(0);
     WINDOW *win = create_popup_window(height, width, NULL);
-    if (!win)
+    if (!win) {
+        curs_set(1);
         return NULL;
+    }
     keypad(win, TRUE);
     wbkgd(win, enable_color ? COLOR_PAIR(SYNTAX_BG) : A_NORMAL);
     wrefresh(stdscr);

--- a/tests/dialog_tests.c
+++ b/tests/dialog_tests.c
@@ -1,0 +1,37 @@
+#include "minunit.h"
+#include "dialog.h"
+#include <ncurses.h>
+
+int tests_run = 0;
+extern int create_popup_fail;
+extern int last_curs_set;
+
+static char *test_dialog_open_failure() {
+    initscr();
+    last_curs_set = -2;
+    create_popup_fail = 1;
+
+    WINDOW *win = dialog_open(5, 10, "Fail");
+
+    mu_assert("window null", win == NULL);
+    mu_assert("cursor restored", last_curs_set == 1);
+
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_dialog_open_failure);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,12 +17,14 @@ gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurses
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o navigation_tests
 ./navigation_tests
 gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o menu_load_tests
 ./menu_load_tests
 
@@ -30,29 +32,41 @@ gcc macro_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o macro_tests
 ./macro_tests
 gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o editor_actions_tests
 ./editor_actions_tests
 gcc clipboard_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o clipboard_tests
 ./clipboard_tests
 gcc theme_fd_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup -Wl,--wrap=wgetch \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o theme_fd_tests
 ./theme_fd_tests
 gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o search_replace_tests
 ./search_replace_tests
+gcc dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -o dialog_tests
+./dialog_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -5,8 +5,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ncurses.h>
 
 char *__real_strdup(const char *);
+WINDOW *__real_create_popup_window(int, int, WINDOW *);
 
 __attribute__((weak)) FileManager file_manager;
 
@@ -15,6 +17,9 @@ int fm_add_fail = 0;
 
 int strdup_fail_on = 0;
 int strdup_call_count = 0;
+
+int create_popup_fail = 0;
+int last_curs_set = -2;
 
 
 bool __wrap_confirm_switch(void) { return true; }
@@ -60,6 +65,19 @@ char *__wrap_strdup(const char *s) {
     if (strdup_fail_on > 0 && strdup_call_count == strdup_fail_on)
         return NULL;
     return __real_strdup(s);
+}
+
+WINDOW *__wrap_create_popup_window(int h, int w, WINDOW *p) {
+    if (create_popup_fail) {
+        create_popup_fail = 0;
+        return NULL;
+    }
+    return __real_create_popup_window(h, w, p);
+}
+
+int __wrap_curs_set(int vis) {
+    last_curs_set = vis;
+    return 0; /* avoid calling real function */
 }
 
 int __wrap_wgetch(WINDOW *win) {


### PR DESCRIPTION
## Summary
- restore cursor visibility if `dialog_open` fails
- simulate window-creation failure in tests
- check that cursor is restored

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f936c855c8324b2262941294de40d