### PR TITLE
Add macro_play_key option

### DIFF
--- a/src/ui_settings.c
+++ b/src/ui_settings.c
@@ -74,6 +74,7 @@ static const Option options[] = {
     {"Symbol color", OPT_COLOR, offsetof(AppConfig, symbol_color), NULL},
     {"Search color", OPT_COLOR, offsetof(AppConfig, search_color), NULL},
     {"Macro record key", OPT_INT, offsetof(AppConfig, macro_record_key), NULL},
+    {"Macro play key", OPT_INT, offsetof(AppConfig, macro_play_key), NULL},
 };
 
 #define FIELD_COUNT ((int)(sizeof(options) / sizeof(options[0])))

--- a/tests/macro_tests.c
+++ b/tests/macro_tests.c
@@ -6,6 +6,7 @@
 #include "editor_state.h"
 #include <ncurses.h>
 #include <string.h>
+#include <stdlib.h>
 
 int tests_run = 0;
 
@@ -115,11 +116,34 @@ static char *test_load_overlong_macro() {
     return 0;
 }
 
+static char *test_config_persist_macro_play_key() {
+    const char *cfg_path = "test_ventorc";
+    setenv("VENTO_CONFIG", cfg_path, 1);
+    remove(cfg_path);
+
+    AppConfig cfg = {0};
+    cfg.macro_play_key = 1234;
+    strncpy(cfg.macros_file, "test_macros.tmp", sizeof(cfg.macros_file) - 1);
+    cfg.macros_file[sizeof(cfg.macros_file) - 1] = '\0';
+
+    config_save(&cfg);
+
+    cfg.macro_play_key = 0;
+    config_load(&cfg);
+
+    mu_assert("macro_play_key persisted", cfg.macro_play_key == 1234);
+
+    remove(cfg_path);
+    unsetenv("VENTO_CONFIG");
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_simple_record_play);
     mu_run_test(test_create_delete_api);
     mu_run_test(test_shrink_on_delete);
     mu_run_test(test_load_overlong_macro);
+    mu_run_test(test_config_persist_macro_play_key);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- allow setting the macro play key in the settings dialog
- exercise config persistence of `macro_play_key` in unit tests

## Testing
- `./run_tests.sh` *(fails: exit code 134)*

------
https://chatgpt.com/codex/tasks/task_e_6847b66d7b9c83249014a31248e52bb9