### PR TITLE
Fix cancelled dialog handling

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -128,5 +128,7 @@ int dialog_prompt(WINDOW *win, int y, int x, char *buf, size_t len) {
         }
     }
     buf[pos] = '\0';
+    if (cancelled)
+        buf[0] = '\0';
     return cancelled ? 0 : 1;
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -47,9 +47,7 @@ void create_dialog(EditorContext *ctx, const char *message, char *output,
         wattroff(dialog_win, COLOR_PAIR(SYNTAX_KEYWORD));
     wrefresh(dialog_win);
 
-    int ok = dialog_prompt(dialog_win, input_y, input_x + 7, output, max_input_len);
-    if (!ok)
-        output[0] = '\0';
+    dialog_prompt(dialog_win, input_y, input_x + 7, output, max_input_len);
 
     dialog_close(dialog_win);
 }
@@ -92,8 +90,6 @@ int show_find_dialog(EditorContext *ctx, char *output, int max_input_len,
     }
 
     int ok = dialog_prompt(dialog_win, input_y, input_x + 7, output, max_input_len);
-    if (!ok)
-        output[0] = '\0';
 
     dialog_close(dialog_win);
     return ok;

--- a/tests/dialog_tests.c
+++ b/tests/dialog_tests.c
@@ -1,6 +1,10 @@
 #include "minunit.h"
 #include "dialog.h"
+#include "ui.h"
+#include "editor_state.h"
 #include <ncurses.h>
+
+void set_wgetch_sequence(const int *keys, int count);
 
 int tests_run = 0;
 extern int create_popup_fail;
@@ -20,8 +24,50 @@ static char *test_dialog_open_failure() {
     return 0;
 }
 
+static char *test_prompt_cancel_clears_buffer() {
+    initscr();
+    WINDOW *win = dialog_open(5, 20, "Prompt");
+    const int keys[] = { 'a', 27 };
+    set_wgetch_sequence(keys, 2);
+    char buf[16] = "";
+    int ok = dialog_prompt(win, 2, 2, buf, sizeof(buf));
+    mu_assert("cancelled", ok == 0);
+    mu_assert("buf empty", buf[0] == '\0');
+    dialog_close(win);
+    endwin();
+    return 0;
+}
+
+static char *test_create_dialog_cancel_clears_buffer() {
+    initscr();
+    const int keys[] = {27};
+    set_wgetch_sequence(keys, 1);
+    EditorContext ctx = {0};
+    char buf[16] = "abc";
+    create_dialog(&ctx, "Test", buf, sizeof(buf));
+    mu_assert("buf empty", buf[0] == '\0');
+    endwin();
+    return 0;
+}
+
+static char *test_show_find_dialog_cancel_clears_buffer() {
+    initscr();
+    const int keys[] = {27};
+    set_wgetch_sequence(keys, 1);
+    EditorContext ctx = {0};
+    char buf[16] = "abc";
+    int ok = show_find_dialog(&ctx, buf, sizeof(buf), NULL);
+    mu_assert("cancelled", ok == 0);
+    mu_assert("buf empty", buf[0] == '\0');
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_dialog_open_failure);
+    mu_run_test(test_prompt_cancel_clears_buffer);
+    mu_run_test(test_create_dialog_cancel_clears_buffer);
+    mu_run_test(test_show_find_dialog_cancel_clears_buffer);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- clear buffer on cancel in `dialog_prompt`
- rely on prompt to clear buffer in `create_dialog` and `show_find_dialog`
- test that cancelled dialogs return empty strings

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68636b608a788324bc77da4410dbd8f5