### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libncursesw5-dev
+      - name: Build
+        run: make
+      - name: Test
+        run: make test


### PR DESCRIPTION
## Summary
- add CI pipeline for building and running tests

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841f41587988324aa58b6876fb4fd93