### PR TITLE
Support long filenames

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -83,7 +83,7 @@ void save_file(EditorContext *ctx, FileState *fs) {
  */
 void save_file_as(EditorContext *ctx, FileState *fs) {
     (void)ctx;
-    char newpath[256];
+    char newpath[PATH_MAX];
     if (!show_save_file_dialog(ctx, newpath, sizeof(newpath)))
         return;    // user cancelled
     canonicalize_path(newpath, fs->filename, sizeof(fs->filename));
@@ -133,7 +133,7 @@ void save_file_as(EditorContext *ctx, FileState *fs) {
  */
 int load_file(EditorContext *ctx, FileState *fs_unused, const char *filename) {
     (void)fs_unused;
-    char file_to_load[256];
+    char file_to_load[PATH_MAX];
     char canonical[PATH_MAX];
     FileState *previous_active = active_file;
 

--- a/src/files.h
+++ b/src/files.h
@@ -7,9 +7,10 @@
 #include <stddef.h>
 #include "editor.h"
 #include "line_buffer.h"
+#include "path_utils.h"
 
 typedef struct FileState {
-    char filename[256];
+    char filename[PATH_MAX];
     LineBuffer buffer;
     int start_line;
     int scroll_x; /* leftmost visible column */


### PR DESCRIPTION
## Summary
- expand `FileState.filename` to `PATH_MAX`
- allow save/open dialogs to use longer buffers

## Testing
- `make`
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6862ed4b33708324a0268916a8c77f0e