### PR TITLE
Add path_utils header

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -6,10 +6,7 @@
 #include <pwd.h>
 #include <dirent.h>
 #include <unistd.h>
-#include <limits.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "path_utils.h"
 #include "editor.h"
 #include "config.h"
 #include "editor_state.h"

--- a/src/config.h
+++ b/src/config.h
@@ -3,10 +3,7 @@
 
 #define VERSION "0.1.3"
 
-#include <limits.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "path_utils.h"
 
 /* Directory containing installed color themes. Can be overridden at compile
  * time by defining THEME_DIR. Defaults to "themes" which resolves to the

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -10,10 +10,7 @@
 #include "file_manager.h"
 #include "ui_common.h"
 #include "editor_state.h"
-#include <limits.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "path_utils.h"
 #include <stdlib.h>
 char *realpath(const char *path, char *resolved_path);
 

--- a/src/files.c
+++ b/src/files.c
@@ -18,10 +18,7 @@
 #include "editor_state.h"
 #include "line_buffer.h"
 #include "undo.h"
-#include <limits.h>
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
+#include "path_utils.h"
 #include <stddef.h>
 char *realpath(const char *path, char *resolved_path);
 /**

--- a/src/path_utils.h
+++ b/src/path_utils.h
@@ -1,0 +1,7 @@
+#ifndef VENTO_PATH_UTILS_H
+#define VENTO_PATH_UTILS_H
+#include <limits.h>
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+#endif


### PR DESCRIPTION
## Summary
- create centralized `path_utils.h` providing `PATH_MAX`
- use the new header in config, file handling modules

## Testing
- `make`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6841eeccc0fc8324ae3e6e1d7fed0028