### PR TITLE
Improve lazy replace support

### DIFF
--- a/tests/search_replace_tests.c
+++ b/tests/search_replace_tests.c
@@ -29,8 +29,85 @@ static char *test_replace_long_near_end() {
     return 0;
 }
 
+static char *test_replace_next_beyond_load() {
+    const char *path = "lazy_replace_next.txt";
+    FILE *f = fopen(path, "w");
+    mu_assert("file created", f != NULL);
+    for (int i = 0; i < 150; ++i) {
+        if (i == 120)
+            fprintf(f, "target\n");
+        else
+            fprintf(f, "line %d\n", i);
+    }
+    fclose(f);
+
+    initscr();
+    FileState *fs = initialize_file_state(path, 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    fs->fp = fopen(path, "r");
+    mu_assert("fp open", fs->fp != NULL);
+    fs->file_pos = 0;
+    fs->file_complete = false;
+    fs->buffer.count = 0;
+
+    load_next_lines(fs, 50);
+
+    replace_next_occurrence(fs, "target", "found");
+
+    mu_assert("replaced", strcmp(lb_get(&fs->buffer, 120), "found") == 0);
+    mu_assert("lines loaded", fs->buffer.count > 120);
+
+    free_file_state(fs);
+    endwin();
+    remove(path);
+    return 0;
+}
+
+static char *test_replace_all_beyond_load() {
+    const char *path = "lazy_replace_all.txt";
+    FILE *f = fopen(path, "w");
+    mu_assert("file created", f != NULL);
+    for (int i = 0; i < 150; ++i) {
+        if (i == 120 || i == 140)
+            fprintf(f, "target\n");
+        else
+            fprintf(f, "line %d\n", i);
+    }
+    fclose(f);
+
+    initscr();
+    FileState *fs = initialize_file_state(path, 10, 80);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    fs->fp = fopen(path, "r");
+    mu_assert("fp open", fs->fp != NULL);
+    fs->file_pos = 0;
+    fs->file_complete = false;
+    fs->buffer.count = 0;
+
+    load_next_lines(fs, 50);
+
+    replace_all_occurrences(fs, "target", "found");
+
+    mu_assert("first replaced", strcmp(lb_get(&fs->buffer, 120), "found") == 0);
+    mu_assert("second replaced", strcmp(lb_get(&fs->buffer, 140), "found") == 0);
+    mu_assert("file loaded", fs->file_complete);
+
+    free_file_state(fs);
+    endwin();
+    remove(path);
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_replace_long_near_end);
+    mu_run_test(test_replace_next_beyond_load);
+    mu_run_test(test_replace_all_beyond_load);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- load lines lazily while replacing all occurrences
- lazily load lines when replacing the next match
- test replacements in partially loaded files

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_686769ff6424832486fefb3093ac7e37