### PR TITLE
Fix show_message compile-time check

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -150,10 +150,14 @@ void load_theme(const char *name, AppConfig *cfg) {
     if (!f) {
         char msg[PATH_MAX + 64];
         snprintf(msg, sizeof(msg), "Unable to open theme file: %s", path);
+#ifdef USE_WEAK_MESSAGE
         if (show_message)
             show_message(msg);
         else
             fprintf(stderr, "%s\n", msg);
+#else
+        show_message(msg);
+#endif
         return;
     }
 


### PR DESCRIPTION
## Summary
- avoid runtime address check on `show_message`
- use `USE_WEAK_MESSAGE` to conditionally call the function

## Testing
- `make test` *(fails: invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_686432b926d08324bb41d2d5bb0a7699