### PR TITLE
Clamp help text column in status bar

### DIFF
--- a/src/editor_actions.c
+++ b/src/editor_actions.c
@@ -317,7 +317,9 @@ void update_status_bar(EditorContext *ctx, FileState *fs) {
     clrtoeol();
     int actual_line_number = fs ? (fs->cursor_y + fs->start_line) : 0;
     mvprintw(LINES - 1, 0, "Lines: %d  Current Line: %d  Column: %d", fs ? fs->buffer.count : 0, actual_line_number, fs ? fs->cursor_x : 0);
-    mvprintw(LINES - 1, COLS - 15, "CTRL-H - Help");
+    int help_col = COLS - 15;
+    if (help_col < 0) help_col = 0;
+    mvprintw(LINES - 1, help_col, "CTRL-H - Help");
     wnoutrefresh(stdscr);
 }
 

--- a/tests/help_text_tests.c
+++ b/tests/help_text_tests.c
@@ -1,0 +1,40 @@
+#include "minunit.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+
+extern int last_mvprintw_x;
+
+int tests_run = 0;
+
+static char *test_help_position_non_negative() {
+    initscr();
+    int lines = LINES;
+    resizeterm(lines, 10);
+    EditorContext ctx = {0};
+    file_manager.count = 1;
+    file_manager.active_index = 0;
+    sync_editor_context(&ctx);
+    last_mvprintw_x = -1;
+    update_status_bar(&ctx, NULL);
+    endwin();
+    mu_assert("help col non-negative", last_mvprintw_x >= 0);
+    mu_assert("help col zero when small", last_mvprintw_x == 0);
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_help_position_non_negative);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -77,3 +77,11 @@ gcc goto_dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurse
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=create_dialog \
     -o goto_dialog_tests
 ./goto_dialog_tests
+gcc help_text_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=create_dialog \
+    -Wl,--wrap=mvprintw \
+    -o help_text_tests
+./help_text_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -84,3 +84,12 @@ int __wrap_wgetch(WINDOW *win) {
     (void)win;
     return 27; /* ESC to exit immediately */
 }
+
+int last_mvprintw_y = -1;
+int last_mvprintw_x = -1;
+int __wrap_mvprintw(int y, int x, const char *fmt, ...) {
+    last_mvprintw_y = y;
+    last_mvprintw_x = x;
+    (void)fmt;
+    return 0; /* suppress real output */
+}


### PR DESCRIPTION
## Summary
- avoid negative column for status bar help text by clamping
- wrap `mvprintw` in tests
- add regression test for small terminal width

## Testing
- `./tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f97cd3468832486ffc0368eda0163