### PR TITLE
Fix create_popup_window error handling

### DIFF
--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -52,7 +52,7 @@ WINDOW *create_centered_window(int height, int width, WINDOW *parent) {
 WINDOW *create_popup_window(int height, int width, WINDOW *parent) {
     WINDOW *win = create_centered_window(height, width, parent);
     if (!win) {
-        show_message("Unable to create window");
+        fprintf(stderr, "Unable to create window\n");
         return NULL;
     }
     return win;


### PR DESCRIPTION
## Summary
- avoid calling `show_message` when window creation fails

## Testing
- `tests/run_tests.sh` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_686452d40ca883248cefc40b62e3f810