### PR TITLE
Add cleanup test, reset globals after exit

### DIFF
--- a/src/editor_init.c
+++ b/src/editor_init.c
@@ -137,6 +137,9 @@ void cleanup_on_exit(FileManager *fm) {
     fm->files = NULL;
     fm->count = 0;
     fm->active_index = -1;
+    fm->capacity = 0;
+    active_file = NULL;
+    text_win = NULL;
 }
 
 /*

--- a/tests/cleanup_tests.c
+++ b/tests/cleanup_tests.c
@@ -1,0 +1,48 @@
+#include "minunit.h"
+#include "files.h"
+#include "file_manager.h"
+#include "undo.h"
+#include "editor.h"
+#include <ncurses.h>
+#include <string.h>
+
+int tests_run = 0;
+
+static char *test_cleanup_frees_stacks() {
+    initscr();
+    FileManager fm;
+    fm_init(&fm);
+    FileState *fs = initialize_file_state("", 2, 8);
+    mu_assert("fs allocated", fs != NULL);
+
+    char *u = strdup("u");
+    char *r = strdup("r");
+    mu_assert("allocated", u && r);
+    push(&fs->undo_stack, (Change){0, u, NULL});
+    push(&fs->redo_stack, (Change){0, NULL, r});
+
+    fm_add(&fm, fs);
+
+    cleanup_on_exit(&fm);
+
+    mu_assert("fm cleared", fm.files == NULL && fm.count == 0 && fm.active_index == -1);
+
+    endwin();
+    return 0;
+}
+
+static char *all_tests() {
+    mu_run_test(test_cleanup_frees_stacks);
+    return 0;
+}
+
+int main(void) {
+    char *result = all_tests();
+    if (result) {
+        printf("%s\n", result);
+    } else {
+        printf("ALL TESTS PASSED\n");
+    }
+    printf("Tests run: %d\n", tests_run);
+    return result != 0;
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -173,3 +173,11 @@ gcc resize_bounds_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncur
     -Wl,--wrap=calloc -Wl,--wrap=realloc \
     -o resize_bounds_tests
 ./resize_bounds_tests
+gcc cleanup_tests.c obj_test/test_stubs.o -I$SRC -Lobj_test -lvento -lncursesw \
+    -Wl,--wrap=fm_switch -Wl,--wrap=fm_add -Wl,--wrap=update_status_bar \
+    -Wl,--wrap=confirm_switch -Wl,--wrap=allocation_failed -Wl,--wrap=clamp_scroll_x \
+    -Wl,--wrap=draw_text_buffer -Wl,--wrap=redraw -Wl,--wrap=strdup \
+    -Wl,--wrap=create_popup_window -Wl,--wrap=curs_set -Wl,--wrap=mvwin -Wl,--wrap=wresize \
+    -Wl,--wrap=calloc -Wl,--wrap=realloc \
+    -o cleanup_tests
+./cleanup_tests


### PR DESCRIPTION
## Summary
- ensure cleanup_on_exit clears global references
- add tests for cleanup behavior

## Testing
- `./run_tests.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68677029cc008324a6841b42309ba1fa