### PR TITLE
Handle shrinking failure in ensure_line_capacity

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -188,7 +188,10 @@ int ensure_line_capacity(FileState *fs, int min_needed) {
         if (!fs->buffer.lines[i]) {
             for (int j = fs->buffer.capacity; j < i; ++j)
                 free(fs->buffer.lines[j]);
-            fs->buffer.lines = realloc(fs->buffer.lines, fs->buffer.capacity * sizeof(char *));
+            char **shrink = realloc(fs->buffer.lines,
+                                   fs->buffer.capacity * sizeof(char *));
+            if (shrink)
+                fs->buffer.lines = shrink;
             return -1;
         }
     }

--- a/tests/line_capacity_tests.c
+++ b/tests/line_capacity_tests.c
@@ -1,0 +1,55 @@
+#include "minunit.h"
+#include "files.h"
+#include <ncurses.h>
+
+extern int calloc_fail_on;
+extern int calloc_call_count;
+extern int realloc_fail_on;
+extern int realloc_call_count;
+
+int tests_run = 0;
+
+static char *test_allocation_failure_cleanup() {
+    initscr();
+    FileState *fs = initialize_file_state("", 2, 8);
+    mu_assert("fs allocated", fs != NULL);
+
+    calloc_call_count = 0;
+    realloc_call_count = 0;
+    calloc_fail_on = 2; /* fail second new line */
+    realloc_fail_on = 2; /* fail shrink */
+
+    int res = ensure_line_capacity(fs, 5);
+    calloc_fail_on = 0;
+    realloc_fail_on = 0;
+
+    mu_assert("failure returned", res == -1);
+    mu_assert("capacity unchanged", fs->buffer.capacity == 2);
+    mu_assert("lines intact", fs->buffer.lines[0] != NULL && fs->buffer.lines[1] != NULL);
+
+    res = ensure_line_capacity(fs, 4);
+    mu_assert("second success", res == 0);
+    mu_assert("capacity grown", fs->buffer.capacity >= 4);
+    for (int i = 0; i < fs->buffer.capacity; ++i)
+        mu_assert("line allocated", fs->buffer.lines[i] != NULL);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_allocation_failure_cleanup);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,6 +18,7 @@ gcc navigation_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurses
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o navigation_tests
 ./navigation_tests
 gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -25,6 +26,7 @@ gcc menu_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o menu_load_tests
 ./menu_load_tests
 
@@ -33,6 +35,7 @@ gcc macro_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o macro_tests
 ./macro_tests
 gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -40,6 +43,7 @@ gcc editor_actions_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o editor_actions_tests
 ./editor_actions_tests
 gcc clipboard_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -47,6 +51,7 @@ gcc clipboard_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o clipboard_tests
 ./clipboard_tests
 gcc theme_fd_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -54,6 +59,7 @@ gcc theme_fd_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw 
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup -Wl,--wrap=wgetch \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o theme_fd_tests
 ./theme_fd_tests
 gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -61,6 +67,7 @@ gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o search_replace_tests
 ./search_replace_tests
 gcc dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -68,6 +75,7 @@ gcc dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o dialog_tests
 ./dialog_tests
 gcc goto_dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -90,6 +98,7 @@ gcc file_dialog_resize_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o file_dialog_resize_tests
 ./file_dialog_resize_tests
 gcc undo_redo_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -97,6 +106,7 @@ gcc undo_redo_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o undo_redo_tests
 ./undo_redo_tests
 gcc delete_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -104,6 +114,7 @@ gcc delete_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o delete_tests
 ./delete_tests
 gcc json_highlight_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -111,6 +122,7 @@ gcc json_highlight_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o json_highlight_tests
 ./json_highlight_tests
 gcc mouse_drag_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
@@ -118,5 +130,14 @@ gcc mouse_drag_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurses
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
     -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
     -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o mouse_drag_tests
 ./mouse_drag_tests
+gcc line_capacity_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
+    -o line_capacity_tests
+./line_capacity_tests

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -10,6 +10,8 @@
 
 char *__real_strdup(const char *);
 WINDOW *__real_create_popup_window(int, int, WINDOW *);
+void *__real_calloc(size_t, size_t);
+void *__real_realloc(void *, size_t);
 
 __attribute__((weak)) FileManager file_manager;
 
@@ -19,6 +21,13 @@ int fm_add_fail = 0;
 int strdup_fail_on = 0;
 int strdup_call_count = 0;
 int allocation_fail_count = 0;
+
+int calloc_fail_on = 0;
+int calloc_call_count = 0;
+int calloc_fail_enabled = 0;
+int realloc_fail_on = 0;
+int realloc_call_count = 0;
+int realloc_fail_enabled = 0;
 
 int create_popup_fail = 0;
 int last_curs_set = -2;
@@ -70,6 +79,20 @@ char *__wrap_strdup(const char *s) {
     if (strdup_fail_on > 0 && strdup_call_count == strdup_fail_on)
         return NULL;
     return __real_strdup(s);
+}
+
+void *__wrap_calloc(size_t nmemb, size_t size) {
+    calloc_call_count++;
+    if (calloc_fail_enabled && calloc_fail_on > 0 && calloc_call_count == calloc_fail_on)
+        return NULL;
+    return __real_calloc(nmemb, size);
+}
+
+void *__wrap_realloc(void *ptr, size_t size) {
+    realloc_call_count++;
+    if (realloc_fail_enabled && realloc_fail_on > 0 && realloc_call_count == realloc_fail_on)
+        return NULL;
+    return __real_realloc(ptr, size);
 }
 
 WINDOW *__wrap_create_popup_window(int h, int w, WINDOW *p) {


### PR DESCRIPTION
## Summary
- fix cleanup on allocation failure in `ensure_line_capacity`
- wrap `calloc` and `realloc` in tests to simulate failures
- add regression test for failed line allocation

## Testing
- `./run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc33063c8324a3ee4b0b402b62ae