### PR TITLE
Add JSON syntax highlighting and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ obj/
 obj_test/
 *.o
 *.json
+!tests/sample.json
 # Test binaries
 /test_*
 tests/*_tests

--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -475,6 +475,8 @@ int set_syntax_mode(const char *filename) {
             return JS_SYNTAX;
         } else if (strcmp(ext, ".css") == 0) {
             return CSS_SYNTAX;
+        } else if (strcmp(ext, ".json") == 0) {
+            return JSON_SYNTAX;
         }
     }
     FILE *fp = fopen(filename, "r");

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -42,7 +42,7 @@ void apply_syntax_highlighting(FileState *fs, WINDOW *win, const char *line, int
  * called during application shutdown to release regex resources.
  */
 void syntax_cleanup(void) {
-    for (int mode = 0; mode < 8; mode++) {
+    for (int mode = 0; mode < 9; mode++) {
         const SyntaxDef *def = syntax_get(mode);
         if (def)
             free_regex_set(def->patterns, def->count);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -12,6 +12,7 @@
 #define JS_SYNTAX 5
 #define CSS_SYNTAX 6
 #define SHELL_SYNTAX 7
+#define JSON_SYNTAX 8
 
 typedef enum {
     SYNTAX_BG = 1,

--- a/src/syntax_registry.c
+++ b/src/syntax_registry.c
@@ -10,7 +10,7 @@
 #include "files.h"
 #include <string.h>
 
-#define SYNTAX_MODE_COUNT 8
+#define SYNTAX_MODE_COUNT 9
 
 /*
  * Table of available syntax definitions indexed by syntax mode.  Entries are
@@ -140,6 +140,15 @@ static SyntaxRegex SHELL_PATTERNS[] = {
 };
 static const SyntaxDef SHELL_DEF = { ".sh", SHELL_PATTERNS, sizeof(SHELL_PATTERNS)/sizeof(SHELL_PATTERNS[0]) };
 
+#define JSON_KEYWORDS_PATTERN "^(true|false|null)\\b"
+static SyntaxRegex JSON_PATTERNS[] = {
+    { .pattern = "^\"([^\"\\]|\\.)*\"", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
+    { .pattern = "^-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
+    { .pattern = JSON_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
+    { .pattern = "^[{}\[\]:,]", .attr = COLOR_PAIR(SYNTAX_SYMBOL) | A_BOLD },
+};
+static const SyntaxDef JSON_DEF = { ".json", JSON_PATTERNS, sizeof(JSON_PATTERNS)/sizeof(JSON_PATTERNS[0]) };
+
 __attribute__((constructor))
 static void init_registry(void) {
     syntax_register(C_SYNTAX, &C_DEF);
@@ -148,5 +157,6 @@ static void init_registry(void) {
     syntax_register(JS_SYNTAX, &JS_DEF);
     syntax_register(CSS_SYNTAX, &CSS_DEF);
     syntax_register(SHELL_SYNTAX, &SHELL_DEF);
+    syntax_register(JSON_SYNTAX, &JSON_DEF);
 }
 

--- a/tests/json_highlight_tests.c
+++ b/tests/json_highlight_tests.c
@@ -1,0 +1,59 @@
+#include "minunit.h"
+#include "files.h"
+#include "syntax.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_json_highlighting_runs() {
+    initscr();
+    FileState *fs = initialize_file_state("tests/sample.json", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+    fs->syntax_mode = JSON_SYNTAX;
+
+    /* Load sample file lines */
+    const char *lines[] = {
+        "{",
+        "  \"num\": 123,",
+        "  \"flag\": true,",
+        "  \"vals\": [null, false]",
+        "}"
+    };
+    int line_count = 5;
+    for (int i = 0; i < line_count; i++) {
+        strcpy(fs->buffer.lines[i], lines[i]);
+    }
+    fs->buffer.count = line_count;
+
+    for (int i = 0; i < fs->buffer.count; i++) {
+        apply_syntax_highlighting(fs, fs->text_win, fs->buffer.lines[i], i + 1);
+    }
+
+    const SyntaxDef *def = syntax_get(JSON_SYNTAX);
+    mu_assert("patterns compiled", def && def->patterns[0].compiled);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_json_highlighting_runs);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -99,3 +99,10 @@ gcc undo_redo_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o undo_redo_tests
 ./undo_redo_tests
+gcc json_highlight_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -o json_highlight_tests
+./json_highlight_tests

--- a/tests/sample.json
+++ b/tests/sample.json
@@ -1,0 +1,5 @@
+{
+  "num": 123,
+  "flag": true,
+  "vals": [null, false]
+}


### PR DESCRIPTION
## Summary
- support JSON syntax highlighting
- recognize JSON extension in file ops
- include unit test for JSON highlighting
- allow tests/sample.json in repo

## Testing
- `./tests/run_tests.sh` *(fails: glibc invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68460924260c8324bdfcd2314ea76a07