### PR TITLE
Improve fopen error message

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -12,6 +12,7 @@
 #include "editor_state.h"
 #include "path_utils.h"
 #include <stdlib.h>
+#include <errno.h>
 char *realpath(const char *path, char *resolved_path);
 
 /*
@@ -57,7 +58,8 @@ void save_file(EditorContext *ctx, FileState *fs) {
             fs->modified = false;
             mvprintw(LINES - 2, 2, "File saved as %s", fs->filename);
         } else {
-            mvprintw(LINES - 2, 2, "Error saving file!");
+            int err = errno;
+            mvprintw(LINES - 2, 2, "Error saving file: %s", strerror(err));
         }
         clrtoeol();
         refresh();
@@ -101,7 +103,8 @@ void save_file_as(EditorContext *ctx, FileState *fs) {
         fs->modified = false;
         mvprintw(LINES - 2, 2, "File saved as %s", fs->filename);
     } else {
-        mvprintw(LINES - 2, 2, "Error saving file!");
+        int err = errno;
+        mvprintw(LINES - 2, 2, "Error saving file: %s", strerror(err));
     }
 
     clrtoeol();
@@ -193,7 +196,8 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     fs->fp = fopen(filename_canon, "r");
     fs->file_pos = 0;
     if (!fs->fp) {
-        mvprintw(LINES - 2, 2, "Error loading file!");
+        int err = errno;
+        mvprintw(LINES - 2, 2, "Error loading file: %s", strerror(err));
         refresh();
         getch();
         mvprintw(LINES - 2, 2, "                            ");

--- a/tests/menu_load_tests.c
+++ b/tests/menu_load_tests.c
@@ -5,8 +5,11 @@
 #include "editor_state.h"
 #include <ncurses.h>
 #include <stdio.h>
+#include <string.h>
+#include <errno.h>
 
 extern int last_status_count;
+extern char last_mvprintw_buf[];
 
 int tests_run = 0;
 
@@ -48,8 +51,24 @@ static char *test_menu_load_and_navigation() {
     return 0;
 }
 
+static char *test_load_error_message() {
+    initscr();
+    fm_init(&file_manager);
+    last_mvprintw_buf[0] = '\0';
+    int res = load_file(NULL, NULL, "/no/such/file");
+    mu_assert("load failed", res < 0);
+    mu_assert("error text", strstr(last_mvprintw_buf, strerror(ENOENT)) != NULL);
+    if (file_manager.count > 0) {
+        for (int i = file_manager.count - 1; i >= 0; i--)
+            fm_close(&file_manager, i);
+    }
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_menu_load_and_navigation);
+    mu_run_test(test_load_error_message);
     return 0;
 }
 

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 #include <ncurses.h>
 
 char *__real_strdup(const char *);
@@ -123,9 +124,13 @@ int __wrap_wresize(WINDOW *win, int h, int w) {
 
 int last_mvprintw_y = -1;
 int last_mvprintw_x = -1;
+char last_mvprintw_buf[256] = "";
 int __wrap_mvprintw(int y, int x, const char *fmt, ...) {
     last_mvprintw_y = y;
     last_mvprintw_x = x;
-    (void)fmt;
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(last_mvprintw_buf, sizeof(last_mvprintw_buf), fmt, ap);
+    va_end(ap);
     return 0; /* suppress real output */
 }


### PR DESCRIPTION
## Summary
- print errno messages in save_file, save_file_as, and load_file
- capture mvprintw messages during tests
- test for error text when load_file fails

## Testing
- `bash tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6845f365dd3483248474449f9455b557