### PR TITLE
Free undo/redo stacks when clearing buffer

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -827,6 +827,16 @@ void clear_text_buffer() {
     active_file->buffer.count = 1;
     if (active_file)
         active_file->start_line = 0;
+
+    if (active_file->undo_stack) {
+        free_stack(active_file->undo_stack);
+        active_file->undo_stack = NULL;
+    }
+
+    if (active_file->redo_stack) {
+        free_stack(active_file->redo_stack);
+        active_file->redo_stack = NULL;
+    }
     
     // Clear the text window
     werase(text_win);

--- a/tests/undo_redo_tests.c
+++ b/tests/undo_redo_tests.c
@@ -65,9 +65,34 @@ static char *test_redo_strdup_failure() {
     return 0;
 }
 
+static char *test_clear_text_buffer_frees_stacks() {
+    initscr();
+    FileState *fs = initialize_file_state("", 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    char *undo_text = strdup("old");
+    char *redo_text = strdup("new");
+    mu_assert("allocated", undo_text && redo_text);
+
+    push(&fs->undo_stack, (Change){0, undo_text, NULL});
+    push(&fs->redo_stack, (Change){0, NULL, redo_text});
+
+    clear_text_buffer();
+
+    mu_assert("undo stack cleared", fs->undo_stack == NULL);
+    mu_assert("redo stack cleared", fs->redo_stack == NULL);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_undo_strdup_failure);
     mu_run_test(test_redo_strdup_failure);
+    mu_run_test(test_clear_text_buffer_frees_stacks);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- clear undo/redo history when clearing the buffer
- test that both stacks are freed on buffer clear

## Testing
- `env TERM=dumb tests/run_tests.sh` *(fails: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6867599995f88324b93b531c8cbc3f3d