### PR TITLE
Fix paste insertion error handling

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -170,8 +170,14 @@ void paste_clipboard(FileState *fs, int *cursor_x, int *cursor_y) {
             (*cursor_y)++;
             fs->cursor_x = *cursor_x = 1;
             fs->cursor_y = *cursor_y;
-            if (lb_insert(&fs->buffer, *cursor_y - 1 + fs->start_line, "") < 0)
-                allocation_failed("lb_insert failed");
+            if (ensure_line_capacity(fs, fs->buffer.count + 1) < 0) {
+                show_message("Unable to allocate line");
+                break;
+            }
+            if (lb_insert(&fs->buffer, *cursor_y - 1 + fs->start_line, "") < 0) {
+                show_message("Unable to insert line");
+                break;
+            }
             char *p = realloc(fs->buffer.lines[*cursor_y - 1 + fs->start_line], fs->line_capacity);
             if (!p)
                 allocation_failed("realloc failed");

--- a/tests/clipboard_tests.c
+++ b/tests/clipboard_tests.c
@@ -316,6 +316,36 @@ static char *test_cut_selection_lazy_load() {
     return 0;
 }
 
+static char *test_paste_many_new_lines() {
+    initscr();
+    FileState *fs = initialize_file_state("", 2, 16);
+    mu_assert("fs allocated", fs != NULL);
+    active_file = fs;
+    text_win = fs->text_win;
+
+    char clip[256] = "";
+    for (int i = 0; i < 30; ++i) {
+        char tmp[16];
+        snprintf(tmp, sizeof(tmp), "l%d", i + 1);
+        strcat(clip, tmp);
+        if (i < 29)
+            strcat(clip, "\n");
+    }
+    strncpy(global_clipboard, clip, sizeof(global_clipboard) - 1);
+    global_clipboard[sizeof(global_clipboard) - 1] = '\0';
+
+    int cx = 1;
+    int cy = 1;
+    paste_clipboard(fs, &cx, &cy);
+
+    mu_assert("line count", fs->buffer.count == 30);
+    mu_assert("last line", strcmp(fs->buffer.lines[29], "l30") == 0);
+
+    free_file_state(fs);
+    endwin();
+    return 0;
+}
+
 static char *all_tests() {
     mu_run_test(test_paste_cursor_clamped);
     mu_run_test(test_paste_grows_capacity);
@@ -327,6 +357,7 @@ static char *all_tests() {
     mu_run_test(test_cut_selection_undo_multiline);
     mu_run_test(test_copy_selection_lazy_load);
     mu_run_test(test_cut_selection_lazy_load);
+    mu_run_test(test_paste_many_new_lines);
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- guard lb_insert in `paste_clipboard` with ensure_line_capacity
- display an error via `show_message` when line insertion fails
- test pasting large multi-line clipboard content

## Testing
- `make test` *(fails: Fatal error: glibc detected an invalid stdio handle)*

------
https://chatgpt.com/codex/tasks/task_e_68676e50b7d083248ae80a82ef716c67