### PR TITLE
Handle uppercase extensions for syntax detection

### DIFF
--- a/src/file_ops.c
+++ b/src/file_ops.c
@@ -1,5 +1,6 @@
 #include <ncurses.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <stdio.h>
 #include "editor.h"
@@ -463,19 +464,19 @@ bool confirm_switch(void) {
 int set_syntax_mode(const char *filename) {
     const char *ext = strrchr(filename, '.');
     if (ext && ext[1] != '\0') {
-        if (strcmp(ext, ".c") == 0 || strcmp(ext, ".h") == 0) {
+        if (strcasecmp(ext, ".c") == 0 || strcasecmp(ext, ".h") == 0) {
             return C_SYNTAX;
-        } else if (strcmp(ext, ".html") == 0 || strcmp(ext, ".htm") == 0) {
+        } else if (strcasecmp(ext, ".html") == 0 || strcasecmp(ext, ".htm") == 0) {
             return HTML_SYNTAX;
-        } else if (strcmp(ext, ".py") == 0) {
+        } else if (strcasecmp(ext, ".py") == 0) {
             return PYTHON_SYNTAX;
-        } else if (strcmp(ext, ".cs") == 0) {
+        } else if (strcasecmp(ext, ".cs") == 0) {
             return CSHARP_SYNTAX;
-        } else if (strcmp(ext, ".js") == 0) {
+        } else if (strcasecmp(ext, ".js") == 0) {
             return JS_SYNTAX;
-        } else if (strcmp(ext, ".css") == 0) {
+        } else if (strcasecmp(ext, ".css") == 0) {
             return CSS_SYNTAX;
-        } else if (strcmp(ext, ".json") == 0) {
+        } else if (strcasecmp(ext, ".json") == 0) {
             return JSON_SYNTAX;
         }
     }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -149,3 +149,11 @@ gcc utf8_word_nav_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncur
     -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o utf8_word_nav_tests
 ./utf8_word_nav_tests
+gcc syntax_mode_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
+    -o syntax_mode_tests
+./syntax_mode_tests

--- a/tests/syntax_mode_tests.c
+++ b/tests/syntax_mode_tests.c
@@ -1,0 +1,34 @@
+#include "minunit.h"
+#include "file_ops.h"
+#include "syntax.h"
+
+int tests_run = 0;
+
+static char *test_uppercase_extensions() {
+    mu_assert(".PY", set_syntax_mode("foo.PY") == PYTHON_SYNTAX);
+    mu_assert(".HTML", set_syntax_mode("foo.HTML") == HTML_SYNTAX);
+    mu_assert(".HTM", set_syntax_mode("foo.HTM") == HTML_SYNTAX);
+    mu_assert(".C", set_syntax_mode("foo.C") == C_SYNTAX);
+    mu_assert(".H", set_syntax_mode("foo.H") == C_SYNTAX);
+    mu_assert(".JS", set_syntax_mode("foo.JS") == JS_SYNTAX);
+    mu_assert(".CSS", set_syntax_mode("foo.CSS") == CSS_SYNTAX);
+    mu_assert(".CS", set_syntax_mode("foo.CS") == CSHARP_SYNTAX);
+    mu_assert(".JSON", set_syntax_mode("foo.JSON") == JSON_SYNTAX);
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_uppercase_extensions);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}


### PR DESCRIPTION
## Summary
- use `strcasecmp` when determining syntax highlighting mode in `file_ops.c`
- add regression tests verifying uppercase extensions are recognized

## Testing
- `./tests/run_tests.sh` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_6867293307c08324b6ead3319435b197