### PR TITLE
Document VENTO_MACROS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ dialog with changes, the updated configuration is automatically saved back to
 You can override the location of this file by setting the `VENTO_CONFIG`
 environment variable to an alternate path.
 
+- Set `VENTO_MACROS` to override the default macros file (`~/.ventomacros`).
+  For example:
+
+  ```sh
+  VENTO_MACROS=$HOME/custom.macros vento
+  ```
+
 This file is created automatically with default values if it does not exist. Unknown keys are ignored when the file is parsed. You can also change these options interactively using the **Settings** dialog. Open it from *File → Settings* (press `CTRL-T` to open the menu) and navigate with the arrow keys. The recognized keys are:
 - `background_color`
 - `text_color`


### PR DESCRIPTION
## Summary
- document the `VENTO_MACROS` environment variable in the configuration section
- show how to set it to use a custom macros file

## Testing
- `TERM=dumb tests/run_tests.sh` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6841ed4058488324b722cca78d9c77fe