### PR TITLE
Document VENTO_MACROS env var

### DIFF
--- a/docs/vento.1
+++ b/docs/vento.1
@@ -55,6 +55,9 @@ Path to the configuration file. Overrides \fI~/.ventorc\fP.
 .TP
 .B VENTO_THEME_DIR
 Directory to search for \fI.theme\fP files. Overrides \fBTHEME_DIR\fP, which defaults to \fBthemes\fP.
+.TP
+.B VENTO_MACROS
+Path to the macros file. Overrides the default macros file (\fI~/.ventomacros\fP).
 .SH KEYBOARD SHORTCUTS
 .TP
 .B CTRL-S


### PR DESCRIPTION
## Summary
- document the `VENTO_MACROS` environment variable in the man page

## Testing
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68460b387d4883249ea6ae4412ba141c