### PR TITLE
Fix narrow resize bounds and add regression test

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -762,6 +762,8 @@ void perform_resize(void) {
     clear(); // Clear the screen
 
     int new_capacity = COLS - 3;
+    if (new_capacity < 1)
+        new_capacity = 1;
 
     /* Resize all open file windows and buffers */
     for (int i = 0; i < file_manager.count; ++i) {

--- a/tests/resize_bounds_tests.c
+++ b/tests/resize_bounds_tests.c
@@ -1,0 +1,43 @@
+#include "minunit.h"
+#include "input.h"
+#include "editor_state.h"
+#include <ncurses.h>
+
+int tests_run = 0;
+
+static char *test_narrow_resize_bounds() {
+    show_line_numbers = 1;
+    initscr();
+    resizeterm(2, 3);
+    FileState *fs = initialize_file_state("", 5, 8);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+    perform_resize();
+    mu_assert("cursor_x >= 1", fs->cursor_x >= 1);
+    mu_assert("scroll_x >= 0", fs->scroll_x >= 0);
+    fs->cursor_x = fs->line_capacity;
+    EditorContext ctx = {0};
+    handle_key_right(&ctx, fs);
+    mu_assert("scroll_x still >= 0", fs->scroll_x >= 0);
+    endwin();
+    free_file_state(fs);
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_narrow_resize_bounds);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -165,3 +165,11 @@ gcc syntax_mode_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncurse
     -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o syntax_mode_tests
 ./syntax_mode_tests
+gcc resize_bounds_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
+    -o resize_bounds_tests
+./resize_bounds_tests


### PR DESCRIPTION
## Summary
- ensure minimum column capacity in `perform_resize`
- test handling of extremely narrow terminal widths

## Testing
- `tests/run_tests.sh` *(fails: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68676bb6ecfc8324a35f18d8c59a5740