### PR TITLE
Handle restore failure in ensure_col_capacity

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -221,8 +221,9 @@ int ensure_col_capacity(FileState *fs, int cols) {
         if (!tmp) {
             for (int j = 0; j < i; ++j) {
                 char *restore = realloc(fs->buffer.lines[j], old_capacity);
-                if (restore)
-                    fs->buffer.lines[j] = restore;
+                if (!restore)
+                    return -1;
+                fs->buffer.lines[j] = restore;
             }
             return -1;
         }


### PR DESCRIPTION
## Summary
- check for errors when shrinking lines after realloc failure

## Testing
- `./tests/run_tests.sh` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68644eda795483248e5bba31c8fabf8f