### PR TITLE
Fix clear_text_buffer when no active file

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -815,6 +815,9 @@ void perform_resize(void) {
  * @return None
  */
 void clear_text_buffer() {
+    if (!active_file)
+        return;
+
     // Set all elements of the text buffer to 0
     for (int i = 0; i < active_file->buffer.capacity; ++i) {
         memset(active_file->buffer.lines[i], 0, active_file->line_capacity);


### PR DESCRIPTION
## Summary
- prevent null dereference when clearing text buffer

## Testing
- `tests/run_tests.sh` *(fails: glibc invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68644879acf0832491a295ef84ab3a68