### PR TITLE
Fix word nav underflow at line start

### DIFF
--- a/src/input_keyboard.c
+++ b/src/input_keyboard.c
@@ -617,7 +617,9 @@ void move_backward_to_previous_word(EditorContext *ctx, FileState *fs) {
             size_t bytes = utf8_to_wchar(line, len, prev, &wc);
             if (!iswalnum(wc))
                 break;
-            fs->cursor_x -= bytes;
+            if (fs->cursor_x <= 1)
+                break;
+            fs->cursor_x = (fs->cursor_x - bytes < 1) ? 1 : fs->cursor_x - bytes;
         }
         while (fs->cursor_x > 1) {
             int prev = prev_utf8_start(line, fs->cursor_x - 1);
@@ -627,12 +629,15 @@ void move_backward_to_previous_word(EditorContext *ctx, FileState *fs) {
             size_t bytes = utf8_to_wchar(line, len, prev, &wc);
             if (iswalnum(wc))
                 break;
-            fs->cursor_x -= bytes;
+            if (fs->cursor_x <= 1)
+                break;
+            fs->cursor_x = (fs->cursor_x - bytes < 1) ? 1 : fs->cursor_x - bytes;
         }
         if (fs->cursor_x > 1) {
             return;
         }
-        if (fs->cursor_y > 1) {
+        if (fs->cursor_y > 1 &&
+            lb_get(&fs->buffer, fs->cursor_y - 2 + fs->start_line)) {
             fs->cursor_y--;
             line = lb_get(&fs->buffer, fs->cursor_y - 1 + fs->start_line);
             fs->cursor_x = line ? strlen(line) + 1 : 1;

--- a/tests/utf8_word_nav_tests.c
+++ b/tests/utf8_word_nav_tests.c
@@ -56,9 +56,56 @@ static char *test_backward_utf8() {
     return 0;
 }
 
+static char *test_backward_no_underflow_start_of_line() {
+    setlocale(LC_ALL, "");
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 32);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "foo");
+    strcpy(fs->buffer.lines[1], "bar");
+    fs->buffer.count = 2;
+    fs->cursor_y = 2;
+    fs->cursor_x = 1;
+
+    move_backward_to_previous_word(NULL, fs);
+    mu_assert("moved to end of prev line", fs->cursor_y == 1 && fs->cursor_x == 4);
+    move_backward_to_previous_word(NULL, fs);
+    mu_assert("stopped at file start", fs->cursor_y == 1 && fs->cursor_x == 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
+static char *test_backward_at_file_start() {
+    setlocale(LC_ALL, "");
+    initscr();
+    FileState *fs = initialize_file_state("", 5, 32);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    strcpy(fs->buffer.lines[0], "abc");
+    fs->buffer.count = 1;
+    fs->cursor_y = 1;
+    fs->cursor_x = 1;
+
+    move_backward_to_previous_word(NULL, fs);
+    mu_assert("remain at file start", fs->cursor_y == 1 && fs->cursor_x == 1);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_forward_utf8);
     mu_run_test(test_backward_utf8);
+    mu_run_test(test_backward_no_underflow_start_of_line);
+    mu_run_test(test_backward_at_file_start);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- avoid cursor underflow when moving backward across UTF-8 words
- stop at file start if previous line is missing
- add regression tests for moving backward at line start

## Testing
- `./tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68642fd136ac83249623702aeb9fbc13