### PR TITLE
Fix delete join overflow

### DIFF
--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -200,7 +200,17 @@ void handle_key_delete(EditorContext *ctx, FileState *fs) {
                 strlen(fs->buffer.lines[fs->cursor_y - 1 + fs->start_line]) - fs->cursor_x + 1);
     } else if (fs->cursor_y + fs->start_line < fs->buffer.count) {
         int idx = fs->cursor_y - 1 + fs->start_line;
-        strcat(fs->buffer.lines[idx], fs->buffer.lines[idx + 1]);
+        char *current = fs->buffer.lines[idx];
+        char *next = fs->buffer.lines[idx + 1];
+        size_t total_len = strlen(current) + strlen(next);
+        if (total_len >= (size_t)fs->line_capacity) {
+            size_t space = fs->line_capacity - strlen(current) - 1;
+            if (space > 0)
+                strncat(current, next, space);
+            current[fs->line_capacity - 1] = '\0';
+        } else {
+            strcat(current, next);
+        }
         lb_delete(&fs->buffer, idx + 1);
     }
     werase(text_win);

--- a/tests/delete_tests.c
+++ b/tests/delete_tests.c
@@ -1,0 +1,72 @@
+#include "minunit.h"
+#include "input.h"
+#include "files.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_delete_join_truncate() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 8);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "hello");
+    strcpy(fs->buffer.lines[1], "world");
+    fs->buffer.count = 2;
+    fs->cursor_y = 1;
+    fs->cursor_x = strlen(fs->buffer.lines[0]) + 1;
+
+    handle_key_delete(NULL, fs);
+
+    mu_assert("line truncated", strcmp(fs->buffer.lines[0], "hellowo") == 0);
+    mu_assert("line count", fs->buffer.count == 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_delete_join_exact_capacity() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 8);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abc");
+    strcpy(fs->buffer.lines[1], "defg");
+    fs->buffer.count = 2;
+    fs->cursor_y = 1;
+    fs->cursor_x = strlen(fs->buffer.lines[0]) + 1;
+
+    handle_key_delete(NULL, fs);
+
+    mu_assert("line joined", strcmp(fs->buffer.lines[0], "abcdefg") == 0);
+    mu_assert("line count", fs->buffer.count == 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_delete_join_truncate);
+    mu_run_test(test_delete_join_exact_capacity);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -99,6 +99,13 @@ gcc undo_redo_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o undo_redo_tests
 ./undo_redo_tests
+gcc delete_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -o delete_tests
+./delete_tests
 gcc json_highlight_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \


### PR DESCRIPTION
## Summary
- prevent overflow when joining lines on delete
- test deletion near line capacity limit

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6862cff5b42483248ca7b0668bd6d200