### PR TITLE
Clamp dialog position on resize

### DIFF
--- a/src/ui_file_dialog.c
+++ b/src/ui_file_dialog.c
@@ -197,6 +197,10 @@ static int file_dialog_loop(EditorContext *ctx, char *path, int max_len,
             resizeterm(0, 0);
             win_height = LINES - 4;
             win_width = COLS - 4;
+            if (win_height > LINES - 2)
+                win_height = LINES - 2;
+            if (win_height < 2)
+                win_height = 2;
             if (win_width > COLS - 2)
                 win_width = COLS - 2;
             if (win_width < 2)
@@ -204,8 +208,14 @@ static int file_dialog_loop(EditorContext *ctx, char *path, int max_len,
             wresize(win, win_height, win_width);
             int win_y = (LINES - win_height) / 2;
             int win_x = (COLS - win_width) / 2;
+            if (win_y < 0)
+                win_y = 0;
+            if (win_y > LINES - win_height)
+                win_y = LINES - win_height;
             if (win_x < 0)
                 win_x = 0;
+            if (win_x > COLS - win_width)
+                win_x = COLS - win_width;
             mvwin(win, win_y, win_x);
             werase(win);
             touchwin(win);

--- a/tests/file_dialog_resize_tests.c
+++ b/tests/file_dialog_resize_tests.c
@@ -1,0 +1,44 @@
+#include "minunit.h"
+#include "ui.h"
+#include "editor_state.h"
+#include <ncurses.h>
+
+extern int last_mvwin_y;
+extern int last_mvwin_x;
+extern int last_wresize_h;
+extern int last_wresize_w;
+void set_wgetch_sequence(const int *keys, int count);
+
+int tests_run = 0;
+
+static char *test_dialog_resize_clamped() {
+    initscr();
+    resizeterm(3, 7);
+    const int keys[] = { KEY_RESIZE, 27 };
+    set_wgetch_sequence(keys, 2);
+    EditorContext ctx = {0};
+    char path[1];
+    show_open_file_dialog(&ctx, path, sizeof(path));
+    mu_assert("x non-negative", last_mvwin_x >= 0);
+    mu_assert("y non-negative", last_mvwin_y >= 0);
+    mu_assert("x within", last_mvwin_x <= COLS - last_wresize_w);
+    mu_assert("y within", last_mvwin_y <= LINES - last_wresize_h);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_dialog_resize_clamped);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,14 +17,14 @@ gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurses
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o navigation_tests
 ./navigation_tests
 gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o menu_load_tests
 ./menu_load_tests
 
@@ -32,42 +32,42 @@ gcc macro_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o macro_tests
 ./macro_tests
 gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o editor_actions_tests
 ./editor_actions_tests
 gcc clipboard_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o clipboard_tests
 ./clipboard_tests
 gcc theme_fd_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup -Wl,--wrap=wgetch \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o theme_fd_tests
 ./theme_fd_tests
 gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o search_replace_tests
 ./search_replace_tests
 gcc dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
-    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o dialog_tests
 ./dialog_tests
 gcc goto_dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -85,3 +85,10 @@ gcc help_text_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw
     -Wl,--wrap=mvprintw \
     -o help_text_tests
 ./help_text_tests
+gcc file_dialog_resize_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -o file_dialog_resize_tests
+./file_dialog_resize_tests


### PR DESCRIPTION
## Summary
- keep file dialog centered inside terminal after resize
- track mvwin and wresize calls in tests
- add resize regression test for file dialog

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b0dfc9c83249da8d27a0b7b807d