### PR TITLE
Clamp mouse drag coords

### DIFF
--- a/src/input_mouse.c
+++ b/src/input_mouse.c
@@ -30,6 +30,14 @@
  */
 void update_selection_mouse(EditorContext *ctx, FileState *fs, int x, int y) {
     (void)ctx;
+    if (x < 1)
+        x = 1;
+    else if (x > fs->line_capacity)
+        x = fs->line_capacity;
+    if (y < 1)
+        y = 1;
+    else if (y > fs->buffer.count)
+        y = fs->buffer.count;
     fs->sel_end_x = x;
     fs->sel_end_y = y;
 
@@ -60,10 +68,20 @@ void handle_mouse_event(EditorContext *ctx, FileState *fs, MEVENT *ev) {
     int my = ev->y - 1; // account for window border
     int offset = get_line_number_offset(fs);
 
-    if (mx >= offset && mx < COLS - 2 && my >= 0 && my < LINES - BOTTOM_MARGIN) {
-        fs->cursor_x = mx - offset + 1;
-        fs->cursor_y = my + 1;
-    }
+    int x = mx - offset + 1;
+    int y = my + 1;
+
+    if (x < 1)
+        x = 1;
+    else if (x > fs->line_capacity)
+        x = fs->line_capacity;
+    if (y < 1)
+        y = 1;
+    else if (y > fs->buffer.count)
+        y = fs->buffer.count;
+
+    fs->cursor_x = x;
+    fs->cursor_y = y;
 
     if (ev->bstate & BUTTON1_PRESSED) {
         start_selection_mode(fs, fs->cursor_x, fs->cursor_y);

--- a/tests/mouse_drag_tests.c
+++ b/tests/mouse_drag_tests.c
@@ -1,0 +1,88 @@
+#include "minunit.h"
+#include "input.h"
+#include "files.h"
+#include "editor.h"
+#include "editor_state.h"
+#include "clipboard.h"
+#ifndef BUTTON1_DRAGGED
+#define BUTTON1_DRAGGED (BUTTON1_PRESSED | REPORT_MOUSE_POSITION)
+#endif
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_drag_clamp_bottom_right() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 8);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    fs->buffer.count = 3;
+    fs->cursor_x = 1;
+    fs->cursor_y = 1;
+    start_selection_mode(fs, fs->cursor_x, fs->cursor_y);
+
+    MEVENT ev = {0};
+    ev.x = COLS + 10;
+    ev.y = LINES + 10;
+    ev.bstate = BUTTON1_DRAGGED;
+
+    handle_mouse_event(NULL, fs, &ev);
+
+    mu_assert("sel_end_x clamped", fs->sel_end_x == fs->line_capacity);
+    mu_assert("sel_end_y clamped", fs->sel_end_y == fs->buffer.count);
+    mu_assert("cursor_x clamped", fs->cursor_x == fs->line_capacity);
+    mu_assert("cursor_y clamped", fs->cursor_y == fs->buffer.count);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_drag_clamp_top_left() {
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 8);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    fs->buffer.count = 3;
+    fs->cursor_x = 3;
+    fs->cursor_y = 2;
+    start_selection_mode(fs, fs->cursor_x, fs->cursor_y);
+
+    MEVENT ev = {0};
+    ev.x = -5;
+    ev.y = -5;
+    ev.bstate = BUTTON1_DRAGGED;
+
+    handle_mouse_event(NULL, fs, &ev);
+
+    mu_assert("sel_end_x min", fs->sel_end_x == 1);
+    mu_assert("sel_end_y min", fs->sel_end_y == 1);
+    mu_assert("cursor_x min", fs->cursor_x == 1);
+    mu_assert("cursor_y min", fs->cursor_y == 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_drag_clamp_bottom_right);
+    mu_run_test(test_drag_clamp_top_left);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -113,3 +113,10 @@ gcc json_highlight_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
     -o json_highlight_tests
 ./json_highlight_tests
+gcc mouse_drag_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -o mouse_drag_tests
+./mouse_drag_tests


### PR DESCRIPTION
## Summary
- clamp mouse selection coordinates within buffer boundaries
- ensure mouse events update cursor positions safely
- add regression tests for dragging outside the text window

## Testing
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6862ee02c7508324bb3232aaa2f18402