### PR TITLE
Add portable realpath wrapper

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -13,7 +13,6 @@
 #include "path_utils.h"
 #include <stdlib.h>
 #include <errno.h>
-char *realpath(const char *path, char *resolved_path);
 
 /*
  * file_ops.c

--- a/src/files.c
+++ b/src/files.c
@@ -20,7 +20,6 @@
 #include "undo.h"
 #include "path_utils.h"
 #include <stddef.h>
-char *realpath(const char *path, char *resolved_path);
 /**
  * canonicalize_path - resolve PATH to an absolute form.
  * @path: input file path, may be NULL or empty.
@@ -37,7 +36,7 @@ char *realpath(const char *path, char *resolved_path);
 
 void canonicalize_path(const char *path, char *out, size_t out_size) {
     char resolved[PATH_MAX];
-    if (path && path[0] != '\0' && realpath(path, resolved)) {
+    if (path && path[0] != '\0' && vento_realpath(path, resolved)) {
         strncpy(out, resolved, out_size - 1);
     } else {
         if (!path)

--- a/src/path_utils.c
+++ b/src/path_utils.c
@@ -1,0 +1,17 @@
+#include "path_utils.h"
+#include <string.h>
+#if defined(_POSIX_VERSION) && !defined(_WIN32)
+#include <stdlib.h>
+#endif
+
+char *vento_realpath(const char *path, char *resolved_path) {
+#if defined(_POSIX_VERSION) && !defined(_WIN32)
+    return realpath(path, resolved_path);
+#else
+    if (!path || !resolved_path)
+        return NULL;
+    strncpy(resolved_path, path, PATH_MAX - 1);
+    resolved_path[PATH_MAX - 1] = '\0';
+    return resolved_path;
+#endif
+}

--- a/src/path_utils.h
+++ b/src/path_utils.h
@@ -1,7 +1,15 @@
 #ifndef VENTO_PATH_UTILS_H
 #define VENTO_PATH_UTILS_H
+
 #include <limits.h>
+#if defined(_POSIX_VERSION) && !defined(_WIN32)
+#include <stdlib.h>
+#endif
+
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
+
+char *vento_realpath(const char *path, char *resolved_path);
+
 #endif


### PR DESCRIPTION
## Summary
- add `path_utils.c` with a fallback `vento_realpath`
- expose `vento_realpath` and PATH_MAX fallback in `path_utils.h`
- use `vento_realpath` in `canonicalize_path`
- remove old `realpath` prototype from `file_ops.c`

## Testing
- `make -j4`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6845f484b70083249d2d00464c2f4dee