### PR TITLE
Handle load error propagation

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -630,7 +630,11 @@ void draw_text_buffer(FileState *fs, WINDOW *win) {
     }
 
     // Ensure enough lines are loaded for display
-    ensure_line_loaded(fs, fs->start_line + max_lines);
+    if (ensure_line_loaded(fs, fs->start_line + max_lines) < 0) {
+        mvprintw(LINES - 2, 2, "Error loading file: %s", strerror(fs->io_errno));
+        refresh();
+        return;
+    }
 
     int visible_width = COLS - 2 - offset;
     if (visible_width < 1)

--- a/src/files.c
+++ b/src/files.c
@@ -124,6 +124,7 @@ FileState *initialize_file_state(const char *filename, int max_lines, int max_co
     file_state->file_pos = 0;
     file_state->file_complete = true;
     file_state->modified = false;
+    file_state->io_errno = 0;
 
     return file_state;
 }
@@ -307,13 +308,13 @@ int load_next_lines(FileState *fs, int count) {
  * Opens the file on demand and reads additional lines as needed using
  * load_next_lines().
  *
- * Returns: none.
+ * Returns: 0 on success, -1 on failure.
  * Side effects: may open fs->fp, read from disk and update file_pos.
  */
 
-void ensure_line_loaded(FileState *fs, int idx) {
+int ensure_line_loaded(FileState *fs, int idx) {
     if (idx < fs->buffer.count)
-        return;
+        return 0;
     int to_load = idx - fs->buffer.count + 1;
     if (to_load < 0)
         to_load = 0;
@@ -321,8 +322,19 @@ void ensure_line_loaded(FileState *fs, int idx) {
         fs->fp = fopen(fs->filename, "r");
         if (fs->fp)
             fseek(fs->fp, fs->file_pos, SEEK_SET);
+        else {
+            fs->io_errno = errno;
+            fs->file_complete = false;
+            return -1;
+        }
     }
-    load_next_lines(fs, to_load);
+    int res = load_next_lines(fs, to_load);
+    if (res < 0) {
+        fs->io_errno = errno;
+        fs->file_complete = false;
+        return -1;
+    }
+    return 0;
 }
 /**
  * load_all_remaining_lines - read the rest of the file into memory.

--- a/src/files.h
+++ b/src/files.h
@@ -39,6 +39,7 @@ typedef struct FileState {
     long file_pos;     /* Offset of fp when partially loaded */
     bool file_complete;/* True when the entire file is loaded */
     bool modified;     /* True if the buffer has unsaved changes */
+    int io_errno;      /* Error code from the last failed load */
 } FileState;
 
 FileState *initialize_file_state(const char *filename, int max_lines, int max_cols);
@@ -47,7 +48,7 @@ int load_file_into_buffer(FileState *file_state);
 int ensure_line_capacity(FileState *fs, int min_needed);
 int ensure_col_capacity(FileState *fs, int cols);
 int load_next_lines(FileState *fs, int count);
-void ensure_line_loaded(FileState *fs, int idx);
+int ensure_line_loaded(FileState *fs, int idx);
 void load_all_remaining_lines(FileState *fs);
 void canonicalize_path(const char *path, char *out, size_t out_size);
 

--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -98,7 +98,14 @@ void handle_key_up(EditorContext *ctx, FileState *fs) {
  * viewport is moved and no undo entry is recorded.
  */
 void handle_key_down(EditorContext *ctx, FileState *fs) {
-    ensure_line_loaded(fs, fs->start_line + fs->cursor_y);
+    if (ensure_line_loaded(fs, fs->start_line + fs->cursor_y) < 0) {
+        mvprintw(LINES - 2, 2, "Error loading file: %s", strerror(fs->io_errno));
+        refresh();
+        getch();
+        mvprintw(LINES - 2, 2, "                            ");
+        refresh();
+        return;
+    }
     if (fs->cursor_y < LINES - BOTTOM_MARGIN && fs->cursor_y < fs->buffer.count) {
         fs->cursor_y++;
     } else if (fs->start_line + fs->cursor_y < fs->buffer.count) {
@@ -341,7 +348,14 @@ void handle_key_page_up(EditorContext *ctx, FileState *fs) {
  */
 void handle_key_page_down(EditorContext *ctx, FileState *fs) {
     (void)ctx;
-    ensure_line_loaded(fs, fs->start_line + (LINES - 4));
+    if (ensure_line_loaded(fs, fs->start_line + (LINES - 4)) < 0) {
+        mvprintw(LINES - 2, 2, "Error loading file: %s", strerror(fs->io_errno));
+        refresh();
+        getch();
+        mvprintw(LINES - 2, 2, "                            ");
+        refresh();
+        return;
+    }
     int max_lines = LINES - 4;
     if (fs->start_line + max_lines < fs->buffer.count) {
         fs->start_line += max_lines;


### PR DESCRIPTION
## Summary
- capture `load_next_lines` result in `ensure_line_loaded`
- mark file as partially loaded and store `errno` on failure
- return error from `ensure_line_loaded`
- show error messages in scrolling and drawing code when loading fails

## Testing
- `make`
- `make test` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6862f8f381608324915fe7758421d9a9