### PR TITLE
Improve load_file error messages

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -210,7 +210,8 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     fs->file_complete = false;
     fs->buffer.count = 0;
     if (load_next_lines(fs, INITIAL_LOAD_LINES) < 0) {
-        mvprintw(LINES - 2, 2, "Error loading file!");
+        int err = errno;
+        mvprintw(LINES - 2, 2, "Error loading file: %s", strerror(err));
         refresh();
         getch();
         mvprintw(LINES - 2, 2, "                            ");
@@ -252,7 +253,8 @@ int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
 
     int idx = fm_add(&file_manager, fs);
     if (idx < 0) {
-        mvprintw(LINES - 2, 2, "Error loading file!");
+        int err = errno;
+        mvprintw(LINES - 2, 2, "Error loading file: %s", strerror(err));
         refresh();
         getch();
         mvprintw(LINES - 2, 2, "                            ");

--- a/src/files.c
+++ b/src/files.c
@@ -20,6 +20,7 @@
 #include "undo.h"
 #include "path_utils.h"
 #include <stddef.h>
+#include <errno.h>
 /**
  * canonicalize_path - resolve PATH to an absolute form.
  * @path: input file path, may be NULL or empty.
@@ -272,11 +273,13 @@ int load_next_lines(FileState *fs, int count) {
     while (loaded < count && (nread = getline(&line, &len, fs->fp)) != -1) {
         (void)nread;
         if (read_line_into(fs, line) < 0) {
+            int err = errno; /* preserve errno across cleanup */
             free(line);
             if (fs->fp) {
                 fclose(fs->fp);
                 fs->fp = NULL;
             }
+            errno = err;
             fs->file_complete = false;
             return -1;
         }

--- a/tests/menu_load_tests.c
+++ b/tests/menu_load_tests.c
@@ -10,6 +10,7 @@
 
 extern int last_status_count;
 extern char last_mvprintw_buf[];
+extern int fm_add_fail;
 
 int tests_run = 0;
 
@@ -66,9 +67,28 @@ static char *test_load_error_message() {
     return 0;
 }
 
+static char *test_load_add_error_message() {
+    initscr();
+    fm_init(&file_manager);
+    last_mvprintw_buf[0] = '\0';
+    fm_add_fail = 1;
+    errno = ENOMEM;
+    int res = load_file(NULL, NULL, "../README.md");
+    fm_add_fail = 0;
+    mu_assert("load add failed", res < 0);
+    mu_assert("error text add", strstr(last_mvprintw_buf, strerror(ENOMEM)) != NULL);
+    if (file_manager.count > 0) {
+        for (int i = file_manager.count - 1; i >= 0; i--)
+            fm_close(&file_manager, i);
+    }
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_menu_load_and_navigation);
     mu_run_test(test_load_error_message);
+    mu_run_test(test_load_add_error_message);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- show errno description when `load_next_lines` or `fm_add` fail
- keep errno intact in `load_next_lines`
- test add failure message

## Testing
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68460732c0948324a3da34462d6cedf7