### PR TITLE
Improve undo/redo error handling

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -92,3 +92,10 @@ gcc file_dialog_resize_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o file_dialog_resize_tests
 ./file_dialog_resize_tests
+gcc undo_redo_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -o undo_redo_tests
+./undo_redo_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -17,6 +17,7 @@ int fm_add_fail = 0;
 
 int strdup_fail_on = 0;
 int strdup_call_count = 0;
+int allocation_fail_count = 0;
 
 int create_popup_fail = 0;
 int last_curs_set = -2;
@@ -26,7 +27,10 @@ bool __wrap_confirm_switch(void) { return true; }
 void __wrap_clamp_scroll_x(FileState *fs) { (void)fs; }
 void __wrap_redraw(void) {}
 bool confirm_quit(void) { return true; }
-void __wrap_allocation_failed(const char *msg) { fprintf(stderr, "alloc fail: %s\n", msg ? msg : ""); }
+void __wrap_allocation_failed(const char *msg) {
+    allocation_fail_count++;
+    fprintf(stderr, "alloc fail: %s\n", msg ? msg : "");
+}
 void __wrap_draw_text_buffer(FileState *fs, WINDOW *win) { (void)fs; (void)win; }
 int last_status_count = -1;
 void __wrap_update_status_bar(EditorContext *ctx, FileState *fs) {

--- a/tests/undo_redo_tests.c
+++ b/tests/undo_redo_tests.c
@@ -1,0 +1,83 @@
+#include "minunit.h"
+#include "files.h"
+#include "undo.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+extern int strdup_fail_on;
+extern int strdup_call_count;
+extern int allocation_fail_count;
+
+static char *test_undo_strdup_failure() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abc");
+    fs->buffer.count = 1;
+    char *new_text = strdup("abc");
+    mu_assert("allocated", new_text != NULL);
+    push(&fs->undo_stack, (Change){0, NULL, new_text});
+
+    strdup_call_count = 0;
+    strdup_fail_on = 1;
+    allocation_fail_count = 0;
+    undo(fs);
+    strdup_fail_on = 0;
+
+    mu_assert("allocation_failed called", allocation_fail_count == 1);
+    mu_assert("redo stack empty", fs->redo_stack == NULL);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_redo_strdup_failure() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abc");
+    fs->buffer.count = 1;
+    char *old_text = strdup("abc");
+    mu_assert("allocated", old_text != NULL);
+    push(&fs->redo_stack, (Change){0, old_text, NULL});
+
+    strdup_call_count = 0;
+    strdup_fail_on = 1;
+    allocation_fail_count = 0;
+    redo(fs);
+    strdup_fail_on = 0;
+
+    mu_assert("allocation_failed called", allocation_fail_count == 1);
+    mu_assert("undo stack empty", fs->undo_stack == NULL);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_undo_strdup_failure);
+    mu_run_test(test_redo_strdup_failure);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}


### PR DESCRIPTION
## Summary
- check strdup allocation in `undo()` and `redo()`
- track allocation failure in tests
- add tests for undo/redo allocation failures

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_683f9fbe7b688324993ef3037ec3f703