### PR TITLE
Ensure search loads lines lazily

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -70,6 +70,14 @@ gcc search_replace_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncu
     -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o search_replace_tests
 ./search_replace_tests
+gcc search_lazy_load_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
+    -o search_lazy_load_tests
+./search_lazy_load_tests
 gcc dialog_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
     -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
     -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \

--- a/tests/search_lazy_load_tests.c
+++ b/tests/search_lazy_load_tests.c
@@ -1,0 +1,63 @@
+#include "minunit.h"
+#include "files.h"
+#include "search.h"
+#include "editor.h"
+#include "editor_state.h"
+#include <ncurses.h>
+#include <stdio.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_find_beyond_initial_load() {
+    const char *path = "lazy_search.txt";
+    FILE *f = fopen(path, "w");
+    mu_assert("file created", f != NULL);
+    for (int i = 0; i < 150; ++i) {
+        if (i == 120)
+            fprintf(f, "target\n");
+        else
+            fprintf(f, "line %d\n", i);
+    }
+    fclose(f);
+
+    initscr();
+    FileState *fs = initialize_file_state(path, 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    fs->fp = fopen(path, "r");
+    mu_assert("fp open", fs->fp != NULL);
+    fs->file_pos = 0;
+    fs->file_complete = false;
+    fs->buffer.count = 0;
+
+    load_next_lines(fs, 50); /* load only part of the file */
+
+    find_next_occurrence(fs, "target");
+
+    mu_assert("found line", fs->match_start_y == 120);
+    mu_assert("lines loaded", fs->buffer.count > 120);
+
+    free_file_state(fs);
+    endwin();
+    remove(path);
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_find_beyond_initial_load);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}


### PR DESCRIPTION
## Summary
- load additional lines while scanning with `ensure_line_loaded`
- test searching beyond initially loaded lines
- run new test in CI

## Testing
- `./run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68675c1efef083248357e7d9ac139ac5