### PR TITLE
Fix regex escape sequence warning

### DIFF
--- a/src/syntax_registry.c
+++ b/src/syntax_registry.c
@@ -145,7 +145,7 @@ static SyntaxRegex JSON_PATTERNS[] = {
     { .pattern = "^\"([^\"\\]|\\.)*\"", .attr = COLOR_PAIR(SYNTAX_STRING) | A_BOLD },
     { .pattern = "^-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?", .attr = COLOR_PAIR(SYNTAX_TYPE) | A_BOLD },
     { .pattern = JSON_KEYWORDS_PATTERN, .attr = COLOR_PAIR(SYNTAX_KEYWORD) | A_BOLD },
-    { .pattern = "^[{}\[\]:,]", .attr = COLOR_PAIR(SYNTAX_SYMBOL) | A_BOLD },
+    { .pattern = "^[]\[{}:,]", .attr = COLOR_PAIR(SYNTAX_SYMBOL) | A_BOLD },
 };
 static const SyntaxDef JSON_DEF = { ".json", JSON_PATTERNS, sizeof(JSON_PATTERNS)/sizeof(JSON_PATTERNS[0]) };
 


### PR DESCRIPTION
## Summary
- fix the JSON regex in `src/syntax_registry.c` to avoid escaping `]`
- recompile to ensure the warning is gone

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686435c78a70832492aaee80d38248ec