### PR TITLE
Fix goto dialog int overflow

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -7,6 +7,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
 #include "config.h"
 #include "editor.h"
 #include "ui.h"
@@ -146,7 +147,7 @@ int show_goto_dialog(EditorContext *ctx, int *line_number) {
     char *endptr;
     long val = strtol(buf, &endptr, 10);
 
-    if (*endptr != '\0' || val < 1) {
+    if (*endptr != '\0' || val < 1 || val > INT_MAX) {
         return 0;
     }
 

--- a/tests/goto_dialog_tests.c
+++ b/tests/goto_dialog_tests.c
@@ -1,0 +1,53 @@
+#include "minunit.h"
+#include "ui.h"
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+
+static const char *dialog_input = NULL;
+
+void __wrap_create_dialog(EditorContext *ctx, const char *message, char *output,
+                          int max_input_len) {
+    (void)ctx; (void)message;
+    if (!output)
+        return;
+    if (dialog_input) {
+        strncpy(output, dialog_input, max_input_len - 1);
+        output[max_input_len - 1] = '\0';
+    } else {
+        output[0] = '\0';
+    }
+}
+
+int tests_run = 0;
+
+static char *test_reject_int_overflow() {
+    initscr();
+    EditorContext ctx = {0};
+    char buf[64];
+    long long big = (long long)INT_MAX + 1LL;
+    snprintf(buf, sizeof(buf), "%lld", big);
+    dialog_input = buf;
+    int line = 0;
+    int res = show_goto_dialog(&ctx, &line);
+    dialog_input = NULL;
+    endwin();
+    mu_assert("overflow rejected", res == 0);
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_reject_int_overflow);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -70,3 +70,10 @@ gcc dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
     -o dialog_tests
 ./dialog_tests
+gcc goto_dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=create_dialog \
+    -o goto_dialog_tests
+./goto_dialog_tests


### PR DESCRIPTION
## Summary
- reject goto line inputs larger than INT_MAX
- add a test for large line numbers
- run new test in test runner

## Testing
- `bash tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f9634b28483249dd11be6565c3cc4