### PR TITLE
Handle oversized macros_file path

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -551,10 +551,25 @@ void macros_save(const AppConfig *cfg) {
     if (!cfg)
         return;
     char path[PATH_MAX];
-    if (cfg->macros_file[0] == '\0')
+    if (cfg->macros_file[0] == '\0') {
         get_macros_path(path, sizeof(path));
-    else
-        strncpy(path, cfg->macros_file, sizeof(path) - 1), path[sizeof(path)-1]='\0';
+    } else {
+        if (strlen(cfg->macros_file) >= PATH_MAX) {
+            char msg[PATH_MAX + 64];
+            snprintf(msg, sizeof(msg), "Macros path too long: %s", cfg->macros_file);
+#ifdef USE_WEAK_MESSAGE
+            if (show_message)
+                show_message(msg);
+            else
+                fprintf(stderr, "%s\n", msg);
+#else
+            show_message(msg);
+#endif
+            return;
+        }
+        strncpy(path, cfg->macros_file, sizeof(path) - 1);
+        path[sizeof(path) - 1] = '\0';
+    }
 
     FILE *f = fopen(path, "w");
     if (!f)

--- a/tests/macro_tests.c
+++ b/tests/macro_tests.c
@@ -138,12 +138,29 @@ static char *test_config_persist_macro_play_key() {
     return 0;
 }
 
+extern char last_show_message_buf[];
+
+static char *test_macros_save_overlong_path() {
+    macros_free_all();
+
+    AppConfig cfg = {0};
+    memset(cfg.macros_file, 'a', sizeof(cfg.macros_file));
+    cfg.macro_record_key = 0;
+    last_show_message_buf[0] = '\0';
+    macros_save(&cfg);
+    mu_assert("warned", strstr(last_show_message_buf, "too long") != NULL);
+
+    macros_free_all();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_simple_record_play);
     mu_run_test(test_create_delete_api);
     mu_run_test(test_shrink_on_delete);
     mu_run_test(test_load_overlong_macro);
     mu_run_test(test_config_persist_macro_play_key);
+    mu_run_test(test_macros_save_overlong_path);
     return 0;
 }
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,7 +8,8 @@ for f in $SRC/*.c; do
     bn=$(basename "$f")
     if [ "$bn" != "vento.c" ]; then
         gcc -c "$f" -o obj_test/$(basename "$f" .c).o -I$SRC \
-            -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra -fcommon
+            -D_POSIX_C_SOURCE=200809L -std=c99 -Wall -Wextra -fcommon \
+            -DUSE_WEAK_MESSAGE
     fi
 done
 ar rcs obj_test/libvento.a obj_test/*.o

--- a/tests/test_stubs.c
+++ b/tests/test_stubs.c
@@ -157,3 +157,14 @@ int __wrap_mvprintw(int y, int x, const char *fmt, ...) {
     va_end(ap);
     return 0; /* suppress real output */
 }
+
+char last_show_message_buf[256] = "";
+int show_message(const char *msg) {
+    if (msg) {
+        strncpy(last_show_message_buf, msg, sizeof(last_show_message_buf) - 1);
+        last_show_message_buf[sizeof(last_show_message_buf) - 1] = '\0';
+    } else {
+        last_show_message_buf[0] = '\0';
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- check macros_file length before saving
- stub show_message for tests
- test overly long macro path handling
- allow overriding show_message in tests

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68672d2c13ac83249bf62ca6323e5176